### PR TITLE
:sparkles: Add black code formatting

### DIFF
--- a/.github/workflows/black-formatting.yml
+++ b/.github/workflows/black-formatting.yml
@@ -1,0 +1,10 @@
+name: Black-Code-Formatting
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable


### PR DESCRIPTION
- currently fails
- code should be once reformatted for the entire project

Currently notebooks are not formatted

```cmd
Skipping .ipynb files as Jupyter dependencies are not installed.
You can fix this by running ``pip install "black[jupyter]"``
```

We could enforce it using `jupyter: true`, see [the documentation](https://black.readthedocs.io/en/stable/integrations/github_actions.html)

```
(...)
- uses: psf/black@stable
  with:
    jupyter: true
```    



