### PR TITLE
Add additional search engine, some fixes

### DIFF
--- a/proteobench/modules/dda_quant/datapoint.py
+++ b/proteobench/modules/dda_quant/datapoint.py
@@ -1,4 +1,5 @@
 import json
+import numpy as np
 from dataclasses import asdict, dataclass
 from datetime import datetime
 
@@ -44,7 +45,7 @@ class Datapoint:
         nr_missing_0 = 0
         for spec in species:
             f = len(df[df[spec] == True])
-            sum_s = (df[df[spec] == True]["1|2_expected_ratio_diff"]).sum()
+            sum_s = np.nan_to_num(df[df[spec] == True]["1|2_expected_ratio_diff"], nan=0, neginf=-1000, posinf=1000).sum()
             ratio = sum_s / f
             prop_ratio = (f / len(df)) * ratio
             prop_ratios.append(prop_ratio)

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_alphapept.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_alphapept.toml
@@ -30,10 +30,10 @@ LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03 = "LFQ_Orbitrap_DDA_Condition_B_Sam
 
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
-"1|2" = 0.5
+"1|2" = 2.0
 
 [species_expected_ratio.ECOLI]
-"1|2" = 1.5
+"1|2" = 0.25
     
 [species_expected_ratio.HUMAN]
 "1|2" = 1.0

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_maxquant.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_maxquant.toml
@@ -28,16 +28,16 @@ LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03 = 2
 
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
-"1|2" = 0.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01" = 0.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02" = 0.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03" = 0.5
+"1|2" = 2.0
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01" = 2.0
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02" = 2.0
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03" = 2.0
 
 [species_expected_ratio.ECOLI]
-"1|2" = 1.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01" = 1.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02" = 1.5
-"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03" = 1.5
+"1|2" = 0.25
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01" = 0.25
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02" = 0.25
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03|LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03" = 0.25
     
 [species_expected_ratio.HUMAN]
 "1|2" = 1.0

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_msfragger.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_msfragger.toml
@@ -28,10 +28,10 @@ Charge = "Charge"
 
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
-"1|2" = 0.5
+"1|2" = 2.0
 
 [species_expected_ratio.ECOLI]
-"1|2" = 1.5
+"1|2" = 0.25
     
 [species_expected_ratio.HUMAN]
 "1|2" = 1.0

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
@@ -28,10 +28,10 @@ abundance_DDA_Condition_B_Sample_Alpha_03 = 2
 
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
-"1|2" = 0.5
+"1|2" = 2.0
 
 [species_expected_ratio.ECOLI]
-"1|2" = 1.5
+"1|2" = 0.25
     
 [species_expected_ratio.HUMAN]
 "1|2" = 1.0

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_sage.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_sage.toml
@@ -1,0 +1,40 @@
+[mapper]
+"proteins" = "Proteins"
+"peptide" = "Sequence"
+"charge" = "Charge"
+
+[replicate_mapper]
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.mzML.gz" = 1
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.mzML.gz" = 1
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.mzML.gz" = 1
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.mzML.gz" = 2
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.mzML.gz" = 2
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.mzML.gz" = 2
+
+[run_mapper]
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.mzML" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01"
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.mzML" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02"
+"LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.mzML" = "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03"
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.mzML" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01"
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.mzML" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02"
+"LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.mzML" = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03"
+
+[species_dict]
+"YEAST" = "_YEAST"
+"ECOLI" = "_ECOLI"
+"HUMAN" = "_HUMAN"
+
+[species_expected_ratio]
+[species_expected_ratio.YEAST]
+"1|2" = 2.0
+
+[species_expected_ratio.ECOLI]
+"1|2" = 0.25
+    
+[species_expected_ratio.HUMAN]
+"1|2" = 1.0
+
+[general]
+contaminant_flag = "Cont_"
+decoy_flag = false
+min_count_multispec = 1

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_wombat.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_wombat.toml
@@ -26,10 +26,10 @@ abundance_B_3 = "LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03"
 
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
-"1|2" = 0.5
+"1|2" = 2.0
 
 [species_expected_ratio.ECOLI]
