### PR TITLE
constrain dependency st-pages to <1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "toml",
   "PyGithub",
   "GitPython",
-  "st-pages",
+  "st-pages<1.0",
 ]
 license = { file = "LICENSE" }
 name = "proteobench"


### PR DESCRIPTION
Fixes:
ImportError: cannot import name 'show_pages_from_config' from 'st_pages'

Because that function has been deprecated in later versions of st-pages:
https://github.com/blackary/st_pages/issues/112

resolves #415