### PR TITLE
bugfix for MBR parameter parsing in MQ

### DIFF
--- a/proteobench/io/params/maxquant.py
+++ b/proteobench/io/params/maxquant.py
@@ -139,7 +139,7 @@ def extract_params(fname, ms2frac="FTMS") -> ProteoBenchParameters:
     params.ident_fdr_psm = None
     params.ident_fdr_peptide = float(record.loc["peptideFdr"].squeeze())
     params.ident_fdr_protein = float(record.loc["proteinFdr"].squeeze())
-    params.enable_match_between_runs = record.loc["matchBetweenRuns"].squeeze() == "True"
+    params.enable_match_between_runs = record.loc["matchBetweenRuns"].squeeze().lower() == "true"
     _precursor_mass_tolerance = record.loc[
         pd.IndexSlice["parameterGroups", "parameterGroup", "mainSearchTol", :]
     ].squeeze()

--- a/test/params/mqpar1.5.3.30_MBR_sel.json
+++ b/test/params/mqpar1.5.3.30_MBR_sel.json
@@ -6,7 +6,7 @@
     "ident_fdr_psm": null,
     "ident_fdr_peptide": 0.01,
     "ident_fdr_protein": 0.01,
-    "enable_match_between_runs": false,
+    "enable_match_between_runs": true,
     "precursor_mass_tolerance": "[-4.5 ppm, 4.5 ppm]",
     "fragment_mass_tolerance": "[-20 ppm, 20 ppm]",
     "enzyme": "Trypsin/P",


### PR DESCRIPTION
Fixing parameter parsing in MQ for older versions of parameter files where parameter was lowercase