### PR TITLE
380 homogenization of parameters

### DIFF
--- a/proteobench/io/params/__init__.py
+++ b/proteobench/io/params/__init__.py
@@ -31,11 +31,11 @@ class ProteoBenchParameters:
     enable_match_between_runs : Optional[bool]
         Match between run (also named cross assignment) is enabled.
     precursor_mass_tolerance : Optional[str]
-       Precursor mass tolerance used for the search,
-       associated with the unit: "20 ppm" = +/- 20 ppm; if several, separate with "|".
+       Precursor mass tolerance used for the search.
+       Given as an interval of upper and lower tolerance, e.g. [-20 ppm, 20 ppm].
     fragment_mass_tolerance : Optional[str]
         Precursor mass tolerance used for the search:
-        "20 ppm" = +/- 20 ppm; if several, separate with "|"
+        Given as an interval of upper and lower tolerance, e.g. [-0.02 Da, 0.02 Da].
     enzyme : Optional[str]
         Enzyme used as parameter for the search. If several, use "|".
     allowed_miscleavages : Optional[int]
@@ -73,16 +73,15 @@ class ProteoBenchParameters:
     search_engine: Optional[str] = None
     search_engine_version: Optional[str] = None
     ident_fdr_psm: Optional[str] = None  # fdr_psm
-    ident_fdr_peptide: Optional[str] = None  # fdr_peptide
-    ident_fdr_protein: Optional[str] = None  # fdr_protein
+    ident_fdr_peptide: Optional[float] = None  # fdr_peptide
+    ident_fdr_protein: Optional[float] = None  # fdr_protein
     enable_match_between_runs: Optional[bool] = None  # MBR
-    # TODO: either add the units for the tolerance here or remove them from the webpage/plot/etc.
     precursor_mass_tolerance: Optional[str] = None  # precursor_tol, precursor_tol_unit
     fragment_mass_tolerance: Optional[str] = None  # fragment_tol, fragment_tol_unit
     enzyme: Optional[str] = None  # enzyme_name
     allowed_miscleavages: Optional[int] = None  # missed_cleavages
-    min_peptide_length: Optional[str] = None  # min_pep_length
-    max_peptide_length: Optional[str] = None  # max_pep_length
+    min_peptide_length: Optional[int] = None  # min_pep_length
+    max_peptide_length: Optional[int] = None  # max_pep_length
     fixed_mods: Optional[str] = None  # fixed_modifications
     variable_mods: Optional[str] = None  # variable_modifications
     max_mods: Optional[int] = None  # max_num_modifications

--- a/proteobench/io/params/alphapept.py
+++ b/proteobench/io/params/alphapept.py
@@ -39,6 +39,8 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     # Extract FASTA related details
     fasta = record["fasta"]
     params.enzyme = fasta["protease"]
+    if params.enzyme == "trypsin":
+        params.enzyme = "Trypsin"
     params.allowed_miscleavages = fasta["n_missed_cleavages"]
     params.fixed_mods = ",".join(fasta["mods_fixed"])
     params.variable_mods = ",".join(fasta["mods_variable"])
@@ -51,8 +53,12 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     _tolerance_unit = "Da"  # Default unit is Da
     if search["ppm"]:
         _tolerance_unit = "ppm"
-    params.precursor_mass_tolerance = f'{search["prec_tol"]} {_tolerance_unit}'
-    params.fragment_mass_tolerance = f'{search["frag_tol"]} {_tolerance_unit}'
+    params.precursor_mass_tolerance = (
+        f'[-{search["prec_tol"]} {_tolerance_unit}, {search["prec_tol"]} {_tolerance_unit}]'
+    )
+    params.fragment_mass_tolerance = (
+        f'[-{search["frag_tol"]} {_tolerance_unit}, {search["frag_tol"]} {_tolerance_unit}]'
+    )
     params.ident_fdr_protein = search["protein_fdr"]
     params.ident_fdr_peptide = search["peptide_fdr"]
 

