### PR TITLE
add Proline input - parsing

### DIFF
--- a/docs/modules/3-DDA-Quantification-ion-level.md
+++ b/docs/modules/3-DDA-Quantification-ion-level.md
@@ -10,7 +10,7 @@ Please refer to the original publication for the full description of sample prep
 
 ## Metric calculation
 
-For each precursor ion (modified sequence + charge), we calculate the average signal per condition ("0" are replaced by NAs and missing values are ignored). The total number of unique precursor ions is reported on the *y*-axis, and the weighted sum of the mean absolute error from the expected ratio is reported on the *x*-axis. Precursors matched to contaminant sequences and/or to multiple species are excluded for error calculation.
+For each precursor ion (modified sequence + charge), we calculate the sum of signal per raw file and condition. Then, we calculate the average signal per condition ("0" are replaced by NAs and missing values are ignored). The total number of unique precursor ions is reported on the *y*-axis, and the weighted sum of the mean absolute error from the expected ratio is reported on the *x*-axis. Precursors matched to contaminant sequences and/or to multiple species are excluded for error calculation.
 
 ## How to use
 

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_alphapept.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_alphapept.toml
@@ -7,7 +7,7 @@ charge = "Charge"
 decoy = "Reverse"
 ms1_int_sum_apex_dn = "Intensity"
 
-[replicate_mapper]
+[condition_mapper]
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03 = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_custom.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_custom.toml
@@ -4,7 +4,7 @@ Sequence = "Sequence"
 Charge = "Charge"
 
 
-[replicate_mapper]
+[condition_mapper]
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03 = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_maxquant.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_maxquant.toml
@@ -5,7 +5,7 @@ Proteins = "Proteins"
 "Modified sequence" = "Modified sequence"
 Charge = "Charge"
 
-[replicate_mapper]
+[condition_mapper]
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02 = "A"
 LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03 = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_msfragger.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_msfragger.toml
@@ -3,7 +3,7 @@
 Protein = "Proteins"
 Charge = "Charge"
 
-[replicate_mapper]
+[condition_mapper]
 "A_1 Intensity" = "A"
 "A_2 Intensity" = "A"
 "A_3 Intensity" = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
@@ -26,6 +26,14 @@ abundance_DDA_Condition_B_Sample_Alpha_03 = "B"
 "_ECOLI" = "ECOLI"
 "_HUMAN" = "HUMAN"
 
+[modifications_parser]
+"parse_column" = "Modified Sequence"
+"before_aa" = false
+"isalpha" = true
+"isupper" = true
+"pattern"="\\((.*?)\\)"
+"modification_dict" = {}
+
 [general]
 contaminant_flag = "Cont_"
 decoy_flag = true

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_proline.toml
@@ -5,7 +5,7 @@ sequence = "Sequence"
 "master_quant_peptide_ion_charge" = "Charge"
 
 
-[replicate_mapper]
+[condition_mapper]
 abundance_DDA_Condition_A_Sample_Alpha_01 = "A"
 abundance_DDA_Condition_A_Sample_Alpha_02 = "A"
 abundance_DDA_Condition_A_Sample_Alpha_03 = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_sage.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_sage.toml
@@ -3,7 +3,7 @@
 "peptide" = "Sequence"
 "charge" = "Charge"
 
-[replicate_mapper]
+[condition_mapper]
 "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.mzML.gz" = "A"
 "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.mzML.gz" = "A"
 "LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.mzML.gz" = "A"

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_wombat.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_wombat.toml
@@ -2,7 +2,7 @@
 protein_group = "Proteins"
 "modified_peptide" = "Modified sequence"
 
-[replicate_mapper]
+[condition_mapper]
 abundance_A_1 = "A"
 abundance_A_2 = "A"
 abundance_A_3 = "A"

--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -208,7 +208,7 @@ class Module(ModuleInterface):
             input_data_frame = pd.read_csv(input_csv, low_memory=False, sep=",")
             input_data_frame["proforma"] = input_data_frame["modified_peptide"]
         elif input_format == "Proline":
-            input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
+            input_data_frame = pd.read_excel(input_csv, sheet_name="Quantified peptide ions", header = 0, index_col = None)
         elif input_format == "Custom":
             input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
 

--- a/proteobench/modules/dda_quant/parse.py
+++ b/proteobench/modules/dda_quant/parse.py
@@ -111,7 +111,7 @@ class ParseInputs(ParseInputsInterface):
         df.rename(columns=parse_settings.mapper, inplace=True)
 
         replicate_to_raw = {}
-        for k, v in parse_settings.replicate_mapper.items():
+        for k, v in parse_settings.condition_mapper.items():
             try:
                 replicate_to_raw[v].append(k)
             except KeyError:
@@ -132,7 +132,7 @@ class ParseInputs(ParseInputsInterface):
 
         # If there is "Raw file" then it is a long format, otherwise short format
         if "Raw file" not in parse_settings.mapper.values():
-            meltvars = parse_settings.replicate_mapper.keys()
+            meltvars = parse_settings.condition_mapper.keys()
             df = df.melt(
                 id_vars=list(set(df.columns).difference(set(meltvars))),
                 value_vars=meltvars,
@@ -140,8 +140,7 @@ class ParseInputs(ParseInputsInterface):
                 value_name="Intensity",
             )
 
-        # TODO replace with condition_mapper
-        df["replicate"] = df["Raw file"].map(parse_settings.replicate_mapper)
+        df["replicate"] = df["Raw file"].map(parse_settings.condition_mapper)
         df = pd.concat([df, pd.get_dummies(df["Raw file"])], axis=1)
 
         if parse_settings.apply_modifications_parser:

