### PR TITLE
:bug: temporay file alwas opened as text object, even if it's binary

### DIFF
--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -10,8 +10,6 @@ import pandas as pd
 def load_input_file(input_csv: str, input_format: str) -> pd.DataFrame:
     """Method loads dataframe from a csv depending on its format."""
     input_data_frame: pd.DataFrame
-    # reload buffer: https://stackoverflow.com/a/64478151/9684872
-    input_csv.seek(0)
     if input_format == "MaxQuant":
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "AlphaPept":

--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import math
 import os
 import re
-import math
 
 import pandas as pd
 
@@ -10,7 +10,8 @@ import pandas as pd
 def load_input_file(input_csv: str, input_format: str) -> pd.DataFrame:
     """Method loads dataframe from a csv depending on its format."""
     input_data_frame: pd.DataFrame
-
+    # reload buffer: https://stackoverflow.com/a/64478151/9684872
+    input_csv.seek(0)
     if input_format == "MaxQuant":
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "AlphaPept":

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -479,9 +479,7 @@ class QuantUIObjects:
         """Executes the benchmarking process and returns the results."""
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             tmp_file.write(self.user_input["input_csv"].getbuffer())
-            # temp_file_name = tmp_file.name
-        # f = open(temp_file_name)
-        # f.seek(0)
+
         # reload buffer: https://stackoverflow.com/a/64478151/9684872
         self.user_input["input_csv"].seek(0)
         if st.session_state[self.variables_quant.slider_id_submitted_uuid] in st.session_state.keys():

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -479,10 +479,11 @@ class QuantUIObjects:
         """Executes the benchmarking process and returns the results."""
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             tmp_file.write(self.user_input["input_csv"].getbuffer())
-            temp_file_name = tmp_file.name
+            # temp_file_name = tmp_file.name
         # f = open(temp_file_name)
         # f.seek(0)
-
+        # reload buffer: https://stackoverflow.com/a/64478151/9684872
+        self.user_input["input_csv"].seek(0)
         if st.session_state[self.variables_quant.slider_id_submitted_uuid] in st.session_state.keys():
             set_slider_val = st.session_state[st.session_state[self.variables_quant.slider_id_submitted_uuid]]
         else:

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -694,8 +694,8 @@ class QuantUIObjects:
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             tmp_file.write(self.user_input["input_csv"].getbuffer())
             temp_file_name = tmp_file.name
-        f = open(temp_file_name)
-        f.seek(0)
+        # f = open(temp_file_name)
+        # f.seek(0)
 
         if st.session_state[self.variables_quant.slider_id_submitted_uuid] in st.session_state.keys():
             set_slider_val = st.session_state[st.session_state[self.variables_quant.slider_id_submitted_uuid]]
@@ -708,7 +708,7 @@ class QuantUIObjects:
             all_datapoints = st.session_state[self.variables_quant.all_datapoints]
 
         return self.ionmodule.benchmarking(
-            f,  # self.user_input["input_csv"],
+            self.user_input["input_csv"],
             self.user_input["input_format"],
             self.user_input,
             all_datapoints,


### PR DESCRIPTION
Opening the temporay file in `r` mode opens  it as a binary file, creating something like

```
 <_io.TextIOWrapper name='/var/folders/l5/ajfaa/T/tmp6asd mode='r' encoding='UTF-8'>
```

In case of `ProlineStudio` a binary excel file is submitted. This will mean that the file cannot be read by pandas (as the format is not utf8).

- [x] need to test if other tools csv files still work

`st.file_uploader` already return a File like object, which can be used. See [docs](https://docs.streamlit.io/develop/api-reference/widgets/st.file_uploader)