-"1|2" = 1.5
+"1|2" = 0.25
     
 [species_expected_ratio.HUMAN]
 "1|2" = 1.0

--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -152,6 +152,8 @@ class Module(ModuleInterface):
             input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
         elif input_format == "AlphaPept":
             input_data_frame = pd.read_csv(input_csv, low_memory=False)
+        elif input_format == "Sage":
+            input_data_frame = pd.read_csv(input_csv, sep='\t', low_memory=False)
         elif input_format == "MSFragger":
             input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
         elif input_format == "WOMBAT":

--- a/proteobench/modules/dda_quant/parse_settings.py
+++ b/proteobench/modules/dda_quant/parse_settings.py
@@ -32,7 +32,7 @@ INPUT_FORMATS = ("MaxQuant",
                 "Sage",
                 "Custom")
 
-LOCAL_DEVELOPMENT = True
+LOCAL_DEVELOPMENT = False
 
 # For local development change below to the json and path, if you do not want to download it from github
 DDA_QUANT_RESULTS_PATH = "https://raw.githubusercontent.com/Proteobench/Results_Module2_quant_DDA/main/results.json" #e.g., K:/results.json

--- a/proteobench/modules/dda_quant/parse_settings.py
+++ b/proteobench/modules/dda_quant/parse_settings.py
@@ -19,6 +19,7 @@ PARSE_SETTINGS_FILES = { "WOMBAT"     : os.path.join(PARSE_SETTINGS_DIR, 'parse_
                         "MSFragger"        : os.path.join(PARSE_SETTINGS_DIR, 'parse_settings_msfragger.toml'),
                         "Proline"         : os.path.join(PARSE_SETTINGS_DIR, 'parse_settings_proline.toml'),
                         "AlphaPept"        : os.path.join(PARSE_SETTINGS_DIR, 'parse_settings_alphapept.toml'),
+                        "Sage"        : os.path.join(PARSE_SETTINGS_DIR, 'parse_settings_sage.toml'),
                         "Custom"        : os.path.join(PARSE_SETTINGS_DIR, 'parse_settings_custom.toml')
             }
 
@@ -28,9 +29,10 @@ INPUT_FORMATS = ("MaxQuant",
                 "MSFragger",
                 "Proline",
                 "WOMBAT",
+                "Sage",
                 "Custom")
 
-LOCAL_DEVELOPMENT = False
+LOCAL_DEVELOPMENT = True
 
 # For local development change below to the json and path, if you do not want to download it from github
 DDA_QUANT_RESULTS_PATH = "https://raw.githubusercontent.com/Proteobench/Results_Module2_quant_DDA/main/results.json" #e.g., K:/results.json

--- a/proteobench/modules/dda_quant/plot.py
+++ b/proteobench/modules/dda_quant/plot.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
-import plotly.figure_factory as ff
 import plotly.graph_objects as go
+import plotly.express as px
 import streamlit as st
 from streamlit_plotly_events import plotly_events
 
@@ -11,18 +11,21 @@ class PlotDataPoint:
     def plot_bench(self, result_df: pd.DataFrame) -> go.Figure:
         """Plot results with Plotly Express."""
 
-        hist_data = [
-            np.array(result_df[result_df["YEAST"] == True]["1|2_ratio"]),
-            np.array(result_df[result_df["HUMAN"] == True]["1|2_ratio"]),
-            np.array(result_df[result_df["ECOLI"] == True]["1|2_ratio"]),
-        ]
-        group_labels = [
-            "YEAST",
-            "HUMAN",
-            "ECOLI",
-        ]
-
-        fig = ff.create_distplot(hist_data, group_labels, show_hist=False)
+        # Remove any precursors not arising from a known organism... contaminants?
+        result_df = result_df[result_df[["YEAST", "ECOLI", "HUMAN"]].any(axis=1)]
+        result_df["kind"] = result_df[["YEAST", "ECOLI", "HUMAN"]].apply(
+            lambda x: ["YEAST", "ECOLI", "HUMAN"][np.argmax(x)], axis=1
+        )
+        fig = px.histogram(
+            result_df,
+            x=np.log2(result_df["1|2_ratio"]),
+            color="kind",
+            marginal="rug",
+            histnorm="probability density",
+            barmode="overlay",
+            opacity=0.7,
+            nbins=100
+        )
 
         fig.update_layout(
             width=700,
@@ -39,9 +42,9 @@ class PlotDataPoint:
                 gridwidth=2,
             ),
         )
