### PR TITLE
rename Datapoint to QuantDatapoint 

### DIFF
--- a/proteobench/datapoint/quant_datapoint.py
+++ b/proteobench/datapoint/quant_datapoint.py
@@ -51,7 +51,7 @@ def filter_df_numquant_nr_prec(row: pd.Series, min_quant: int = 3) -> int | None
 
 
 @dataclass
-class Datapoint:
+class QuantDatapoint:
     """
     A data structure used to store the results of a benchmark run.
 
@@ -145,7 +145,7 @@ class Datapoint:
         except AttributeError:
             user_input = {key: ("" if value is None else value) for key, value in user_input.items()}
 
-        result_datapoint = Datapoint(
+        result_datapoint = QuantDatapoint(
             id=input_format + "_" + user_input["software_version"] + "_" + formatted_datetime,
             software_name=input_format,
             software_version=user_input["software_version"],
@@ -168,7 +168,9 @@ class Datapoint:
 
         result_datapoint.generate_id()
 
-        results = dict(ChainMap(*[Datapoint.get_metrics(intermediate, nr_observed) for nr_observed in range(1, 7)]))
+        results = dict(
+            ChainMap(*[QuantDatapoint.get_metrics(intermediate, nr_observed) for nr_observed in range(1, 7)])
+        )
         result_datapoint.results = results
         result_datapoint.median_abs_epsilon = result_datapoint.results[default_cutoff_min_prec]["median_abs_epsilon"]
         result_datapoint.mean_abs_epsilon = result_datapoint.results[default_cutoff_min_prec]["mean_abs_epsilon"]

--- a/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
+++ b/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 from pandas import DataFrame
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
     DatapointAppendError,
@@ -151,7 +151,7 @@ class DDAQuantIonModule(QuantModule):
             raise IntermediateFormatGenerationError(f"Error generating intermediate data structure: {e}")
 
         # try:
-        current_datapoint = Datapoint.generate_datapoint(
+        current_datapoint = QuantDatapoint.generate_datapoint(
             intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
         )
         # except Exception as e:

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import pandas as pd
 from pandas import DataFrame
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
     DatapointAppendError,
@@ -139,7 +139,7 @@ class DIAQuantIonModule(QuantModule):
 
         # Generate current data point
         try:
-            current_datapoint = Datapoint.generate_datapoint(
+            current_datapoint = QuantDatapoint.generate_datapoint(
                 intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
             )
         except Exception as e:

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 import pandas as pd
 from pandas import DataFrame
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
     DatapointAppendError,
@@ -139,7 +139,7 @@ class DIAQuantIonModulediaPASEF(QuantModule):
 
         # Generate current data point
         try:
-            current_datapoint = Datapoint.generate_datapoint(
+            current_datapoint = QuantDatapoint.generate_datapoint(
                 intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
             )
         except Exception as e:

--- a/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import pandas as pd
 from pandas import DataFrame
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
     DatapointAppendError,
@@ -139,7 +139,7 @@ class DDAQuantPeptidoformModule(QuantModule):
 
         # Generate current data point
         try:
-            current_datapoint = Datapoint.generate_datapoint(
+            current_datapoint = QuantDatapoint.generate_datapoint(
                 intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
             )
         except Exception as e:

--- a/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import pandas as pd
 from pandas import DataFrame
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
     DatapointAppendError,
@@ -115,7 +115,7 @@ class DIAQuantPeptidoformModule(QuantModule):
 
         # Generate current data point
         try:
-            current_datapoint = Datapoint.generate_datapoint(
+            current_datapoint = QuantDatapoint.generate_datapoint(
                 intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
             )
         except Exception as e:

--- a/proteobench/modules/quant/quant_base/quant_base_module.py
+++ b/proteobench/modules/quant/quant_base/quant_base_module.py
@@ -12,7 +12,7 @@ import streamlit as st
 from pandas import DataFrame
 
 from proteobench.datapoint.quant_datapoint import (
-    Datapoint,
+    QuantDatapoint,
     filter_df_numquant_epsilon,
     filter_df_numquant_nr_prec,
 )
@@ -244,7 +244,7 @@ class QuantModule:
         )
         intermediate_data_structure = quant_score.generate_intermediate(standard_format, replicate_to_raw)
 
-        current_datapoint = Datapoint.generate_datapoint(
+        current_datapoint = QuantDatapoint.generate_datapoint(
             intermediate_data_structure, input_format, user_input, default_cutoff_min_prec=default_cutoff_min_prec
         )
 

--- a/test/test_module_dda_quant.py
+++ b/test/test_module_dda_quant.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.github.gh import GithubProteobotRepo
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
@@ -236,7 +236,7 @@ class TestDatapoint(unittest.TestCase):
         current_datetime = datetime.datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d_%H%M%S_%f")
 
-        result_datapoint = Datapoint(
+        result_datapoint = QuantDatapoint(
             id=input_format + "_" + user_input["software_version"] + "_" + formatted_datetime,
             software_name=input_format,
             software_version=user_input["software_version"],

--- a/test/test_module_dia_quant.py
+++ b/test/test_module_dia_quant.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from proteobench.datapoint.quant_datapoint import Datapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import DatapointGenerationError
 from proteobench.github.gh import GithubProteobotRepo
 from proteobench.io.parsing.parse_ion import load_input_file
@@ -240,7 +240,7 @@ class TestDatapoint(unittest.TestCase):
         current_datetime = datetime.datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d_%H%M%S_%f")
 
-        result_datapoint = Datapoint(
+        result_datapoint = QuantDatapoint(
             id=input_format + "_" + user_input["software_version"] + "_" + formatted_datetime,
             software_name=input_format,
             software_version=user_input["software_version"],


### PR DESCRIPTION
rename Datapoint to QuantDatapoint to avoid confusion with future distinct Datapoint classes (e.g. the Datapoint class for the subcellular profiling module)