### PR TITLE
homogenise peptidoform strings in DDA result files

### DIFF
--- a/proteobench/io/parsing/io_parse_settings/parse_settings_fragpipe.toml
+++ b/proteobench/io/parsing/io_parse_settings/parse_settings_fragpipe.toml
@@ -29,7 +29,7 @@
 "before_aa" = false
 "isalpha" = true
 "isupper" = true
-"pattern"="\\[([^]]+)\\]"
+"pattern"="(?<=\\[).+?(?=\\])"
 "modification_dict" = {"57.0215" = "Carbamidomethyl", "57.0216" = "Carbamidomethyl", "15.9949" = "Oxidation", "-17.026548" = "Gln->pyro-Glu", "-18.010565" = "Glu->pyro-Glu", "42.0106" = "Acetyl"}
 
 [general]

--- a/proteobench/io/parsing/io_parse_settings/parse_settings_sage.toml
+++ b/proteobench/io/parsing/io_parse_settings/parse_settings_sage.toml
@@ -29,7 +29,7 @@
 "before_aa" = false
 "isalpha" = true
 "isupper" = true
-"pattern"="\\[([^]]+)\\]"
+"pattern"="(?<=\\[).+?(?=\\])"
 "modification_dict" = {"+57.0215" = "Carbamidomethyl", "+15.9949" = "Oxidation", "-17.026548" = "Gln->pyro-Glu", "-18.010565" = "Glu->pyro-Glu", "+42" = "Acetyl"}
 
 [general]

--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -14,6 +14,7 @@ def load_input_file(input_csv: str, input_format: str) -> pd.DataFrame:
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "AlphaPept":
         input_data_frame = pd.read_csv(input_csv, low_memory=False)
+        input_data_frame["charge"] = input_data_frame["charge"].astype(int)
     elif input_format == "Sage":
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "FragPipe":

--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -13,8 +13,7 @@ def load_input_file(input_csv: str, input_format: str) -> pd.DataFrame:
     if input_format == "MaxQuant":
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "AlphaPept":
-        input_data_frame = pd.read_csv(input_csv, low_memory=False)
-        input_data_frame["charge"] = input_data_frame["charge"].astype(int)
+        input_data_frame = pd.read_csv(input_csv, low_memory=False, dtype={"charge": int})
     elif input_format == "Sage":
         input_data_frame = pd.read_csv(input_csv, sep="\t", low_memory=False)
     elif input_format == "FragPipe":


### PR DESCRIPTION
2 minor changes:
1) fix regex for modification detection in sage and FragPipe parsing (the old one included the square brackets in the match group, and therefore they did not match to the modifications in the .toml)
2) parse charges from AlphaPept output to int