-        fig.update_xaxes(range=[0, 4])
+        fig.update_xaxes(range=[-4, 4])
         fig.update_xaxes(showgrid=True, gridcolor="lightgray", gridwidth=1)
-        # fig.update_yaxes(showgrid=True, gridcolor="lightgray", gridwidth=1)
+        fig.update_yaxes(showgrid=True, gridcolor="lightgray", gridwidth=1)
 
         return fig
 
@@ -66,6 +69,7 @@ class PlotDataPoint:
             "MSFragger": "#ff7f0e",
             "WOMBAT": "#7f7f7f",
             "Proline": "#d62728",
+            "Sage": "#f74c00",
             "Custom": "#9467bd",
         }
 

--- a/test/test_module_dda_quant.py
+++ b/test/test_module_dda_quant.py
@@ -19,6 +19,7 @@ TESTDATA_FILES = {
     "MaxQuant": os.path.join(TESTDATA_DIR, "MaxQuant_evidence_sample.txt"),
     "MSFragger": os.path.join(TESTDATA_DIR, "MSFragger_combined_ion.tsv"),
     "AlphaPept": os.path.join(TESTDATA_DIR, "AlphaPept_subset.csv"),
+    "Sage": os.path.join(TESTDATA_DIR, "lfq.tsv"),
 }
 
 
@@ -57,12 +58,12 @@ def process_file(format_name: str):
 
 
 class TestOutputFileReading(unittest.TestCase):
-    supported_formats = ("MaxQuant", "MSFragger", "AlphaPept") #"WOMBAT", 
+    supported_formats = ("MaxQuant", "MSFragger", "AlphaPept", "Sage") #"WOMBAT", 
     """ Simple tests for reading csv input files."""
 
     def test_search_engines_supported(self):
         """Test whether the expected formats are supported."""
-        for format_name in ("MaxQuant", "AlphaPept", "MSFragger", "Proline"): #, "WOMBAT"
+        for format_name in ("MaxQuant", "AlphaPept", "MSFragger", "Proline", "Sage"): #, "WOMBAT"
             self.assertTrue(format_name in INPUT_FORMATS)
 
     def test_input_file_loading(self):

