### PR TITLE
Refactor/fewer default args

### DIFF
--- a/proteobench/io/parsing/parse_settings.py
+++ b/proteobench/io/parsing/parse_settings.py
@@ -13,13 +13,13 @@ from .parse_ion import get_proforma_bracketed
 
 
 class ParseSettingsBuilder:
-    def __init__(self, parse_settings_dir: str, module_id: str = "quant_lfq_ion_DDA"):
+    def __init__(self, parse_settings_dir: str, module_id: str):
         """
         Initializes the settings builder with parse settings from TOML files.
 
         Args:
             parse_settings_dir (str): The directory containing the parse settings files.
-            module_id (str): The ID of the module used to fetch the specific parse settings. Defaults to "quant_lfq_ion_DDA".
+            module_id (str): The ID of the module used to fetch the specific parse settings.
         """
         self.PARSE_SETTINGS_TOMLS = toml.load(
             os.path.join(os.path.dirname(__file__), "io_parse_settings", "parse_settings_files.toml")

--- a/proteobench/io/parsing/parse_settings.py
+++ b/proteobench/io/parsing/parse_settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pandas as pd
 import toml
@@ -13,21 +13,17 @@ from .parse_ion import get_proforma_bracketed
 
 
 class ParseSettingsBuilder:
-    def __init__(self, parse_settings_dir: Optional[str] = None, module_id: str = "quant_lfq_ion_DDA"):
+    def __init__(self, parse_settings_dir: str, module_id: str = "quant_lfq_ion_DDA"):
         """
         Initializes the settings builder with parse settings from TOML files.
 
         Args:
-            parse_settings_dir (Optional[str]): The directory containing the parse settings files. Defaults to None.
+            parse_settings_dir (str): The directory containing the parse settings files.
             module_id (str): The ID of the module used to fetch the specific parse settings. Defaults to "quant_lfq_ion_DDA".
         """
         self.PARSE_SETTINGS_TOMLS = toml.load(
             os.path.join(os.path.dirname(__file__), "io_parse_settings", "parse_settings_files.toml")
         )
-        if parse_settings_dir is None:
-            parse_settings_dir = os.path.join(
-                os.path.dirname(__file__), "io_parse_settings", "Quant", "lfq", "ion", "DDA"
-            )
 
         try:
             self.PARSE_SETTINGS_FILES = {

--- a/proteobench/modules/constants.py
+++ b/proteobench/modules/constants.py
@@ -1,6 +1,6 @@
 import pathlib
 
-IO_PARSE_SETTINGS_DIR = pathlib.Path(__file__) / ".." / ".." / ".." / ".." / "io" / "parsing" / "io_parse_settings"
+IO_PARSE_SETTINGS_DIR = pathlib.Path(__file__) / ".." / ".." / "io" / "parsing" / "io_parse_settings"
 QUANT_LFQ_SETTINGS_DIR = IO_PARSE_SETTINGS_DIR / "Quant" / "lfq"
 
 MODULE_SETTINGS_DIRS = {

--- a/proteobench/modules/constants.py
+++ b/proteobench/modules/constants.py
@@ -1,7 +1,7 @@
 import pathlib
 
 IO_PARSE_SETTINGS_DIR = pathlib.Path(__file__) / ".." / ".." / "io" / "parsing" / "io_parse_settings"
-QUANT_LFQ_SETTINGS_DIR = IO_PARSE_SETTINGS_DIR / "Quant" / "lfq"
+QUANT_LFQ_SETTINGS_DIR = (IO_PARSE_SETTINGS_DIR / "Quant" / "lfq").resolve()
 
 MODULE_SETTINGS_DIRS = {
     "quant_lfq_ion_DIA_AIF": (QUANT_LFQ_SETTINGS_DIR / "ion" / "DIA" / "AIF").as_posix(),

--- a/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
+++ b/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
@@ -13,7 +13,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 

--- a/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
+++ b/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import pandas as pd
 from pandas import DataFrame
 
@@ -15,6 +13,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 
@@ -26,30 +25,11 @@ class DDAQuantIonModule(QuantModule):
     ----------
     module_id : str
         Module identifier for configuration.
-    parse_settings_dir : str
-        Directory containing parsing settings.
     precursor_name: str
         Level of quantification.
     """
 
     module_id = "quant_lfq_ion_DDA"
-    parse_settings_dir: str = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "..",
-            "..",
-            "io",
-            "parsing",
-            "io_parse_settings",
-            "Quant",
-            "lfq",
-            "ion",
-            "DDA",
-        )
-    )
 
     def __init__(
         self,
@@ -74,7 +54,7 @@ class DDAQuantIonModule(QuantModule):
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=self.parse_settings_dir,
+            parse_settings_dir=MODULE_SETTINGS_DIRS[self.module_id],
             module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"

--- a/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
+++ b/proteobench/modules/quant/lfq/ion/DDA/quant_lfq_ion_DDA.py
@@ -8,8 +8,6 @@ from pandas import DataFrame
 from proteobench.datapoint.quant_datapoint import QuantDatapoint
 from proteobench.exceptions import (
     ConvertStandardFormatError,
-    DatapointAppendError,
-    DatapointGenerationError,
     IntermediateFormatGenerationError,
     ParseError,
     ParseSettingsError,
@@ -22,32 +20,42 @@ from proteobench.score.quant.quantscores import QuantScores
 
 
 class DDAQuantIonModule(QuantModule):
-    """DDA Quantification Module for Ion level Quantification."""
+    """DDA Quantification Module for Ion level Quantification.
+
+    Attributes
+    ----------
+    module_id : str
+        Module identifier for configuration.
+    parse_settings_dir : str
+        Directory containing parsing settings.
+    precursor_name: str
+        Level of quantification.
+    """
+
+    module_id = "quant_lfq_ion_DDA"
+    parse_settings_dir: str = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "io",
+            "parsing",
+            "io_parse_settings",
+            "Quant",
+            "lfq",
+            "ion",
+            "DDA",
+        )
+    )
 
     def __init__(
         self,
         token: str,
         proteobench_repo_name: str = "Proteobench/Results_quant_ion_DDA",
         proteobot_repo_name: str = "Proteobot/Results_quant_ion_DDA",
-        # TODO: Figure out how to do nicer relative calls
-        parse_settings_dir: str = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "..",
-                "io",
-                "parsing",
-                "io_parse_settings",
-                "Quant",
-                "lfq",
-                "ion",
-                "DDA",
-            )
-        ),
-        module_id="quant_lfq_ion_DDA",
     ):
         """
         DDA Quantification Module for Ion level Quantification.
@@ -61,21 +69,15 @@ class DDAQuantIonModule(QuantModule):
         proteobench_repo_name
             Name of the repository where the benchmarking results will be stored.
 
-        Attributes
-        ----------
-        precursor_name: str
-            Level of quantification.
-
         """
         super().__init__(
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=parse_settings_dir,
-            module_id=module_id,
+            parse_settings_dir=self.parse_settings_dir,
+            module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"
-        self.module_id = module_id
 
     def is_implemented(self) -> bool:
         """Returns whether the module is fully implemented."""

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
@@ -23,32 +23,43 @@ from proteobench.score.quant.quantscores import QuantScores
 
 
 class DIAQuantIonModule(QuantModule):
-    """DIA Quantification Module for Ion level Quantification."""
+    """DIA Quantification Module for Ion level Quantification.
+
+    Attributes
+    ----------
+    module_id : str
+        Module identifier for configuration.
+    parse_settings_dir : str
+        Directory containing parsing settings.
+    precursor_name: str
+        Level of quantification.
+    """
+
+    module_id: str = "quant_lfq_ion_DIA_AIF"
+    parse_settings_dir: str = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "io",
+            "parsing",
+            "io_parse_settings",
+            "Quant",
+            "lfq",
+            "ion",
+            "DIA",
+            "AIF",
+        )
+    )
 
     def __init__(
         self,
         token: str,
         proteobot_repo_name: str = "Proteobot/Results_quant_ion_DIA",
         proteobench_repo_name: str = "Proteobench/Results_quant_ion_DIA",
-        parse_settings_dir: str = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "..",
-                "io",
-                "parsing",
-                "io_parse_settings",
-                "Quant",
-                "lfq",
-                "ion",
-                "DIA",
-                "AIF",
-            )
-        ),
-        module_id: str = "quant_lfq_ion_DIA_AIF",
     ):
         """
         DIA Quantification Module for Ion level Quantification.
@@ -57,15 +68,13 @@ class DIAQuantIonModule(QuantModule):
             token (str): GitHub token for the user.
             proteobot_repo_name (str): Name of the repository for pull requests and where new points are added.
             proteobench_repo_name (str): Name of the repository where the benchmarking results will be stored.
-            parse_settings_dir (str): Directory containing parsing settings.
-            module_id (str): Module identifier for configuration.
         """
         super().__init__(
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=parse_settings_dir,
-            module_id=module_id,
+            parse_settings_dir=self.parse_settings_dir,
+            module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"
 

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -18,6 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 
@@ -29,31 +29,11 @@ class DIAQuantIonModule(QuantModule):
     ----------
     module_id : str
         Module identifier for configuration.
-    parse_settings_dir : str
-        Directory containing parsing settings.
     precursor_name: str
         Level of quantification.
     """
 
     module_id: str = "quant_lfq_ion_DIA_AIF"
-    parse_settings_dir: str = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "..",
-            "..",
-            "io",
-            "parsing",
-            "io_parse_settings",
-            "Quant",
-            "lfq",
-            "ion",
-            "DIA",
-            "AIF",
-        )
-    )
 
     def __init__(
         self,
@@ -73,7 +53,7 @@ class DIAQuantIonModule(QuantModule):
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=self.parse_settings_dir,
+            parse_settings_dir=MODULE_SETTINGS_DIRS[self.module_id],
             module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_AIF.py
@@ -17,7 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import pandas as pd
 from pandas import DataFrame
@@ -23,32 +23,43 @@ from proteobench.score.quant.quantscores import QuantScores
 
 
 class DIAQuantIonModulediaPASEF(QuantModule):
-    """DIA Quantification Module for Ion level Quantification for diaPASEF."""
+    """DIA Quantification Module for Ion level Quantification for diaPASEF.
+
+    Attributes
+    ----------
+    module_id : str
+        Module identifier for configuration.
+    parse_settings_dir : str
+        Directory containing parsing settings.
+    precursor_name: str
+        Level of quantification.
+    """
+
+    module_id: str = "quant_lfq_ion_DIA_diaPASEF"
+    parse_settings_dir: str = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "io",
+            "parsing",
+            "io_parse_settings",
+            "Quant",
+            "lfq",
+            "ion",
+            "DIA",
+            "diaPASEF",
+        )
+    )
 
     def __init__(
         self,
         token: str,
         proteobot_repo_name: str = "Proteobot/Results_quant_ion_DIA_diaPASEF",
         proteobench_repo_name: str = "Proteobench/Results_quant_ion_DIA_diaPASEF",
-        parse_settings_dir: str = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "..",
-                "io",
-                "parsing",
-                "io_parse_settings",
-                "Quant",
-                "lfq",
-                "ion",
-                "DIA",
-                "diaPASEF",
-            )
-        ),
-        module_id: str = "quant_lfq_ion_DIA_diaPASEF",
     ):
         """
         DIA Quantification Module for Ion level Quantification for diaPASEF.
@@ -57,15 +68,13 @@ class DIAQuantIonModulediaPASEF(QuantModule):
             token (str): GitHub token for the user.
             proteobot_repo_name (str): Name of the repository for pull requests and where new points are added.
             proteobench_repo_name (str): Name of the repository where the benchmarking results will be stored.
-            parse_settings_dir (str): Directory containing parsing settings.
-            module_id (str): Module identifier for configuration.
         """
         super().__init__(
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=parse_settings_dir,
-            module_id=module_id,
+            parse_settings_dir=self.parse_settings_dir,
+            module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"
 

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
@@ -17,7 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 

--- a/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
+++ b/proteobench/modules/quant/lfq/ion/DIA/quant_lfq_ion_DIA_diaPASEF.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -18,6 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_ion import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 
@@ -29,31 +29,11 @@ class DIAQuantIonModulediaPASEF(QuantModule):
     ----------
     module_id : str
         Module identifier for configuration.
-    parse_settings_dir : str
-        Directory containing parsing settings.
     precursor_name: str
         Level of quantification.
     """
 
     module_id: str = "quant_lfq_ion_DIA_diaPASEF"
-    parse_settings_dir: str = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "..",
-            "..",
-            "io",
-            "parsing",
-            "io_parse_settings",
-            "Quant",
-            "lfq",
-            "ion",
-            "DIA",
-            "diaPASEF",
-        )
-    )
 
     def __init__(
         self,
@@ -73,7 +53,7 @@ class DIAQuantIonModulediaPASEF(QuantModule):
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=self.parse_settings_dir,
+            parse_settings_dir=MODULE_SETTINGS_DIRS[self.module_id],
             module_id=self.module_id,
         )
         self.precursor_name = "precursor ion"

--- a/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
@@ -23,31 +23,42 @@ from proteobench.score.quant.quantscores import QuantScores
 
 
 class DDAQuantPeptidoformModule(QuantModule):
-    """DDA Quantification Module for Peptidoform level Quantification."""
+    """DDA Quantification Module for Peptidoform level Quantification.
+
+    Attributes
+    ----------
+    module_id : str
+        Module identifier for configuration.
+    parse_settings_dir : str
+        Directory containing parsing settings.
+    precursor_name: str
+        Level of quantification.
+    """
+
+    module_id: str = "quant_lfq_peptidoform_DDA"
+    parse_settings_dir: str = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "io",
+            "parsing",
+            "io_parse_settings",
+            "Quant",
+            "lfq",
+            "peptidoform",
+            "DDA",
+        )
+    )
 
     def __init__(
         self,
         token: str,
         proteobot_repo_name: str = "Proteobot/Results_quant_peptidoform_DDA",
         proteobench_repo_name: str = "Proteobench/Results_quant_peptidoform_DDA",
-        parse_settings_dir: str = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "..",
-                "io",
-                "parsing",
-                "io_parse_settings",
-                "Quant",
-                "lfq",
-                "peptidoform",
-                "DDA",
-            )
-        ),
-        module_id: str = "quant_lfq_peptidoform_DDA",
     ):
         """
         DDA Quantification Module for Peptidoform level Quantification.
@@ -56,18 +67,15 @@ class DDAQuantPeptidoformModule(QuantModule):
             token (str): GitHub token for the user.
             proteobot_repo_name (str): Repository for pull requests and adding new points.
             proteobench_repo_name (str): Repository for storing benchmarking results.
-            parse_settings_dir (str): Directory containing parsing settings.
-            module_id (str): Module identifier for configuration.
         """
         super().__init__(
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=parse_settings_dir,
-            module_id=module_id,
+            parse_settings_dir=self.parse_settings_dir,
+            module_id=self.module_id,
         )
         self.precursor_name = "peptidoform"
-        self.module_id = module_id
 
     def is_implemented(self) -> bool:
         """Returns whether the module is fully implemented."""

--- a/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -18,6 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_peptidoform import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 
@@ -29,30 +29,11 @@ class DDAQuantPeptidoformModule(QuantModule):
     ----------
     module_id : str
         Module identifier for configuration.
-    parse_settings_dir : str
-        Directory containing parsing settings.
     precursor_name: str
         Level of quantification.
     """
 
     module_id: str = "quant_lfq_peptidoform_DDA"
-    parse_settings_dir: str = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "..",
-            "..",
-            "io",
-            "parsing",
-            "io_parse_settings",
-            "Quant",
-            "lfq",
-            "peptidoform",
-            "DDA",
-        )
-    )
 
     def __init__(
         self,
@@ -72,7 +53,7 @@ class DDAQuantPeptidoformModule(QuantModule):
             token,
             proteobot_repo_name=proteobot_repo_name,
             proteobench_repo_name=proteobench_repo_name,
-            parse_settings_dir=self.parse_settings_dir,
+            parse_settings_dir=MODULE_SETTINGS_DIRS[self.module_id],
             module_id=self.module_id,
         )
         self.precursor_name = "peptidoform"