--- a/proteobench/modules/dda_quant/parse_settings.py
+++ b/proteobench/modules/dda_quant/parse_settings.py
@@ -15,7 +15,7 @@ PARSE_SETTINGS_DIR = os.path.join(os.path.dirname(__file__), "io_parse_settings"
 MapSettingFiles: dict[str, Path]
 
 PARSE_SETTINGS_FILES = {
-    "WOMBAT": os.path.join(PARSE_SETTINGS_DIR, "parse_settings_wombat.toml"),
+    # "WOMBAT": os.path.join(PARSE_SETTINGS_DIR, "parse_settings_wombat.toml"), # Wombat is not compatible with the module precursor ions
     "MaxQuant": os.path.join(PARSE_SETTINGS_DIR, "parse_settings_maxquant.toml"),
     "MSFragger": os.path.join(PARSE_SETTINGS_DIR, "parse_settings_msfragger.toml"),
     "Proline": os.path.join(PARSE_SETTINGS_DIR, "parse_settings_proline.toml"),
@@ -32,7 +32,7 @@ INPUT_FORMATS = (
     "AlphaPept",
     "MSFragger",
     "Proline",
-    "WOMBAT",
+    # "WOMBAT",
     "Sage",
     "Custom",
 )
@@ -52,7 +52,7 @@ DDA_QUANT_RESULTS_REPO = "https://github.com/Proteobench/Results_Module2_quant_D
 
 class ParseSettings:
     """Structure that contains all the parameters used to parse
-    the given database search output."""
+    the given benchmark run output depending on the software tool used."""
 
     def __init__(self, input_format: str):
         parse_settings = toml.load(PARSE_SETTINGS_FILES[input_format])
@@ -96,5 +96,5 @@ class ParseSettings:
 
 
 def parse_settings(input_format: str) -> Settings:
-    """load settings from toml file"""
+    """load settings from toml file corresponding to the software tool."""
     raise NotImplementedError

--- a/proteobench/modules/dda_quant/parse_settings.py
+++ b/proteobench/modules/dda_quant/parse_settings.py
@@ -58,7 +58,7 @@ class ParseSettings:
         parse_settings = toml.load(PARSE_SETTINGS_FILES[input_format])
 
         self.mapper = parse_settings["mapper"]
-        self.replicate_mapper = parse_settings["replicate_mapper"]
+        self.condition_mapper = parse_settings["condition_mapper"]
         self.run_mapper = parse_settings["run_mapper"]
         self.decoy_flag = parse_settings["general"]["decoy_flag"]
         self.species_dict = parse_settings["species_mapper"]

--- a/proteobench/modules/interfaces.py
+++ b/proteobench/modules/interfaces.py
@@ -49,7 +49,7 @@ class PlotDataPoint(ABC):
 @dataclass
 class Settings:
     mapper: str
-    replicate_mapper: str
+    condition_mapper: str
     decoy_flag: str
     species_dict: str
     contaminant_flag: str

--- a/proteobench/modules/template/io_parse_settings/parse_settings_format1.toml
+++ b/proteobench/modules/template/io_parse_settings/parse_settings_format1.toml
@@ -10,7 +10,7 @@ charge = "Charge"
 decoy = "Reverse"
 
 # Map numeric columns to experimental designu
-[replicate_mapper]
+[condition_mapper]
 STANDARD_NAME_1 = 1
 STANDARD_NAME_2 = 2
 STANDARD_NAME_3 = 3

--- a/proteobench/modules/template/io_parse_settings/parse_settings_format2.toml
+++ b/proteobench/modules/template/io_parse_settings/parse_settings_format2.toml
@@ -9,8 +9,8 @@ sequence = "Modified sequence"
 charge = "Charge"
 decoy = "Reverse"
 
-# Map numeric columns to experimental designu
-[replicate_mapper]
+# Map numeric columns to experimental design
+[condition_mapper]
 STANDARD_NAME_1 = 1
 STANDARD_NAME_2 = 2
 STANDARD_NAME_3 = 3

--- a/proteobench/modules/template/parse.py
+++ b/proteobench/modules/template/parse.py
@@ -23,7 +23,7 @@ class ParseInputs(ParseInputsInterface):
         df.rename(columns=parse_settings.mapper, inplace=True)
 
         standard_structure = {}
-        for k, v in parse_settings.replicate_mapper.items():
+        for k, v in parse_settings.condition_mapper.items():
             try:
                 standard_structure[v].append(k)
             except KeyError:

--- a/proteobench/modules/template/parse_settings.py
+++ b/proteobench/modules/template/parse_settings.py
@@ -30,4 +30,4 @@ class ParseSettings:
         # They need to be defined in the different formats' .toml files
         # e.g.
         self.mapper = parse_settings["mapper"]
-        self.replicate_mapper = parse_settings["replicate_mapper"]
+        self.condition_mapper = parse_settings["condition_mapper"]


### PR DESCRIPTION
I have:
- replaced the "replicate_mapper" with "condition_mapper" everywhere
- removed Wombat from the input options of the DDA quant module since it is precursor ions, and there is not output for this from Wombat. I kept the associated files though. So that we have them when we copy the script for the peptidoform module
- tried to parse the Proline input: before, we used as input a txt file that contained only the ion quantification. Now we use the excel file as input. This way, we also have the tabs with the parameters. 
**BUT**: I did not manage to parse the modifications. I don't really understand how the `Modified sequence` is generated and how the toml `[modifications_parser]` should look like. 
Maybe @RobbinBouwmeester could give me pointers?