### PR TITLE
:bug: Refactor saving of parameters file in DDA quant base module (#283)

### DIFF
--- a/proteobench/modules/dda_quant_base/module.py
+++ b/proteobench/modules/dda_quant_base/module.py
@@ -200,9 +200,8 @@ class Module:
             logging.warning(f"Could not make directory: {path_write}")
 
         # TODO: save parameters file "locally" together with the raw and intermediate?
-        outfile_param = open(os.path.join(path_write, "params.csv"), "w")
-        outfile_param.write(str(param_loc.getvalue()))
-        outfile_param.close()
+        with open(os.path.join(path_write, "params.csv"), "w") as f:
+            f.write(",\n".join(_file.getvalue().decode("utf-8") for _file in param_loc))
 
         input_df.to_csv(os.path.join(path_write, "input_df.csv"))
         result_performance.to_csv(os.path.join(path_write, "result_performance.csv"))


### PR DESCRIPTION
iRegaring Issue #283 
- regression: button now return a list due to FragPipe taking two parameter files (commit https://github.com/Proteobench/ProteoBench/commit/88ff9c845d768bca071f811ffee1608a58f191ef)
- regression: not re-submitting previously recorded runs, lead to an error for recording new runs (commit https://github.com/Proteobench/ProteoBench/commit/f81d3960ce85363ca1f9c3f71172f4976301c391)