--- a/proteobench/io/params/diann.py
+++ b/proteobench/io/params/diann.py
@@ -286,14 +286,34 @@ def extract_params(fname: str) -> ProteoBenchParameters:
             else:
                 parameters[proteobench_setting] = parse_setting(proteobench_setting, cmdline_dict[cmd_setting])
 
+    # Parse cut parameter to standard enzyme name
+    if parameters["enzyme"] == "K*,R*":
+        parameters["enzyme"] = "Trypsin/P"
+    elif parameters["enzyme"] == "K*,R*,!*P":
+        parameters["enzyme"] = "Trypsin"
+
     # If mass-acc flag is not present in cmdline string, extract it from the log file
     if "precursor_mass_tolerance" not in parameters.keys():
         mass_tol = extract_with_regex(lines, mass_tolerance_regex)
-        parameters["precursor_mass_tolerance"] = mass_tol + " ppm"
-        parameters["fragment_mass_tolerance"] = mass_tol + " ppm"
+        parameters["precursor_mass_tolerance"] = "[-" + mass_tol + " ppm" + ", " + mass_tol + " ppm]"
+        parameters["fragment_mass_tolerance"] = "[-" + mass_tol + " ppm" + ", " + mass_tol + " ppm]"
     else:
-        parameters["precursor_mass_tolerance"] = str(parameters["precursor_mass_tolerance"]) + " ppm"
-        parameters["fragment_mass_tolerance"] = str(parameters["fragment_mass_tolerance"]) + " ppm"
+        parameters["precursor_mass_tolerance"] = (
+            "[-"
+            + str(parameters["precursor_mass_tolerance"])
+            + " ppm"
+            + ", "
+            + str(parameters["precursor_mass_tolerance"])
+            + " ppm]"
+        )
+        parameters["fragment_mass_tolerance"] = (
+            "[-"
+            + str(parameters["fragment_mass_tolerance"])
+            + " ppm"
+            + ", "
+            + str(parameters["fragment_mass_tolerance"])
+            + " ppm]"
+        )
 
     # If scan window is not customely set, extract it from the log file
     parameters["scan_window"] = int(extract_with_regex(lines, scan_window_regex))
@@ -311,4 +331,5 @@ if __name__ == "__main__":
         params = extract_params(file)
         data_dict = params.__dict__
         series = pd.Series(data_dict)
+        print(series)
         series.to_csv(file.with_suffix(".csv"))

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -25,15 +25,14 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         params.loc["spectrum, fragment monoisotopic mass error units"].replace("Daltons", "Da"),
     )
 
-    # Assert the symmetry of parent mass error tolerances
-    assert (
-        params.loc["spectrum, parent monoisotopic mass error minus"]
-        == params.loc["spectrum, parent monoisotopic mass error plus"]
-    ), "not symmetric tolerance"
-
     # Construct tolerance strings for parent mass error
