### PR TITLE
449 add raw file names next to link to pxd

### DIFF
--- a/docs/available-modules/2-quant-lfq-ion-dda.md
+++ b/docs/available-modules/2-quant-lfq-ion-dda.md
@@ -18,7 +18,16 @@ Other modules will be more suited to explore further post-pocessing steps.
 A subset of the Q Exactive HF-X Orbitrap (Thermo Fisher) data dependent acquisition (DDA) data described by [Van Puyvelde et al., 2022](https://www.nature.com/articles/s41597-022-01216-6) was used as a benchmark dataset. Here, only the first biological replicate series (named “alpha”) was used, encompassing three technical replicates of two different conditions (referred to as “A” and “B”). The samples are a mixture of commercial peptide digest standards of the following species: Escherichia coli (P/N:186003196, Waters Corporation), Yeast (P/N: V7461, Promega) and Human (P/N: V6951, Promega), with logarithmic fold changes (log2FCs) of 0, −1 and 2 for respectively Human, Yeast and E.coli. 
 Please refer to the original publication for the full description of sample preparation and data acquisition parameters ([Van Puyvelde et al., 2022](https://www.nature.com/articles/s41597-022-01216-6)). 
 
-The files can be downloaded from the proteomeXchange repository [PXD028735](https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/datasets/raw_files/DDA/](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA/)
+The files can be downloaded from the proteomeXchange repository [PXD028735](https://www.ebi.ac.uk/pride/archive/projects/PXD028735), make sure that you download the following raw files:
+
+- [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_01.raw)
+- [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_02.raw)
+- [LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_A_Sample_Alpha_03.raw)
+- [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_01.raw)
+- [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw)
+- [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw)
+
+Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/datasets/raw_files/DDA/](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA/)
 
 **It is imperative not to rename the files once downloaded!**
 

--- a/docs/available-modules/4-quant-lfq-ion-dia-aif.md
+++ b/docs/available-modules/4-quant-lfq-ion-dia-aif.md
@@ -1,6 +1,6 @@
 # DIA quantification - precursor ions - AIF data
 
-This module compares the sensitivity and quantification accuracy for data-independent acquisition (DIA) data, namely All-Ion Fragmentation, on a Q Exactive HF-X Orbitrap (Thermo Fisher).
+This module compares the sensitivity and quantification accuracy for data-independent acquisition (DIA) data, namely All-Ion Fragmentation (AIF), on a Q Exactive HF-X Orbitrap (Thermo Fisher).
 Users can load their data and inspect the results privately. They can also make their outputs public by providing the associated parameter file and submitting the benchmark run to ProteoBench. By doing so, their workflow output will be stored alongside all other benchmark runs in ProteoBench and will be accessible to the entire community.
 
 **This module is not designed to compare later-stages post-processing of quantitative data such as missing value replacement, and we advise users to publically upload data without replacement of missing values and without manual filtering.**  
@@ -8,7 +8,6 @@ Users can load their data and inspect the results privately. They can also make 
 We think that this module is more suited to evaluate the impact of (non exhaustive list):
 - search engine identification
 - peak picking
-- match between run
 - low-level ion signal normalisation
 
 Other modules will be more suited to explore further post-pocessing steps. 
@@ -18,7 +17,16 @@ Other modules will be more suited to explore further post-pocessing steps.
 A subset of the Q Exactive HF-X Orbitrap (Thermo Fisher) data independent acquisition (DIA) data described by [Van Puyvelde et al., 2022](https://www.nature.com/articles/s41597-022-01216-6) was used as a benchmark dataset (in the manuscript referred to as All-Ion Fragmentation (AIF)). Here, only the first biological replicate series (named “alpha”) was used, encompassing three technical replicates of two different conditions (referred to as “A” and “B”). The samples are a mixture of commercial peptide digest standards of the following species: Escherichia coli (P/N:186003196, Waters Corporation), Yeast (P/N: V7461, Promega) and Human (P/N: V6951, Promega), with logarithmic fold changes (log2FCs) of 0, −1 and 2 for respectively Human, Yeast and E.coli. 
 Please refer to the original publication for the full description of sample preparation and data acquisition parameters ([Van Puyvelde et al., 2022](https://www.nature.com/articles/s41597-022-01216-6)). 
 
-The files can be downloaded from the proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/
+The files can be downloaded from the proteomeXchange repository [PXD028735](https://www.ebi.ac.uk/pride/archive/projects/PXD028735), make sure that you download the following raw files:
+
+- [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01.raw)
+- [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02.raw)
+- [LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03.raw)
+- [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01.raw)
+- [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw)
+- [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw)
+
+Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/datasets/raw_files/DDA/](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/)
 
 **It is imperative not to rename the files once downloaded!**
 

--- a/webinterface/pages/markdown_files/Quant/lfq/ion/DDA/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/ion/DDA/input_file_description.md
@@ -1,3 +1,7 @@
 
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#how-to-use)" section of this module. For the data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#data-set)". You can download an (*incomplete*) MaxQuant file example [here](https://raw.githubusercontent.com/Proteobench/ProteoBench/refs/heads/main/test/data/dda_quant/MaxQuant_2_5_1_evidence_sample.txt).
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#data-set)". You can download an (*incomplete*) MaxQuant file example [here](https://raw.githubusercontent.com/Proteobench/ProteoBench/refs/heads/main/test/data/dda_quant/MaxQuant_2_5_1_evidence_sample.txt) for testing.
+
+Remember: contaminant sequences are already present in the fasta file 
+associated to this module. **Do not add other contaminants** to your 
+search. This is important when using MaxQuant and FragPipe, among other tools.

--- a/webinterface/pages/markdown_files/Quant/lfq/ion/DIA/AIF/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/ion/DIA/AIF/input_file_description.md
@@ -1,9 +1,5 @@
-Please upload the ouput of your analysis, and indicate what software 
-tool it comes from (this is necessary to correctly parse your table - find 
-more information in the "[How to use](https://proteobench.readthedocs.io/en/stable/available-modules/4-quant-lfq-ion-dia-aif/)"
-section of this module).
-
-Currently, we support output files from AlphaDIA, DIA-NN, FragPipe, MSAID, MaxQuant and Spectronaut. It is also possible to reformat your data in a tab-delimited file that we call "custom format" in the [documentation](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/). 
+Please upload the output of your analysis, and indicate what software
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#data-set)". 
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/peptidoform/DDA/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/peptidoform/DDA/input_file_description.md
@@ -1,3 +1,6 @@
-
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda/#how-to-use)" section of this module. For the data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda/#data-set)".
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda)". 
+
+Remember: contaminant sequences are already present in the fasta file 
+associated to this module. **Do not add other contaminants** to your 
+search. This is important when using MaxQuant and FragPipe, among other tools.


### PR DESCRIPTION
I added the direct links to the raw files on PRIDE. 
I also homogenised the markdown texts in the tabs `Submit your data`, but please make sure you agree @rodvrees. And you can of course change back if you don't.
In particular: I removed the list of compatible software for the DIA module because: 
1. it is not in the DDA modules
2. the information is in the selection box
3. it is a bit harder to keep up to date.
But I don't feel strongly about it. I am totally fine if you want to revert it to how it was. 

I also put back the mention of the contaminants in MQ to homogenise, but I know that @RobbinBouwmeester removed it in the past. If you want I can remove it again, although I think that it can be good to keep it since it highlights that everything is included in the fasta and people who routinely use their own (with or without MQ) may think of not doing so. But remove is you dislike ;)