--- a/webinterface/configuration/dda_quant.json
+++ b/webinterface/configuration/dda_quant.json
@@ -1,1 +1,166 @@
-{"version": {"type": "text_input", "label": "Search engine version", "placeholder" : "1.0"}, "software_name": {"type": "text_input", "label": "Search engine name", "value": {"MaxQuant": "MaxQuant", "AlphaPept": "AlphaPept", "MSFragger": "MSFragger", "Proline": "Proline", "WOMBAT": "WOMBAT"}}, "fdr_psm": {"type": "number_input", "label": "FDR psm", "min_value": 0.0, "max_value": 1.0, "format": "%.4f"}, "fdr_peptide": {"type": "number_input", "label": "FDR peptide", "min_value": 0.0, "max_value": 1.0, "format": "%.4f"}, "fdr_protein": {"type": "number_input", "label": "FDR protein", "min_value": 0.0, "max_value": 1.0, "format": "%.4f"}, "precursor_mass_tolerance": {"type": "number_input", "label": "Precursor mass tolerance", "min_value": 0.0, "max_value": 200.0, "format": "%.4f"}, "precursor_mass_tolerance_unit": {"type": "selectbox", "label": "Precursor tolerance unit", "value": {"MaxQuant": "-", "AlphaPept": "-", "MSFragger": "-", "Proline": "-", "WOMBAT": "-"}, "options": ["-", "PPM", "Da"]}, "fragment_mass_tolerance": {"type": "number_input", "label": "Fragment mass tolerance", "min_value": 0.0, "max_value": 100.0, "format": "%.4f"}, "fragment_mass_tolerance_unit": {"type": "selectbox", "label": "Fragment mass tolerance unit", "value": {"MaxQuant": "-", "AlphaPept": "-", "MSFragger": "-", "Proline": "-", "WOMBAT": "-"}, "options": ["-", "PPM", "Da"]}, "search_enzyme_name": {"type": "selectbox", "label": "Enzyme", "value": {"MaxQuant": "-", "AlphaPept": "-", "MSFragger": "-", "Proline": "-", "WOMBAT": "-"}, "options": ["-", "Trypsin", "Chemotrypsin"]}, "allowed_missed_cleavage": {"type": "number_input", "label": "Maximum allowed number of missed cleavage",  "min_value": 0, "max_value": 10,"format": "%d"}, "fixed_mods": {"type": "text_input", "label": "Specify the fixed mods that were set", "placeholder": "CAM"}, "variable_mods": {"type": "text_input", "label": "Specify the variable mods that were set (separated by a comma)", "placeholder": "MOxid, N-term Acetyl"}, "precursor_charge": {"type": "text_input", "label": "Possible charge states (separated by a comma)", "placeholder": "2,3,4,5,6"}, "max_num_mods_on_peptide": {"type": "number_input", "label": "Maximum number of modifications on peptides",  "min_value": 0, "max_value": 10,"format": "%d"}, "min_peptide_length": {"type": "number_input", "label": "Minimum peptide length",  "min_value": 0, "max_value": 100,"format": "%d"}, "max_peptide_length": {"type": "number_input", "label": "Maximum peptide length",  "min_value": 0, "max_value": 1000,"format": "%d"}, "mbr": {"type": "checkbox", "label": "Quantified with MBR", "value": {"MaxQuant": false, "AlphaPept": false, "MSFragger": false, "Proline": false, "WOMBAT": false}}, "workflow_description": {"type": "text_area", "label": "Fill in details not specified above", "placeholder": "This workflow was run with isotope errors considering M-1, M+1, and M+2 ...'", "height": 275}}
+{
+    "version": {
+        "type": "text_input",
+        "label": "Search engine version",
+        "placeholder": "1.0"
+    },
+    "software_name": {
+        "type": "text_input",
+        "label": "Search engine name",
+        "value": {
+            "MaxQuant": "MaxQuant",
+            "AlphaPept": "AlphaPept",
+            "MSFragger": "MSFragger",
+            "Proline": "Proline",
+            "Sage": "Sage",
+            "WOMBAT": "WOMBAT"
+        }
+    },
+    "fdr_psm": {
+        "type": "number_input",
+        "label": "FDR psm",
+        "min_value": 0.0,
+        "max_value": 1.0,
+        "format": "%.4f"
+    },
+    "fdr_peptide": {
+        "type": "number_input",
+        "label": "FDR peptide",
+        "min_value": 0.0,
+        "max_value": 1.0,
+        "format": "%.4f"
+    },
+    "fdr_protein": {
+        "type": "number_input",
+        "label": "FDR protein",
+        "min_value": 0.0,
+        "max_value": 1.0,
+        "format": "%.4f"
+    },
+    "precursor_mass_tolerance": {
+        "type": "number_input",
+        "label": "Precursor mass tolerance",
+        "min_value": 0.0,
+        "max_value": 200.0,
+        "format": "%.4f"
+    },
+    "precursor_mass_tolerance_unit": {
+        "type": "selectbox",
+        "label": "Precursor tolerance unit",
+        "value": {
+            "MaxQuant": "-",
+            "AlphaPept": "-",
+            "MSFragger": "-",
+            "Proline": "-",
+            "WOMBAT": "-",
+            "Sage": "-"
+        },
+        "options": [
+            "-",
+            "PPM",
+            "Da"
+        ]
+    },
+    "fragment_mass_tolerance": {
+        "type": "number_input",
+        "label": "Fragment mass tolerance",
+        "min_value": 0.0,
+        "max_value": 100.0,
+        "format": "%.4f"
+    },
+    "fragment_mass_tolerance_unit": {
+        "type": "selectbox",
+        "label": "Fragment mass tolerance unit",
+        "value": {
+            "MaxQuant": "-",
+            "AlphaPept": "-",
+            "MSFragger": "-",
+            "Proline": "-",
+            "WOMBAT": "-",
+            "Sage": "-"
+        },
+        "options": [
+            "-",
+            "PPM",
+            "Da"
+        ]
+    },
+    "search_enzyme_name": {
+        "type": "selectbox",
+        "label": "Enzyme",
+        "value": {
+            "MaxQuant": "-",
+            "AlphaPept": "-",
+            "MSFragger": "-",
+            "Proline": "-",
+            "WOMBAT": "-",
+            "Sage": "-"
+        },
+        "options": [
+            "-",
+            "Trypsin",
+            "Chemotrypsin"
+        ]
+    },
+    "allowed_missed_cleavage": {
+        "type": "number_input",
+        "label": "Maximum allowed number of missed cleavage",
+        "min_value": 0,
+        "max_value": 10,
+        "format": "%d"
+    },
+    "fixed_mods": {
+        "type": "text_input",
+        "label": "Specify the fixed mods that were set",
+        "placeholder": "CAM"
+    },
+    "variable_mods": {
+        "type": "text_input",
+        "label": "Specify the variable mods that were set (separated by a comma)",
+        "placeholder": "MOxid, N-term Acetyl"
+    },
+    "precursor_charge": {
+        "type": "text_input",
+        "label": "Possible charge states (separated by a comma)",
+        "placeholder": "2,3,4,5,6"
+    },
+    "max_num_mods_on_peptide": {
+        "type": "number_input",
+        "label": "Maximum number of modifications on peptides",
+        "min_value": 0,
+        "max_value": 10,
+        "format": "%d"
+    },
+    "min_peptide_length": {
+        "type": "number_input",
+        "label": "Minimum peptide length",
+        "min_value": 0,
+        "max_value": 100,
+        "format": "%d"
+    },
+    "max_peptide_length": {
+        "type": "number_input",
+        "label": "Maximum peptide length",
+        "min_value": 0,
+        "max_value": 1000,
+        "format": "%d"
+    },
+    "mbr": {
+        "type": "checkbox",
+        "label": "Quantified with MBR",
+        "value": {
+            "MaxQuant": false,
+            "AlphaPept": false,
+            "MSFragger": false,
+            "Proline": false,
+            "WOMBAT": false,
+            "Sage": true
+        }
+    },
+    "workflow_description": {
+        "type": "text_area",
+        "label": "Fill in details not specified above",
+        "placeholder": "This workflow was run with isotope errors considering M-1, M+1, and M+2 ...'",
+        "height": 275
+    }
+}