--- a/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DDA/quant_lfq_peptidoform_DDA.py
@@ -17,7 +17,7 @@ from proteobench.exceptions import (
 )
 from proteobench.io.parsing.parse_peptidoform import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
 

--- a/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
@@ -41,6 +41,7 @@ class DIAQuantPeptidoformModule(QuantModule):
             proteobench_repo_name (str): Name of the repository where the benchmarking results will be stored.
             module_id (str): Module identifier for configuration.
         """
+        raise NotImplementedError("This module init lacks required arguments for its parent class.")
         super().__init__(token, proteobot_repo_name=proteobot_repo_name, proteobench_repo_name=proteobench_repo_name)
         self.precursor_name = "peptidoform"
 

--- a/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -20,17 +19,27 @@ from proteobench.io.parsing.parse_peptidoform import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
 
 
 class DIAQuantPeptidoformModule(QuantModule):
-    """DIA Quantification Module for Peptidoform level Quantification."""
+    """DIA Quantification Module for Peptidoform level Quantification.
+
+    Attributes
+    ----------
+    module_id : str
+        Module identifier for configuration.
+    precursor_name: str
+        Level of quantification.
+    """
+
+    module_id = "quant_lfq_peptidoform_DIA"
 
     def __init__(
         self,
         token: str,
         proteobot_repo_name: str = "Proteobot/Results_quant_peptidoform_DIA",
         proteobench_repo_name: str = "Proteobench/Results_quant_peptidoform_DIA",
-        module_id: str = "quant_lfq_peptidoform_DIA",
     ):
         """
         DDA Quantification Module for Peptidoform level Quantification.
