### PR TITLE
:heavy_plus_sign: Add selected theme as docs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 
 [project.optional-dependencies]
 dev = ["black"]
-docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "myst-parser", "pydata_sphinx_theme"]
+docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "myst-parser", "pydata-sphinx-theme"]
 web = ["streamlit>1.27", "scipy"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 
 [project.optional-dependencies]
 dev = ["black"]
-docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "myst-parser"]
+docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "myst-parser", "pydata_sphinx_theme"]
 web = ["streamlit>1.27", "scipy"]
 
 [project.urls]


### PR DESCRIPTION
Try to get [failing docs running](https://readthedocs.org/projects/proteobench/builds/22852679/).

Theme dependency is missing.