### PR TITLE
Fix that resets all datapoints

### DIFF
--- a/webinterface/pages/DDA_Quant_ion.py
+++ b/webinterface/pages/DDA_Quant_ion.py
@@ -582,9 +582,10 @@ class StreamlitUI:
         else:
             self.call_later_plot()
 
-        # TODO do we need add this to the session state?
-        st.session_state[self.variables_dda_quant.all_datapoints] = all_datapoints
-        st.session_state[self.variables_dda_quant.input_df] = input_df
+        if all_datapoints is not None:
+            # TODO do we need add this to the session state?
+            st.session_state[self.variables_dda_quant.all_datapoints] = all_datapoints
+            st.session_state[self.variables_dda_quant.input_df] = input_df
 
         # Create unique element IDs
         if self.variables_dda_quant.meta_file_uploader_uuid not in st.session_state.keys():


### PR DESCRIPTION
Should also mean that we can revert these changes:
           
```
# TODO I have written a copy to a different variable as it is reset when meta data file is uploaded
# TODO this needs to change in the future!
submit_df = st.session_state[self.variables_dda_quant.all_datapoints_submission]
input_df = st.session_state[self.variables_dda_quant.input_df_submission]
result_performance = st.session_state[self.variables_dda_quant.result_performance_submission]
```