@@ -41,8 +50,17 @@ class DIAQuantPeptidoformModule(QuantModule):
             proteobench_repo_name (str): Name of the repository where the benchmarking results will be stored.
             module_id (str): Module identifier for configuration.
         """
-        raise NotImplementedError("This module init lacks required arguments for its parent class.")
-        super().__init__(token, proteobot_repo_name=proteobot_repo_name, proteobench_repo_name=proteobench_repo_name)
+        raise NotImplementedError(
+            "This module is not be implemented properly, no parse settings .toml files exist. After .toml files have "
+            "been added, the parse settings dir must be added to `MODULE_SETTINGS_DIRS` in the constants.py file!"
+        )
+        super().__init__(
+            token,
+            proteobot_repo_name=proteobot_repo_name,
+            proteobench_repo_name=proteobench_repo_name,
+            parse_settings_dir=MODULE_SETTINGS_DIRS[self.module_id],
+            module_id=self.module_id,
+        )
         self.precursor_name = "peptidoform"
 
     def is_implemented(self) -> bool:
@@ -82,9 +100,8 @@ class DIAQuantPeptidoformModule(QuantModule):
 
         # Parse settings file
         try:
-            parse_settings_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "io_parse_settings/Quant/DIA")
             parse_settings = ParseSettingsBuilder(
-                parse_settings_dir=parse_settings_dir, module_id=self.module_id
+                parse_settings_dir=self.parse_settings_dir, module_id=self.module_id
             ).build_parser(input_format)
         except KeyError as e:
             raise ParseSettingsError(f"Error parsing settings file for parsing, settings missing: {e}")

--- a/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
+++ b/proteobench/modules/quant/lfq/peptidoform/DIA/quant_lfq_peptidoform_DIA.py
@@ -19,7 +19,7 @@ from proteobench.io.parsing.parse_peptidoform import load_input_file
 from proteobench.io.parsing.parse_settings import ParseSettingsBuilder
 from proteobench.modules.quant.quant_base.quant_base_module import QuantModule
 from proteobench.score.quant.quantscores import QuantScores
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 
 
 class DIAQuantPeptidoformModule(QuantModule):

--- a/proteobench/modules/quant/quant_base/constants.py
+++ b/proteobench/modules/quant/quant_base/constants.py
@@ -1,0 +1,11 @@
+import pathlib
+
+IO_PARSE_SETTINGS_DIR = pathlib.Path(__file__) / ".." / ".." / ".." / ".." / "io" / "parsing" / "io_parse_settings"
+QUANT_LFQ_SETTINGS_DIR = IO_PARSE_SETTINGS_DIR / "Quant" / "lfq"
+
+MODULE_SETTINGS_DIRS = {
+    "quant_lfq_ion_DIA_AIF": (QUANT_LFQ_SETTINGS_DIR / "ion" / "DIA" / "AIF").as_posix(),
+    "quant_lfq_ion_DIA_diaPASEF": (QUANT_LFQ_SETTINGS_DIR / "ion" / "DIA" / "diaPASEF").as_posix(),
+    "quant_lfq_ion_DDA": (QUANT_LFQ_SETTINGS_DIR / "ion" / "DDA").as_posix(),
+    "quant_lfq_peptidoform_DDA": (QUANT_LFQ_SETTINGS_DIR / "peptidoform" / "DDA").as_posix(),
+}

--- a/proteobench/modules/quant/quant_base/quant_base_module.py
+++ b/proteobench/modules/quant/quant_base/quant_base_module.py
@@ -83,11 +83,11 @@ class QuantModule:
 
     def __init__(
         self,
-        token: Optional[str] = None,
-        proteobench_repo_name: str = "",
-        proteobot_repo_name: str = "",
-        parse_settings_dir: str = "",
-        module_id: str = "",
+        token: Optional[str],
+        proteobench_repo_name: str,
+        proteobot_repo_name: str,
+        parse_settings_dir: str,
+        module_id: str,
     ):
         """
         Initialize the QuantModule with GitHub repo and settings.

