### PR TITLE
fix custom import

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Overview of ProteoBench
     Changelog <changelog.rst>
 
 
-ProteoBench is an open and collaborative platform for community-curated benchmarks for proteomics 
+`ProteoBench <https://proteobench.cubimed.rub.de/>`_ is an open and collaborative platform for community-curated benchmarks for proteomics 
 data analysis pipelines. Our goal is to allow a continuous, easy, and controlled comparison of 
 proteomics data analysis workflows.
 

--- a/docs/modules/3-DDA-Quantification-ion-level.md
+++ b/docs/modules/3-DDA-Quantification-ion-level.md
@@ -83,16 +83,20 @@ For public submission, you can upload the same excel export, just make sure to h
 
 ### Custom format
 
-You can use the tab-delimited Custom format containing the following columns:
-- Sequence: peptide sequence
-- Proteins: Protein accessions according to fasta file
-- Charge: Charge state of measured peptide
+If you do not use a tool that is compatible with ProteoBench, you can upload a tab-delimited table format containing the following columns:
+
+- Sequence: peptide sequence without the modification(s)
+- Proteins: column containing the protein identifiers. These should be separated by ";", and contain the species flag (for example "_YEAST").
+- Charge: Charge state of measured peptide ions
+- Modified sequence: column containing the sequences and the localised modifications in the [ProForma standard](https://www.psidev.info/proforma) format. 
 - LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01: Quantitative column sample 1
 - LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02: Quantitative column sample 2
 - LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03: Quantitative column sample 3
 - LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01: Quantitative column sample 4
 - LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02: Quantitative column sample 5
 - LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03: Quantitative column sample 6
+
+the table must not contain non-validated ions. If you have any issue, contact us [here](mailto:proteobench@eubic-ms.org?subject=ProteoBench_query).
 
 ## toml file description
 

--- a/proteobench/modules/dda_quant/io_parse_settings/parse_settings_custom.toml
+++ b/proteobench/modules/dda_quant/io_parse_settings/parse_settings_custom.toml
@@ -1,7 +1,8 @@
 [mapper]
 "Proteins" = "Proteins"
-Sequence = "Sequence"
-Charge = "Charge"
+"Sequence" = "Sequence"
+"Charge" = "Charge"
+"Modified sequence" = "Modified sequence"
 
 
 [condition_mapper]

--- a/proteobench/modules/dda_quant/module.py
+++ b/proteobench/modules/dda_quant/module.py
@@ -267,6 +267,7 @@ class Module(ModuleInterface):
             input_data_frame["proforma"] = input_data_frame["ProForma"]
         elif input_format == "Custom":
             input_data_frame = pd.read_csv(input_csv, low_memory=False, sep="\t")
+            input_data_frame["proforma"] = input_data_frame["Modified sequence"]
 
         return input_data_frame
 

--- a/webinterface/configuration/dda_quant.json
+++ b/webinterface/configuration/dda_quant.json
@@ -55,7 +55,8 @@
             "Proline": "-",
             "i2MassChroQ": "-",
             "WOMBAT": "-",
-            "Sage": "-"
+            "Sage": "-",
+            "Custom": "-"
         },
         "options": [
             "-",
@@ -125,7 +126,8 @@
             "Proline": false,
             "i2MassChroQ": false,
             "WOMBAT": false,
-            "Sage": true
+            "Sage": true,
+            "Custom": false
         }
     },
     "comments_for_submission": {


### PR DESCRIPTION
I fixed the custom import. I'll update the docs asap. 

One thing that I noticed though @RobbinBouwmeester:
in module.py, there is this line:
`input_data_frame["proforma"] = input_data_frame["Modified sequence"]`
But isn't it redundant with the toml file line that defines the column with the modified sequence? 