### PR TITLE
477 how to handle xtandem hidden parameters that have an impact on final results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,4 @@
     "flake8.args": [
         "--max-line-length=120",
     ],
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "editor.rulers": [
             88
         ],
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "ms-python.autopep8"
     },
     "python.testing.unittestArgs": [
         "-v",
@@ -21,4 +21,6 @@
     "flake8.args": [
         "--max-line-length=120",
     ],
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "editor.rulers": [
             88
         ],
-        "editor.defaultFormatter": "ms-python.autopep8"
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "python.testing.unittestArgs": [
         "-v",

--- a/docs/available-modules/2-quant-lfq-ion-dda.md
+++ b/docs/available-modules/2-quant-lfq-ion-dda.md
@@ -89,8 +89,10 @@ In FragPipe output files, the protein identifiers matching a given ion are in tw
 
 
 ### i2MassChroQ
-A ProteoBench-compatible format is available in i2MassChroQ through the button "ProteoBench export". It generates a tab-delimited file containing one row per quantified ion for metric calculation ("proteobench_export.tsv"; column headers are: "rawfile", "sequence", "ProForma", "charge", "proteins" and "area"); and a parameter file for public submission ("Project parameters.tsv"). Like with the other tools, the protein identifiers should be in the format "sp|P49327|FAS_HUMAN". 
+A ProteoBench-compatible format is available in i2MassChroQ through the button `ProteoBench export`. It generates a tab-delimited file containing one row per quantified ion for metric calculation ("proteobench_export.tsv"; column headers are: "rawfile", "sequence", "ProForma", "charge", "proteins" and "area"); and a parameter file for public submission ("Project parameters.tsv"). Like with the other tools, the protein identifiers should be in the format "sp|P49327|FAS_HUMAN". 
 Link to the i2MassChroQ documentation [here](http://pappso.inrae.fr/bioinfo/i2masschroq/documentation/html/).
+#### Specific information for searches with X!Tandem
+Among the default parameters of X!Tandem, "quick acetyl" and "quick pyrolidone" seach for the variable modifications N-ter acetylation and pyrolidone. Please turn these off if you don't want to include such modifications in your search. 
 
 ### MaxQuant
 By default, MaxQuant uses a contaminants-only fasta file that is located in the software folder (“contaminant.txt”). However, the fasta file provided for this module already contains a set of curated contaminant sequences. Therefore, in the MaxQuant settings (Global parameters > Sequences), **UNTICK the “Include contaminants” box**. 

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -44,15 +44,11 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
 
     # Add "hidden" modifications when using X!Tandem:
     var_mods = ""
-    print(var_mods)
     if params.loc["AnalysisSoftware_name"] == "X!Tandem":
-        if params.loc["Protein, quick acetyl"] == "yes":
+        if params.loc["protein, quick acetyl"] == "yes":
             var_mods = ",Acetyl(N-term)"
-        if params.loc["Protein, quick pyrolidone"] == "yes":
-            var_mods = var_mods + ",Pyrolidone(N-term)"
-
-    print(var_mods)
-    # print(var_mods + ",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()))
+        if params.loc["protein, quick pyrolidone"] == "yes":
+            var_mods = ",Pyrolidone(N-term)" + var_mods
 
     # Create and return a ProteoBenchParameters object with the extracted values
     params = ProteoBenchParameters(
@@ -70,15 +66,14 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
         max_peptide_length=None,  # Not mentioned, up to 38 AA in peptides
-        # fixed_mods=var_mods + ",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()),
-        # variable_mods=var_mods + ",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna()),
-        fixed_mods=",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()),
-        variable_mods=",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna()),
+        fixed_mods=",".join(params.loc[params.index.str.contains(
+            "residue, modification mass")].dropna())+var_mods,
+        variable_mods=",".join(params.loc[params.index.str.contains(
+            "residue, potential modification mass")].dropna())+var_mods,
         max_mods=None,
         min_precursor_charge=1,  # Fixed in software
         max_precursor_charge=params.loc["spectrum, maximum parent charge"],
     )
-    print(params)
 
     return params
 
@@ -94,7 +89,8 @@ if __name__ == "__main__":
         file = pathlib.Path(fname)
 
         # Read the parameter file to extract parameters
-        params = pd.read_csv(file, sep="\t", header=None, index_col=0).squeeze()
+        params = pd.read_csv(file, sep="\t", header=None,
+                             index_col=0).squeeze()
         params = extract_params(file.with_suffix(".tsv"))
 
         # Convert the parameters to a dictionary and then to a pandas Series

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -42,13 +42,15 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     if params.loc["refine"] == "yes":
         max_cleavage = params.loc["refine, maximum missed cleavage sites"]
 
+    fixed_mods_list = list(params.loc[params.index.str.contains("residue, modification mass")].dropna())
+    var_mods_list = list(params.loc[params.index.str.contains("residue, potential modification mass")].dropna())
+
     # Add "hidden" modifications when using X!Tandem:
-    var_mods = ""
-    if params.loc["AnalysisSoftware_name"] == "X!Tandem":
+    if params.loc["AnalysisSoftware_name"] == "X!Tandem" or params.loc["AnalysisSoftware_name"] == "X! Tandem":
         if params.loc["protein, quick acetyl"] == "yes":
-            var_mods = ",Acetyl(N-term)"
+            var_mods_list.append("Acetyl(N-term)")
         if params.loc["protein, quick pyrolidone"] == "yes":
-            var_mods = ",Pyrolidone(N-term)" + var_mods
+            var_mods_list.append("Pyrolidone(N-term)")
 
     # Create and return a ProteoBenchParameters object with the extracted values
     params = ProteoBenchParameters(
@@ -66,9 +68,8 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
         max_peptide_length=None,  # Not mentioned, up to 38 AA in peptides
-        fixed_mods=",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()) + var_mods,
-        variable_mods=",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna())
-        + var_mods,
+        fixed_mods=";".join(fixed_mods_list),
+        variable_mods=";".join(var_mods_list),
         max_mods=None,
         min_precursor_charge=1,  # Fixed in software
         max_precursor_charge=params.loc["spectrum, maximum parent charge"],

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -42,6 +42,18 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     if params.loc["refine"] == "yes":
         max_cleavage = params.loc["refine, maximum missed cleavage sites"]
 
+    # Add "hidden" modifications when using X!Tandem:
+    var_mods = ""
+    print(var_mods)
+    if params.loc["AnalysisSoftware_name"] == "X!Tandem":
+        if params.loc["Protein, quick acetyl"] == "yes":
+            var_mods = ",Acetyl(N-term)"
+        if params.loc["Protein, quick pyrolidone"] == "yes":
+            var_mods = var_mods + ",Pyrolidone(N-term)"
+
+    print(var_mods)
+    # print(var_mods + ",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()))
+
     # Create and return a ProteoBenchParameters object with the extracted values
     params = ProteoBenchParameters(
         software_name="i2MassChroQ",
@@ -58,12 +70,15 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
         max_peptide_length=None,  # Not mentioned, up to 38 AA in peptides
+        # fixed_mods=var_mods + ",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()),
+        # variable_mods=var_mods + ",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna()),
         fixed_mods=",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()),
         variable_mods=",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna()),
         max_mods=None,
         min_precursor_charge=1,  # Fixed in software
         max_precursor_charge=params.loc["spectrum, maximum parent charge"],
     )
+    print(params)
 
     return params
 

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -66,10 +66,9 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
         max_peptide_length=None,  # Not mentioned, up to 38 AA in peptides
-        fixed_mods=",".join(params.loc[params.index.str.contains(
-            "residue, modification mass")].dropna())+var_mods,
-        variable_mods=",".join(params.loc[params.index.str.contains(
-            "residue, potential modification mass")].dropna())+var_mods,
+        fixed_mods=",".join(params.loc[params.index.str.contains("residue, modification mass")].dropna()) + var_mods,
+        variable_mods=",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna())
+        + var_mods,
         max_mods=None,
         min_precursor_charge=1,  # Fixed in software
         max_precursor_charge=params.loc["spectrum, maximum parent charge"],
@@ -89,8 +88,7 @@ if __name__ == "__main__":
         file = pathlib.Path(fname)
 
         # Read the parameter file to extract parameters
-        params = pd.read_csv(file, sep="\t", header=None,
-                             index_col=0).squeeze()
+        params = pd.read_csv(file, sep="\t", header=None, index_col=0).squeeze()
         params = extract_params(file.with_suffix(".tsv"))
 
         # Convert the parameters to a dictionary and then to a pandas Series

--- a/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_sel.csv
+++ b/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_sel.csv
@@ -14,7 +14,7 @@ allowed_miscleavages,3
 min_peptide_length,
 max_peptide_length,
 fixed_mods,57.02146@C
-variable_mods,15.99491@M
+variable_mods,15.99491@M,Acetyl(N-term),Pyrolidone(N-term)
 max_mods,
 min_precursor_charge,1
 max_precursor_charge,4

--- a/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_sel.csv
+++ b/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_sel.csv
@@ -14,7 +14,7 @@ allowed_miscleavages,3
 min_peptide_length,
 max_peptide_length,
 fixed_mods,57.02146@C
-variable_mods,15.99491@M,Acetyl(N-term),Pyrolidone(N-term)
+variable_mods,15.99491@M;Acetyl(N-term);Pyrolidone(N-term)
 max_mods,
 min_precursor_charge,1
 max_precursor_charge,4

--- a/test/test_parse_params_i2masschroq.py
+++ b/test/test_parse_params_i2masschroq.py
@@ -15,3 +15,7 @@ def test_extract_params():
     actual = pd.Series(actual.__dict__)
     actual = pd.read_csv(io.StringIO(actual.to_csv()), index_col=0).squeeze("columns")
     assert expected.equals(actual)
+
+
+if __name__ == "__main__":
+    test_extract_params()


### PR DESCRIPTION
Hi!

It now adds ",Acetyl(N-term)" when "protein, quick acetyl	yes", and ",Pyrolidone(N-term)" when "protein, quick pyrolidone	yes" in the parameter file, if the search engine is X!Tandem. 

I also changed the test result. 

It is not clean because the modification format is not the same as the modifications automatically parsed ("15.99491@M"), but I am not sure what would correspond to "Pyrolidone N-ter" in this fomat. I have to look for it.

There was a change made to the `vscode/settings.json`, I changed it back. I think. Not sure. Sorry about that. Please let me know if I messed this bit up.