### PR TITLE
:bug: add tolerance unit of alphapept search (#260)

### DIFF
--- a/proteobench/io/params/alphapept.py
+++ b/proteobench/io/params/alphapept.py
@@ -1,4 +1,5 @@
 """Alphapept uses the yaml format to save configuration."""
+
 import pathlib
 
 import pandas as pd
@@ -25,8 +26,11 @@ def extract_params(fname) -> ProteoBenchParameters:
     params.min_peptide_length = fasta["pep_length_min"]
     params.max_peptide_length = fasta["pep_length_max"]
     search = record["search"]
-    params.precursor_mass_tolerance = search["prec_tol"]
-    params.fragment_mass_tolerance = search["frag_tol"]
+    _tolerance_unit = "Da"  # default
+    if search["ppm"]:
+        _tolerance_unit = "ppm"
+    params.precursor_mass_tolerance = f'{search["prec_tol"]} {_tolerance_unit}'
+    params.fragment_mass_tolerance = f'{search["frag_tol"]} {_tolerance_unit}'
     params.ident_fdr_protein = search["protein_fdr"]
     params.ident_fdr_peptide = search["peptide_fdr"]
     # params.ident_fdr_psm = search

--- a/test/params/alphapept_0.4.9.csv
+++ b/test/params/alphapept_0.4.9.csv
@@ -7,8 +7,8 @@ ident_fdr_psm,
 ident_fdr_peptide,0.01
 ident_fdr_protein,0.01
 enable_match_between_runs,False
-precursor_mass_tolerance,20
-fragment_mass_tolerance,50
+precursor_mass_tolerance,20 ppm
+fragment_mass_tolerance,50 ppm
 enzyme,trypsin
 allowed_miscleavages,2
 min_peptide_length,7

--- a/test/params/alphapept_0.4.9_unnormalized.csv
+++ b/test/params/alphapept_0.4.9_unnormalized.csv
@@ -7,8 +7,8 @@ ident_fdr_psm,
 ident_fdr_peptide,0.01
 ident_fdr_protein,0.01
 enable_match_between_runs,False
-precursor_mass_tolerance,20
-fragment_mass_tolerance,50
+precursor_mass_tolerance,20 ppm
+fragment_mass_tolerance,50 ppm
 enzyme,trypsin
 allowed_miscleavages,2
 min_peptide_length,7


### PR DESCRIPTION
Not explicit in parameter file, but stated in documentation: https://mannlabs.github.io/alphapept/search.html

Is there an alternative to ppm included?