-    _tol_prec = "{} {}".format(
+    _tol_prec_lower = "{} {}".format(
         params.loc["spectrum, parent monoisotopic mass error minus"],
+        params.loc["spectrum, parent monoisotopic mass error units"].replace("Daltons", "Da"),
+    )
+
+    _tol_prec_upper = "{} {}".format(
+        params.loc["spectrum, parent monoisotopic mass error plus"],
         params.loc["spectrum, parent monoisotopic mass error units"].replace("Daltons", "Da"),
     )
 
@@ -55,13 +54,13 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         software_version=params.loc["i2MassChroQ_VERSION"],
         search_engine=params.loc["AnalysisSoftware_name"],
         search_engine_version=str(params.loc["AnalysisSoftware_version"] or ""),
-        ident_fdr_psm=params.loc["psm_fdr"],
-        ident_fdr_peptide=params.loc["peptide_fdr"],
-        ident_fdr_protein=params.loc["protein_fdr"],
+        ident_fdr_psm=float(params.loc["psm_fdr"]),
+        ident_fdr_peptide=float(params.loc["peptide_fdr"]),
+        ident_fdr_protein=float(params.loc["protein_fdr"]),
         # set match between runs to True if it is enabled
         enable_match_between_runs=True if params.loc["mcq_mbr"] == "T" else False,
-        precursor_mass_tolerance=_tol_prec,
-        fragment_mass_tolerance=_tol_frag,
+        precursor_mass_tolerance="[-" + _tol_prec_lower + ", " + _tol_prec_upper + "]",
+        fragment_mass_tolerance="[-" + _tol_frag + ", " + _tol_frag + "]",
         enzyme=_enzyme,
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
@@ -93,6 +92,7 @@ if __name__ == "__main__":
         # Convert the parameters to a dictionary and then to a pandas Series
         data_dict = params.__dict__
         series = pd.Series(data_dict)
+        print(series)
 
         # Write the Series to a CSV file
         series.to_csv(file.parent / (file.stem + "_sel.csv"))

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -22,7 +22,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     # Construct tolerance strings for fragment and parent mass errors
     _tol_frag = "{} {}".format(
         params.loc["spectrum, fragment monoisotopic mass error"],
-        params.loc["spectrum, fragment monoisotopic mass error units"],
+        params.loc["spectrum, fragment monoisotopic mass error units"].replace("Daltons", "Da"),
     )
 
     # Assert the symmetry of parent mass error tolerances
@@ -34,7 +34,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     # Construct tolerance strings for parent mass error
     _tol_prec = "{} {}".format(
         params.loc["spectrum, parent monoisotopic mass error minus"],
-        params.loc["spectrum, parent monoisotopic mass error units"],
+        params.loc["spectrum, parent monoisotopic mass error units"].replace("Daltons", "Da"),
     )
 
     # Max missed cleavage sites, either from scoring or refinement

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -51,7 +51,8 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         ident_fdr_psm=params.loc["psm_fdr"],
         ident_fdr_peptide=params.loc["peptide_fdr"],
         ident_fdr_protein=params.loc["protein_fdr"],
-        enable_match_between_runs=params.loc["mcq_mbr"],
+        # set match between runs to True if it is enabled
+        enable_match_between_runs=True if params.loc["mcq_mbr"] == "T" else False,
         precursor_mass_tolerance=_tol_prec,
         fragment_mass_tolerance=_tol_frag,
         enzyme=params.loc["protein, cleavage site"],

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -70,7 +70,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         variable_mods=",".join(params.loc[params.index.str.contains("residue, potential modification mass")].dropna()),
         max_mods=None,
         min_precursor_charge=1,  # Fixed in software
-        max_precursor_charge=params.loc["spectrum, maximum parent charge"],
+        max_precursor_charge=int(params.loc["spectrum, maximum parent charge"]),
     )
 
     return params

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -43,11 +43,11 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         max_cleavage = int(params.loc["refine, maximum missed cleavage sites"])
 
     _enzyme = str(params.loc["protein, cleavage site"])
-    # Replace the regular expression for cleavage site with the one used in ProteoBench
+    # Replace the enzyme pattern with the enzyme name used in ProteoBench
     if _enzyme == "[RK]|{P}":
-        _enzyme = "(?<=[KR])(?!P)"
+        _enzyme = "Trypsin"
     elif _enzyme == "[RK]":