--- a/test/test_modules_constants.py
+++ b/test/test_modules_constants.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+from proteobench.modules.constants import MODULE_SETTINGS_DIRS
 
 
 @pytest.mark.parametrize(

--- a/test/test_quant_module_constants.py
+++ b/test/test_quant_module_constants.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+from proteobench.modules.quant.quant_base.constants import MODULE_SETTINGS_DIRS
+
+
+@pytest.mark.parametrize(
+    "module_id",
+    list(MODULE_SETTINGS_DIRS.keys()),
+)
+def test_MODULE_SETTINGS_DIRS(module_id):
+    assert os.path.exists(MODULE_SETTINGS_DIRS[module_id])

--- a/webinterface/pages/2_Quant_LFQ_ion_DDA.py
+++ b/webinterface/pages/2_Quant_LFQ_ion_DDA.py
@@ -27,7 +27,9 @@ class StreamlitUI:
         except KeyError:
             token = ""
         self.ionmodule: DDAQuantIonModule = DDAQuantIonModule(token=token)
-        self.parsesettingsbuilder = ParseSettingsBuilder(parse_settings_dir=self.variables_dda_quant.parse_settings_dir)
+        self.parsesettingsbuilder = ParseSettingsBuilder(
+            module_id=self.ionmodule.module_id, parse_settings_dir=self.variables_dda_quant.parse_settings_dir
+        )
 
         self.quant_uiobjects = QuantUIObjects(self.variables_dda_quant, self.ionmodule, self.parsesettingsbuilder)
 

--- a/webinterface/pages/2_Quant_LFQ_ion_DDA.py
+++ b/webinterface/pages/2_Quant_LFQ_ion_DDA.py
@@ -27,7 +27,7 @@ class StreamlitUI:
         except KeyError:
             token = ""
         self.ionmodule: DDAQuantIonModule = DDAQuantIonModule(token=token)
-        self.parsesettingsbuilder = ParseSettingsBuilder()
+        self.parsesettingsbuilder = ParseSettingsBuilder(parse_settings_dir=self.variables_dda_quant.parse_settings_dir)
 
         self.quant_uiobjects = QuantUIObjects(self.variables_dda_quant, self.ionmodule, self.parsesettingsbuilder)
 

--- a/webinterface/pages/pages_variables/Quant/lfq/ion/DDA/variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq/ion/DDA/variables.py
@@ -55,7 +55,7 @@ class VariablesDDAQuant:
     description_results_md: str = "pages/markdown_files/Quant/lfq/ion/DDA/result_description.md"
     description_submission_md: str = "pages/markdown_files/Quant/lfq/ion/DDA/submit_description.md"
 
-    parse_settings_dir: str = "../proteobench/io/parsing/io_parse_settings/Quant/DDA"
+    parse_settings_dir: str = "../proteobench/io/parsing/io_parse_settings/Quant/lfq/ion/DDA"
 
     texts: Type[WebpageTexts] = WebpageTexts
     doc_url: str = "https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/"


### PR DESCRIPTION
1) This pull-requests removes the default values for several init arguments from `QuantModule` (and subclasses), which should actually not have a default value and be mandatory to provide. 
    -  Related to Point (1) of  #581
    - Subclasses of `QuantModule` actually have the init arguments `module_id` and `parse_settings_dir` removed and replaced by a class attribute.
    - The **module id** and the **settings .toml files** are so closely coupled and essential for a specific quant module that it doesn't make sense to allow changing them.

2) In addition, this pull-requests introduces a `modules/constants.py` submodule to organize the "parse settings directory paths" in one single place. Now we don't have to use the akward and error prone way to specify the `parse_settings_dir` in the modules init (see below). 

```Python
class DDAQuantIonModule(QuantModule):
    """DDA Quantification Module for Ion level Quantification."""

    def __init__(
        self,
        token: str,
        proteobench_repo_name: str = "Proteobench/Results_quant_ion_DDA",
        proteobot_repo_name: str = "Proteobot/Results_quant_ion_DDA",
        # TODO: Figure out how to do nicer relative calls
        parse_settings_dir: str = os.path.abspath(
            os.path.join(
                os.path.dirname(__file__),
                "..",
                "..",
                "..",
                "..",
                "..",
                "io",
                "parsing",
                "io_parse_settings",
                "Quant",
                "lfq",
                "ion",
                "DDA",
            )
        ),
        module_id="quant_lfq_ion_DDA",
    ):
```

3) As a bonus, this pull-requests removes unused imports from all the files I've edited because my IDE was set to do so ;)

I've tried to be very careful to properly implement the changes but not everything in Proteobench (especially the streamlit part) is covered by tests. I've also made the commits very small and focused to hopefully allow a quick and easy review.

Best,
David