### PR TITLE
Provide DDAquant fasta download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,4 @@ dmypy.json
 results.json
 
 # secrets
-.streamlit/
+.streamlit/secrets.toml

--- a/webinterface/.streamlit/config.toml
+++ b/webinterface/.streamlit/config.toml
@@ -1,3 +1,5 @@
 [theme]
 base="light"
 
+[server]
+enableStaticServing = true

--- a/webinterface/pages/DDA_Quant.py
+++ b/webinterface/pages/DDA_Quant.py
@@ -134,7 +134,7 @@ class StreamlitUI:
         )
         st.markdown(
             """
-                    Download the fasta file here: [TODO]
+                    Download the zipped FASTA file here: [ProteoBenchFASTA_DDAQuantification.zip](app/static/ProteoBenchFASTA_DDAQuantification.zip).
                     The fasta file provided for this module contains the three species
                     present in the samples and contaminant proteins
                     ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))


### PR DESCRIPTION
Implements the FASTA download as discussed in #139   

- adds the statically served (zipped) FASTA file for downloading
- makes ignoring of secrets in .gitignore more specific (warning for the future, but could be reversed)