### PR TITLE
fix min. value threshold in module.py compute_group_stats

### DIFF
--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -81,7 +81,7 @@ class Module(ModuleInterface):
         """Method used to precursor statistics, such as number of observations, CV, mean per group etc."""
 
         # fiter for min_intensity
-        relevant_columns_df = relevant_columns_df[relevant_columns_df["Intensity"] >= min_intensity]
+        relevant_columns_df = relevant_columns_df[relevant_columns_df["Intensity"] > min_intensity]
 
         # TODO: check if this is still needed
         # sum intensity values of the same precursor and "Raw file" using the sum


### PR DESCRIPTION
The minimum values was set to ` >= min_intensity` with min_intensity = 0
I changed it to ` > min_intensity`

another option would be to switch min_intensity to a higher value, but then we would need to decide on a value.