### PR TITLE
adding gdpr notices if provided

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "openpyxl",
   "numpy",
   "plotly",
+  "streamlit>=1.31",
   "streamlit_extras",
   "streamlit-plotly-events",
   "matplotlib",

--- a/webinterface/_base.py
+++ b/webinterface/_base.py
@@ -44,11 +44,10 @@ class StreamlitPage(ABC):
             unsafe_allow_html=True,
         )
         st.image("logos/logo_participants/logos_all.png")
-        st.markdown(
-            """
-            This site is hosted by the BMBF-funded de.NBI Cloud within the German Network for Bioinformatics Infrastructure (de.NBI)
-            """
-        )
+
+        # add hosting information if provided
+        if "hosting" in st.secrets.keys():
+            st.markdown(st.secrets["hosting"]["information"])
 
     @abstractmethod
     def _main_page(self):
@@ -57,3 +56,8 @@ class StreamlitPage(ABC):
     def _sidebar(self):
         """Format sidebar."""
         st.sidebar.image("logos/logo_funding/main_logos_sidebar.png", width=300)
+
+        # add gdpr links if provided
+        if "gdpr_links" in st.secrets.keys():
+            st.sidebar.page_link(st.secrets["gdpr_links"]["privacy_notice_link"], label="-> privacy notice")
+            st.sidebar.page_link(st.secrets["gdpr_links"]["legal_notice_link"], label="-> legal notice")


### PR DESCRIPTION
This addition shows links to "privacy notice" and "legal notice" on a hosted system. This is only rendered if the data is given in the `secrets.toml`.

Also, the "hosting information" is now only rendered if a specific string is provided in the `secrets.toml`.