### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-streamlit.yml
+++ b/.github/workflows/test-streamlit.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9 # Streamlit.io default (as of 2023/09/25)
+          python-version: 3.11 # Python version specified in automated release workflow
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ classifiers = [
 ]
 
 keywords = ['proteomics', 'peptides', 'retention time', 'mass spectrometry']
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "pandas",
   "openpyxl",
-  "numpy",
+  "numpy>1.24.4",
   "plotly",
   "streamlit>=1.31",
   "streamlit_extras",
@@ -65,7 +65,7 @@ profile = "black"
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py311']
 
 [tool.flake8]
 max-line-length = 120


### PR DESCRIPTION
Related to the discussion about dropping support for old Python versions: #576 

I've created this pull request to get the discussion going. So far it includes the following changes:

- Drop support for Python version 3.8, 3.9, 3.10
- Add support for version 3.12 and 3.13
- Set default Python version to 3.11

I've chosen the version 3.11 as the default one because it is used in the `automated_release` workflow. But I actually don't really have an opinion if the default version should be 3.11 or a newer one.