### PR TITLE
refactoring the sidebar and general configs

### DIFF
--- a/webinterface/Home.py
+++ b/webinterface/Home.py
@@ -1,4 +1,4 @@
-"""psm_utils Streamlit-based web server."""
+"""Proteobench Streamlit-based web server."""
 
 from _base import StreamlitPage
 

--- a/webinterface/_base.py
+++ b/webinterface/_base.py
@@ -1,8 +1,9 @@
-"""Base classes for psm_utils online Streamlit web server."""
+"""Base classes for ProteoBench online Streamlit web server."""
 
 from abc import ABC, abstractmethod
 
 import streamlit as st
+import pages.texts.proteobench_builder as pbb
 from st_pages import show_pages_from_config
 
 import proteobench
@@ -14,16 +15,11 @@ class StreamlitPage(ABC):
     def __init__(self) -> None:
         self.state = st.session_state
 
-        st.set_page_config(
-            page_title="Proteobench",
-            page_icon=":rocket:",
-            layout="centered",
-            initial_sidebar_state="expanded",
-        )
-
+        pbb.proteobench_page_config(page_layout="centered")
+        pbb.proteobench_sidebar()
+        
         self._preface()
         self._main_page()
-        self._sidebar()
         show_pages_from_config()
 
     def _preface(self):
@@ -56,12 +52,3 @@ class StreamlitPage(ABC):
     @abstractmethod
     def _main_page(self):
         raise NotImplementedError()
-
-    def _sidebar(self):
-        """Format sidebar."""
-        st.sidebar.image("logos/logo_funding/main_logos_sidebar.png", width=300)
-
-        # add gdpr links if provided
-        if "gdpr_links" in st.secrets.keys():
-            st.sidebar.page_link(st.secrets["gdpr_links"]["privacy_notice_link"], label="-> privacy notice")
-            st.sidebar.page_link(st.secrets["gdpr_links"]["legal_notice_link"], label="-> legal notice")

--- a/webinterface/pages/DDA_Quant_ion.py
+++ b/webinterface/pages/DDA_Quant_ion.py
@@ -11,6 +11,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 import streamlit_utils
+import pages.texts.proteobench_builder as pbb
 from pages.pages_variables.dda_quant_variables import VariablesDDAQuant
 from pages.texts.generic_texts import WebpageTexts
 from streamlit_extras.let_it_rain import rain
@@ -43,18 +44,14 @@ class StreamlitUI:
         self.texts: Type[WebpageTexts] = WebpageTexts
         self.user_input: Dict[str, Any] = dict()
 
-        st.set_page_config(
-            page_title="Proteobench web server",
-            page_icon=":rocket:",
-            layout="wide",
-            initial_sidebar_state="expanded",
-        )
+        pbb.proteobench_page_config()
+        pbb.proteobench_sidebar()
+
         if self.variables_dda_quant.submit not in st.session_state:
             st.session_state[self.variables_dda_quant.submit] = False
 
         self.ionmodule: IonModule = IonModule()
         self._main_page()
-        self._sidebar()
 
     def generate_input_field(self, input_format: str, content: dict) -> Any:
         """
@@ -215,12 +212,6 @@ class StreamlitUI:
         Populates the results section of the UI. This is called after data processing is complete.
         """
         self.generate_results("", None, None, False, None)
-
-    def _sidebar(self):
-        """
-        Sets up the sidebar for the Streamlit application, including images and additional info.
-        """
-        st.sidebar.image("logos/logo_funding/main_logos_sidebar.png", width=300)
 
     def _run_proteobench(self) -> None:
         """

--- a/webinterface/pages/TEMPLATE.py
+++ b/webinterface/pages/TEMPLATE.py
@@ -12,6 +12,9 @@ from proteobench.modules.template.module import Module
 from proteobench.modules.template.parse_settings import INPUT_FORMATS, LOCAL_DEVELOPMENT, TEMPLATE_RESULTS_PATH
 from proteobench.modules.template.plot import plot_bench1, plot_bench2
 
+import pages.texts.proteobench_builder as pbb
+
+
 logger = logging.getLogger(__name__)
 
 ## Different parts of the web application
@@ -38,16 +41,12 @@ class StreamlitUI:
         self.texts = WebpageTexts
         self.user_input = dict()
 
-        st.set_page_config(
-            page_title="Proteobench web server",
-            page_icon=":rocket:",
-            layout="centered",
-            initial_sidebar_state="expanded",
-        )
+        pbb.proteobench_page_config()
+        pbb.proteobench_sidebar()
+
         if SUBMIT not in st.session_state:
             st.session_state[SUBMIT] = False
         self._main_page()
-        self._sidebar()
 
     # Here the user can select the input file format. This is defined in the
     # modules folder in the io_parse_settings folder
@@ -107,16 +106,6 @@ class StreamlitUI:
 
     def _populate_results(self):
         self.generate_results("", None, None, False)
-
-    def _sidebar(self):
-        """Format sidebar."""
-        st.sidebar.image(
-            "https://upload.wikimedia.org/wikipedia/commons/8/85/Garden_bench_001.jpg",
-            width=150,
-        )
-        # st.sidebar.markdown(self.texts.Sidebar.badges)
-        st.sidebar.header("About")
-        st.sidebar.markdown(self.texts.Sidebar.about, unsafe_allow_html=True)
 
     def _run_proteobench(self):
         # Run Proteobench

--- a/webinterface/pages/texts/proteobench_builder.py
+++ b/webinterface/pages/texts/proteobench_builder.py
@@ -1,0 +1,23 @@
+"""Streamlit-wide page settings and tools for ProteoBench."""
+import streamlit as st
+
+def proteobench_page_config(page_layout = "wide"):
+    """Set some ProteoBench wide page settings"""
+    st.set_page_config(
+        page_title="Proteobench",
+        page_icon=":rocket:",
+        layout=page_layout,
+        initial_sidebar_state="expanded",
+    )
+
+def proteobench_sidebar():
+    """Format the sidebar for ProteoBench."""
+    st.sidebar.image("logos/logo_funding/main_logos_sidebar.png", width=300)
+
+    # add gdpr links if provided
+    if "gdpr_links" in st.secrets.keys():
+        st.sidebar.page_link(st.secrets["gdpr_links"]["privacy_notice_link"], label="-> privacy notice")
+        st.sidebar.page_link(st.secrets["gdpr_links"]["legal_notice_link"], label="-> legal notice")
+    
+    if "tracking" in st.secrets.keys() and "html" in st.secrets["tracking"].keys():
+        st.sidebar.html(st.secrets["tracking"]["html"])


### PR DESCRIPTION
This PR refactors the call for the sidebar, so it is only defined in one position.
Also, allows a secret-setting for website tracking / analysing.

As soon as this is merged (and a new version created), we should be able to track the traffic on our server page.  