### PR TITLE
added test configuration to launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ ENV/
 env.bak/
 venv.bak/
 .vscode
+.idea
 
 # Spyder project settings
 .spyderproject

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,28 @@
-
 {
     "version": "0.2.0",
     "configurations": [
+        {
+            "name": "Python: Testing",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
         {
             "name": "Python: BStreamlit",
             "type": "python",
             "request": "launch",
             "module": "streamlit",
             "args": [
-                 "run",
-                 "Home.py",
-                 "--server.port",
-                 "8080"
+                "run",
+                "Home.py",
+                "--server.port",
+                "8080"
             ],
             "cwd": "${workspaceFolder}/webinterface/",
-            "justMyCode":false
+            "justMyCode": false
         }
     ]
 }


### PR DESCRIPTION
In VS code, I had a problem debugging the code in the module when running tests from the Testing panel in debug mode.

The problem appears only when I run the test from the testing panel in VScode. When I run it from the file, the breakpoints in the module are hit.
We fixed the issue with an additional Testing launch configuration:
{
            “name”: “Python: Testing”,
            “type”: “python”,
            “request”: “launch”,
            “program”: “${file}“,
            “purpose”: [“debug-test”],
            “console”: “integratedTerminal”,
            “justMyCode”: false
   },

It seems that the critical option is "justMyCode": false
