### PR TITLE
:bug: Fix #47 by addiding dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy",
     "plotly",
     "streamlit_extras",
+    "streamlit-plotly-events",
     "matplotlib",
     "importlib-metadata; python_version < '3.8'",
     "toml"


### PR DESCRIPTION
The tested passed and only when in the streamlit app the error appeared. Should we investigate how to test the app?