### PR TITLE
:error: move type conversion up to avoid SettingWithCopyWarning

### DIFF
--- a/proteobench/plotting/plot_quant.py
+++ b/proteobench/plotting/plot_quant.py
@@ -175,7 +175,9 @@ class PlotDataPoint:
 
         # Get all unique color-software combinations (necessary for highlighting)
         color_software_combinations = benchmark_metrics_df[["color", "software_name"]].drop_duplicates()
-
+        benchmark_metrics_df["enable_match_between_runs"] = benchmark_metrics_df["enable_match_between_runs"].astype(
+            str
+        )
         # plot the data points, one trace per software tool
         for _, row in color_software_combinations.iterrows():
             color = row["color"]
@@ -185,7 +187,7 @@ class PlotDataPoint:
                 (benchmark_metrics_df["color"] == color) & (benchmark_metrics_df["software_name"] == software)
             ]
             # to do: remove this line as soon as parameters are homogeneous, see #380
-            tmp_df["enable_match_between_runs"] = tmp_df["enable_match_between_runs"].astype(str)
+            # tmp_df["enable_match_between_runs"] = tmp_df["enable_match_between_runs"].astype(str)
             fig.add_trace(
                 go.Scatter(
                     x=tmp_df["median_abs_epsilon"],


### PR DESCRIPTION
Avoid warning
```
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

/Users/heweb/miniforge3/envs/proteobench/lib/python3.12/site-packages/proteobench/plotting/plot_quant.py:188: SettingWithCopyWarning:
```