--- a/webinterface/pages/DDA_Quant.py
+++ b/webinterface/pages/DDA_Quant.py
@@ -110,12 +110,12 @@ class StreamlitUI:
                     The raw files used for this module were acquired on an Orbitrap
                     Q-Exactive H-FX (ThermoScientific). They can be downloaded from the
                     proteomeXchange repository PXD028735. You can download them here:
-                    [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01.raw)
-                    [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02.raw)
-                    [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03.raw)
-                    [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01.raw)
-                    [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw)
-                    [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw)  
+                    [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.raw)
+                    [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.raw)
+                    [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.raw)
+                    [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.raw)
+                    [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw)
+                    [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw)  
 
                     **It is imperative not to rename the files once downloaded!**
                     """


### PR DESCRIPTION
Hi all, 

I stumbled across this - super cool project. I added support for the [Sage search engine](https://github.com/lazear/sage), since I happened to already have PXD028735 downloaded. 

I've also added some misc. fixes - happy to cherrypick out any you don't want. Also, if you're not ready to add in additional tools, I can hold off on the PR.
- I think the expected ratios are off for all of the tools
- I fixed the filenames to use the DDA files, not the DIA (AIF) files
- Changed deprecated plotly function to new plotly express histogram (also, old one was not properly displaying densities)
- Added tests for Sage input

Everything seems to work on all of the existing test datasets. I did notice that for some reason, the overall metrics are not being calculated correctly for Sage and displayed on the final scatterplot that compares tools (there are NaN values maybe?) despite the "Download calculated ratios" file looking OK.