### PR TITLE
server update by webhook

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -88,19 +88,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}
-  
-  update-server:
-    name: Update ProteoBench on server
-    needs: [build-and-release, publish]
-    runs-on: ubuntu-latest
-    steps:
-    - name: executing update script on server
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.SERVER_IP }}
-        port: ${{ secrets.SERVER_PORT }}
-        username: ${{ secrets.SERVER_USERNAME }}
-        key: ${{ secrets.SERVER_KEY }}
-        script_stop: true
-        script: |
-          sudo ~/callupdate.sh


### PR DESCRIPTION
The server will be updated by a webhook instead of the SSH call in the workflow.
I set up the webhook, it should be triggered on each new release. 