-        _enzyme = "(?<=[RK])"
+        _enzyme = "Trypsin/P"
 
     # Create and return a ProteoBenchParameters object with the extracted values
     params = ProteoBenchParameters(

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -20,7 +20,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     params = pd.read_csv(fname, sep="\t", header=None, index_col=0).squeeze()
 
     # Construct tolerance strings for fragment and parent mass errors
-    _tol_frag = "{} ({})".format(
+    _tol_frag = "{} {}".format(
         params.loc["spectrum, fragment monoisotopic mass error"],
         params.loc["spectrum, fragment monoisotopic mass error units"],
     )
@@ -32,7 +32,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     ), "not symmetric tolerance"
 
     # Construct tolerance strings for parent mass error
-    _tol_prec = "{} ({})".format(
+    _tol_prec = "{} {}".format(
         params.loc["spectrum, parent monoisotopic mass error minus"],
         params.loc["spectrum, parent monoisotopic mass error units"],
     )

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -42,6 +42,13 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     if params.loc["refine"] == "yes":
         max_cleavage = params.loc["refine, maximum missed cleavage sites"]
 
+    _enzyme = str(params.loc["protein, cleavage site"])
+    # Replace the regular expression for cleavage site with the one used in ProteoBench
+    if _enzyme == "[RK]|{P}":
+        _enzyme = "(?<=[KR])(?!P)"
+    elif _enzyme == "[RK]":
+        _enzyme = "(?<=[RK])"
+
     # Create and return a ProteoBenchParameters object with the extracted values
     params = ProteoBenchParameters(
         software_name="i2MassChroQ",
@@ -55,7 +62,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         enable_match_between_runs=True if params.loc["mcq_mbr"] == "T" else False,
         precursor_mass_tolerance=_tol_prec,
         fragment_mass_tolerance=_tol_frag,
-        enzyme=params.loc["protein, cleavage site"],
+        enzyme=_enzyme,
         allowed_miscleavages=max_cleavage,
         min_peptide_length=None,  # "spectrum, minimum fragment mz"
         max_peptide_length=None,  # Not mentioned, up to 38 AA in peptides

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -40,7 +40,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
     # Max missed cleavage sites, either from scoring or refinement
     max_cleavage = params.loc["scoring, maximum missed cleavage sites"]
     if params.loc["refine"] == "yes":
-        max_cleavage = params.loc["refine, maximum missed cleavage sites"]
+        max_cleavage = int(params.loc["refine, maximum missed cleavage sites"])
 
     _enzyme = str(params.loc["protein, cleavage site"])
     # Replace the regular expression for cleavage site with the one used in ProteoBench

--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -47,7 +47,7 @@ def extract_params(fname: pathlib.Path) -> ProteoBenchParameters:
         software_name="i2MassChroQ",
         software_version=params.loc["i2MassChroQ_VERSION"],
         search_engine=params.loc["AnalysisSoftware_name"],
-        search_engine_version=params.loc["AnalysisSoftware_version"],
+        search_engine_version=str(params.loc["AnalysisSoftware_version"] or ""),
         ident_fdr_psm=params.loc["psm_fdr"],
         ident_fdr_peptide=params.loc["peptide_fdr"],
         ident_fdr_protein=params.loc["protein_fdr"],

--- a/proteobench/io/params/maxdia.py
+++ b/proteobench/io/params/maxdia.py
@@ -27,8 +27,10 @@ def extract_params(fname: str) -> ProteoBenchParameters:
     series = build_Series_from_records(read_file(fname)).reset_index()
 
     # Extract and set peptide length parameters
-    parameters.min_peptide_length = series.loc[series["level_0"] == "minPeptideLength", 0].values[0]
-    parameters.max_peptide_length = series.loc[series["level_0"] == "maxPeptideLengthForUnspecificSearch", 0].values[0]
+    parameters.min_peptide_length = int(series.loc[series["level_0"] == "minPeptideLength", 0].values[0])
+    parameters.max_peptide_length = int(
+        series.loc[series["level_0"] == "maxPeptideLengthForUnspecificSearch", 0].values[0]
+    )
 
     # Set search engine version from software version
     parameters.search_engine_version = parameters.__dict__["software_version"]

--- a/proteobench/io/params/maxquant.py
+++ b/proteobench/io/params/maxquant.py
@@ -137,28 +137,30 @@ def extract_params(fname, ms2frac="FTMS") -> ProteoBenchParameters:
     params.search_engine = "Andromeda"
     params.software_version = record.loc["maxQuantVersion"].squeeze()
     params.ident_fdr_psm = None
-    params.ident_fdr_peptide = record.loc["peptideFdr"].squeeze()
-    params.ident_fdr_protein = record.loc["proteinFdr"].squeeze()
-    params.enable_match_between_runs = record.loc["matchBetweenRuns"].squeeze()
-    precursor_mass_tolerance = record.loc[
+    params.ident_fdr_peptide = float(record.loc["peptideFdr"].squeeze())
+    params.ident_fdr_protein = float(record.loc["proteinFdr"].squeeze())
+    params.enable_match_between_runs = record.loc["matchBetweenRuns"].squeeze() == "True"
+    _precursor_mass_tolerance = record.loc[
         pd.IndexSlice["parameterGroups", "parameterGroup", "mainSearchTol", :]
     ].squeeze()
-    params.precursor_mass_tolerance = f"{precursor_mass_tolerance} ppm"
+    _precursor_mass_tolerance = f"{_precursor_mass_tolerance} ppm"
+    params.precursor_mass_tolerance = "[-" + _precursor_mass_tolerance + ", " + _precursor_mass_tolerance + "]"
     # ! differences between version >1.6 and <=1.5
     fragment_mass_tolerance = record.loc[pd.IndexSlice["msmsParamsArray", "msmsParams", "MatchTolerance", :]].squeeze()
     in_ppm = bool(record.loc[pd.IndexSlice["msmsParamsArray", "msmsParams", "MatchToleranceInPpm", :]].squeeze())
     if in_ppm:
         fragment_mass_tolerance = f"{fragment_mass_tolerance} ppm"
+    fragment_mass_tolerance = f"[-{fragment_mass_tolerance}, {fragment_mass_tolerance}]"
     params.fragment_mass_tolerance = fragment_mass_tolerance
     params.enzyme = record.loc[("parameterGroups", "parameterGroup", "enzymes", "string")].squeeze()
-    params.allowed_miscleavages = record.loc[
-        pd.IndexSlice["parameterGroups", "parameterGroup", "maxMissedCleavages", :]
-    ].squeeze()
+    params.allowed_miscleavages = int(
+        record.loc[pd.IndexSlice["parameterGroups", "parameterGroup", "maxMissedCleavages", :]].squeeze()
+    )
     try:
-        params.min_peptide_length = record.loc["minPepLen"].squeeze()
+        params.min_peptide_length = int(record.loc["minPepLen"].squeeze())
     except KeyError:
         # Version 2.6 and above
-        params.minPeptideLength = record.loc["minPeptideLength"].squeeze()
+        params.min_peptide_length = int(record.loc["minPeptideLength"].squeeze())
     # minPeptideLengthForUnspecificSearch (what is it?)
     params.max_peptide_length = None
     # fixed mods
@@ -180,11 +182,11 @@ def extract_params(fname, ms2frac="FTMS") -> ProteoBenchParameters:
         params.variable_mods = variable_mods
     else:
         params.variable_mods = ",".join(variable_mods)
-    params.max_mods = record.loc[("parameterGroups", "parameterGroup", "maxNmods")].squeeze()
+    params.max_mods = int(record.loc[("parameterGroups", "parameterGroup", "maxNmods")].squeeze())
     params.min_precursor_charge = None
-    params.max_precursor_charge = record.loc[
-        pd.IndexSlice["parameterGroups", "parameterGroup", "maxCharge", :]
-    ].squeeze()
+    params.max_precursor_charge = int(
+        record.loc[pd.IndexSlice["parameterGroups", "parameterGroup", "maxCharge", :]].squeeze()
+    )
     return params
 
 

--- a/proteobench/io/params/msaid.py
+++ b/proteobench/io/params/msaid.py
@@ -22,9 +22,9 @@ def extract_params(fname: str) -> ProteoBenchParameters:
         "search_engine": "Chimerys",
         "search_engine_version": "4.1.1",
         "quantification_method": "MS2 Area",
-        "ident_fdr_psm": "0.01",
-        "ident_fdr_peptide": "0.01",
-        "ident_fdr_protein": "0.01",
+        "ident_fdr_psm": 0.01,
+        "ident_fdr_peptide": 0.01,
+        "ident_fdr_protein": 0.01,
         "enable_match_between_runs": False,
     }
 
@@ -37,16 +37,18 @@ def extract_params(fname: str) -> ProteoBenchParameters:
     # Extract relevant parameters from the file's dictionary
     parameters["search_engine"] = params_dict["Algorithm"].split(" ")[0]
     parameters["search_engine_version"] = params_dict["Algorithm"].split(" ")[1]
-    parameters["fragment_mass_tolerance"] = params_dict["Fragment Mass Tolerance"]
+    parameters["fragment_mass_tolerance"] = (
+        "[-" + params_dict["Fragment Mass Tolerance"] + ", " + params_dict["Fragment Mass Tolerance"] + "]"
+    )
     parameters["enzyme"] = params_dict["Enzyme"]
-    parameters["allowed_miscleavages"] = params_dict["Max. Missed Cleavage Sites"]
-    parameters["min_peptide_length"] = params_dict["Min. Peptide Length"]
-    parameters["max_peptide_length"] = params_dict["Max. Peptide Length"]
+    parameters["allowed_miscleavages"] = int(params_dict["Max. Missed Cleavage Sites"])
+    parameters["min_peptide_length"] = int(params_dict["Min. Peptide Length"])
+    parameters["max_peptide_length"] = int(params_dict["Max. Peptide Length"])
     parameters["fixed_mods"] = params_dict["Static Modifications"]
     parameters["variable_mods"] = params_dict["Variable Modifications"]
-    parameters["max_mods"] = params_dict["Maximum Number of Modifications"]
-    parameters["min_precursor_charge"] = params_dict["Min. Peptide Charge"]
-    parameters["max_precursor_charge"] = params_dict["Max. Peptide Charge"]
+    parameters["max_mods"] = int(params_dict["Maximum Number of Modifications"])
+    parameters["min_precursor_charge"] = int(params_dict["Min. Peptide Charge"])
+    parameters["max_precursor_charge"] = int(params_dict["Max. Peptide Charge"])
     parameters["quantification_method"] = params_dict["Quantification Type"]
 
     # Set flag for enabling match between runs based on quantification method

--- a/proteobench/io/params/proline.py
+++ b/proteobench/io/params/proline.py
@@ -103,8 +103,10 @@ def extract_params(fname: str) -> ProteoBenchParameters:
     params.allowed_miscleavages = sheet.loc[0, "max_missed_cleavages"]
     params.fixed_mods = sheet.loc[0, "fixed_ptms"]
     params.variable_mods = sheet.loc[0, "variable_ptms"]
-    params.precursor_mass_tolerance = sheet.loc[0, "peptide_mass_error_tolerance"]
-    params.fragment_mass_tolerance = sheet.loc[0, "fragment_mass_error_tolerance"]
+    _precursor_mass_tolerance = sheet.loc[0, "peptide_mass_error_tolerance"]
+    params.precursor_mass_tolerance = f"[-{_precursor_mass_tolerance}, {_precursor_mass_tolerance}]"
+    _fragment_mass_tolerance = sheet.loc[0, "fragment_mass_error_tolerance"]
+    params.fragment_mass_tolerance = f"[-{_fragment_mass_tolerance}, {_fragment_mass_tolerance}]"
 
     # Extract charge states and set min/max precursor charge
     charges = find_charge(sheet.loc[0, "peptide_charge_states"])
@@ -130,7 +132,7 @@ def extract_params(fname: str) -> ProteoBenchParameters:
     sheet_name = "Quant config"
     sheet = excel.parse(sheet_name, dtype="object", index_col=0)
     enable_match_between_runs = sheet.index.str.contains("cross assignment").any()
-    params.enable_match_between_runs = enable_match_between_runs
+    params.enable_match_between_runs = bool(enable_match_between_runs)
 
     # Try to extract software version from "Dataset statistics and infos" sheet
     try:

--- a/proteobench/io/params/sage.py
+++ b/proteobench/io/params/sage.py
@@ -43,21 +43,38 @@ def extract_params(fname: Union[str, pathlib.Path]) -> ProteoBenchParameters:
     params.search_engine = "Sage"
     params.search_engine_version = data["version"]
     params.enzyme = data["database"]["enzyme"]["cleave_at"]
+    if params.enzyme == "KR" or params.enzyme == "RK":
+        try:
+            if data["database"]["enzyme"]["restrict"] == "P":
+                params.enzyme = "Trypsin"
+        except KeyError:
+            params.enyzme = "Trypsin/P"
+
     params.allowed_miscleavages = data["database"]["enzyme"]["missed_cleavages"]
     params.fixed_mods = data["database"]["static_mods"]
     params.variable_mods = data["database"]["variable_mods"]
 
     try:
-        params.precursor_mass_tolerance = data["precursor_tol"]["ppm"]
+        _precursor_mass_tolerance = data["precursor_tol"]["ppm"]
+        # add unit after each value in list
+        _precursor_mass_tolerance = [str(val) + " ppm" for val in _precursor_mass_tolerance]
+        params.precursor_mass_tolerance = "[" + ", ".join(_precursor_mass_tolerance) + "]"
     except KeyError:
-        params.precursor_mass_tolerance = data["precursor_tol"]["Da"]
+        _precursor_mass_tolerance = data["precursor_tol"]["Da"]
+        # add unit after each value in list
+        _precursor_mass_tolerance = [str(val) + " Da" for val in params.precursor_mass_tolerance]
+        params.precursor_mass_tolerance = "[" + ", ".join(_precursor_mass_tolerance) + "]"
 
-    params.fragment_mass_tolerance = data["fragment_tol"]["ppm"]
-    params.min_peptide_length = data["database"]["enzyme"]["min_len"]
-    params.max_peptide_length = data["database"]["enzyme"]["max_len"]
-    params.max_mods = data["database"]["max_variable_mods"]
-    params.min_precursor_charge = data["precursor_charge"][0]
-    params.max_precursor_charge = data["precursor_charge"][1]
+    _fragment_mass_tolerance = data["fragment_tol"]["ppm"]
+    # add unit after each value in list
+    _fragment_mass_tolerance = [str(val) + " ppm" for val in _fragment_mass_tolerance]
+    params.fragment_mass_tolerance = "[" + ", ".join(_fragment_mass_tolerance) + "]"
+
+    params.min_peptide_length = int(data["database"]["enzyme"]["min_len"])
+    params.max_peptide_length = int(data["database"]["enzyme"]["max_len"])
+    params.max_mods = int(data["database"]["max_variable_mods"])
+    params.min_precursor_charge = int(data["precursor_charge"][0])
+    params.max_precursor_charge = int(data["precursor_charge"][1])
     params.enable_match_between_runs = True
 
     return params
@@ -68,6 +85,7 @@ if __name__ == "__main__":
     Extract parameters from Sage JSON files and save them as CSV.
     """
     from pathlib import Path
+    from pprint import pprint
 
     file = Path("../../../test/params/sage_results.json")
 
@@ -76,6 +94,7 @@ if __name__ == "__main__":
 
     # Convert the extracted parameters to a dictionary and then to a pandas Series
     data_dict = params.__dict__
+    pprint(params.__dict__)
     series = pd.Series(data_dict)
 
     # Write the Series to a CSV file


### PR DESCRIPTION
Standardise parameters and parameter types of all search engine parsers: When parsing the parameters from search engine config files, the parsed parameters should now be parsed to the respective types defined in the ProteoBenchParameters init.
Also:
 - Change mass tolerances to intervals to accomodate asymmetric searches (usually sage/MSFragger)
- parse cleavage sites and enzyme names to standards ("Trypsin"/"Trypsin/P")