### PR TITLE
adresses issue #154

### DIFF
--- a/proteobench/modules/dda_quant/io_parse_settings/module_settings.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/module_settings.toml
@@ -1,12 +1,15 @@
 [species_expected_ratio]
 [species_expected_ratio.YEAST]
 "A_vs_B" = 2.0
+"color" = "red"
 
 [species_expected_ratio.ECOLI]
 "A_vs_B" = 0.25
-    
+color = "blue"
+
 [species_expected_ratio.HUMAN]
 "A_vs_B" = 1.0
+color = "green"
 
 [general]
 min_count_multispec = 1

--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -159,9 +159,11 @@ class Module(ModuleInterface):
         # for species in parse_settings.species_dict.values(), set all values in new column "species" to species if withe species is True
         for species in species_expected_ratio.keys():
             withspecies.loc[withspecies[species] == True, "species"] = species
-            withspecies.loc[withspecies[species] == True, "expectedRatio"] = species_expected_ratio[species]["A_vs_B"]
+            withspecies.loc[withspecies[species] == True, "log2_expectedRatio"] = np.log2(
+                species_expected_ratio[species]["A_vs_B"]
+            )
 
-        withspecies["epsilon"] = withspecies["log2_A_vs_B"] - withspecies["expectedRatio"]
+        withspecies["epsilon"] = withspecies["log2_A_vs_B"] - withspecies["log2_expectedRatio"]
         return withspecies
 
     @staticmethod

--- a/test/test_module_dda_quant.py
+++ b/test/test_module_dda_quant.py
@@ -179,8 +179,12 @@ class TestPlot(unittest.TestCase):
         combineddf["HUMAN"] = combineddf["SPECIES"] == "HUMAN"
         combineddf["ECOLI"] = combineddf["SPECIES"] == "ECOLI"
         combineddf["YEAST"] = combineddf["SPECIES"] == "YEAST"
-
-        fig = PlotDataPoint().plot_bench(combineddf)
+        species_dict = {
+            "YEAST": {"A_vs_B": 2.0, "color": "red"},
+            "ECOLI": {"A_vs_B": 0.25, "color": "blue"},
+            "HUMAN": {"A_vs_B": 1.0, "color": "green"},
+        }
+        fig = PlotDataPoint().plot_fold_change_histogram(combineddf, species_dict)
         # fig.write_html("dummy.html")
         self.assertIsNotNone(fig)
 

--- a/webinterface/pages/DDA_Quant.py
+++ b/webinterface/pages/DDA_Quant.py
@@ -15,9 +15,9 @@ from proteobench.modules.dda_quant.datapoint import (
 )
 from proteobench.modules.dda_quant.module import Module
 from proteobench.modules.dda_quant.parse_settings import (
-    DDA_QUANT_RESULTS_PATH,
     INPUT_FORMATS,
     LOCAL_DEVELOPMENT,
+    ParseSettings,
 )
 from proteobench.modules.dda_quant.plot import PlotDataPoint
 
@@ -316,7 +316,8 @@ class StreamlitUI:
                     """
         )
         if recalculate:
-            fig = PlotDataPoint().plot_bench(result_performance)
+            parse_settings = ParseSettings(self.user_input["input_format"])
+            fig = PlotDataPoint().plot_fold_change_histogram(result_performance, parse_settings.species_expected_ratio)
         else:
             fig = st.session_state[FIG1]
         st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
histogram colors are specified in toml and shown in histogram. See issue #154 for details.
Also added vertical lines to show expected fold changes.
On this occasion noticed that the ratios in the toml are not log2 ratios so need to be transformed this pull request fixes this bug in the compute_epsilon function.
