### PR TITLE
fix direct Proline import - issue #42

### DIFF
--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
@@ -2,24 +2,24 @@
 "samesets_accessions" = "Proteins"
 sequence = "Sequence"
 "modifications" = "Modifications"
-charge = "Charge"
+"master_quant_peptide_ion_charge" = "Charge"
 
 
 [replicate_mapper]
-abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01 = 1
-abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02 = 1
-abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03 = 1
-abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01 = 2
-abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02 = 2
-abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03 = 2
+abundance_DDA_Condition_A_Sample_Alpha_01 = 1
+abundance_DDA_Condition_A_Sample_Alpha_02 = 1
+abundance_DDA_Condition_A_Sample_Alpha_03 = 1
+abundance_DDA_Condition_B_Sample_Alpha_01 = 2
+abundance_DDA_Condition_B_Sample_Alpha_02 = 2
+abundance_DDA_Condition_B_Sample_Alpha_03 = 2
 
 [run_mapper]
-"abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01"
-"abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02"
-"abundance_LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03"
-"abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01"
-"abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02"
-"abundance_LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03"
+"abundance_DDA_Condition_A_Sample_Alpha_01" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01"
+"abundance_DDA_Condition_A_Sample_Alpha_02" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02"
+"abundance_DDA_Condition_A_Sample_Alpha_03" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03"
+"abundance_DDA_Condition_B_Sample_Alpha_01" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01"
+"abundance_DDA_Condition_B_Sample_Alpha_02" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02"
+"abundance_DDA_Condition_B_Sample_Alpha_03" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03"
 
 [species_dict]
 "YEAST" = "_YEAST"

--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -157,7 +157,7 @@ class Module(ModuleInterface):
                 self.strip_sequence_wombat
             )
         elif input_format == "Proline":
-            input_data_frame = pd.read_excel(input_csv, sheet_name="Best PSM from protein sets")
+            input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
         elif input_format == "Custom":
             input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
 


### PR DESCRIPTION
I have modified the .toml (changed the modification header and file names) and the import line in module.py (from excel to tsv input file)
By default, Proline removes the "LFQ_Orbitrap_" of the raw files. We may need to comment on this in the documentation/instructions. I am not sure that it always does the same thing. I'll ask David.