### PR TITLE
648 update and possibly improve alphadia parameter parser

### DIFF
--- a/proteobench/io/params/alphadia.py
+++ b/proteobench/io/params/alphadia.py
@@ -19,7 +19,7 @@ USER_DEFINED_REGEX = re.compile(r"(\[|\()?user defined(\]|\))?")
 DEFAULT_REGEX = re.compile(r"(\[|\()?default:?(\]|\))?")
 
 CONFIG_KEY_MAPPER = {
-    "version": "version",
+    "version": "software_version",
     "software_name": "software_name",
     "search_engine": "search_engine",
     "search_engine_version": "search_engine_version",
@@ -171,7 +171,7 @@ def clean_up_parameters(all_parameters: Dict[str, str]) -> None:
     for key in keys_to_remove:
         del all_parameters[key]
 
-    for key, value in all_parameters.items():
+    for key, value in all_parameters.items(): 
         if isinstance(value, str):
             value_list = list(set(value.split(", ")))
             if len(value_list) == 1:
@@ -180,7 +180,7 @@ def clean_up_parameters(all_parameters: Dict[str, str]) -> None:
                 for val in value_list:
                     if "default" in val:
                         all_parameters[key] = DEFAULT_REGEX.sub("", val).replace("]", "").strip()
-                        break
+                        
                     if "user defined" in val:
                         all_parameters[key] = USER_DEFINED_REGEX.sub("", val)
                         break

--- a/test/params/log_alphadia_1.10.csv
+++ b/test/params/log_alphadia_1.10.csv
@@ -1,6 +1,6 @@
 ,0
 software_name,AlphaDIA
-software_version,1.0
+software_version,1.10.3
 search_engine,AlphaDIA
 search_engine_version,None
 ident_fdr_psm,None
@@ -8,8 +8,8 @@ ident_fdr_peptide,None
 ident_fdr_protein,None
 enable_match_between_runs,True
 precursor_mass_tolerance,10 
-fragment_mass_tolerance,10
-enzyme,trypsin
+fragment_mass_tolerance,15 
+enzyme,trypsin/p 
 allowed_miscleavages,1
 min_peptide_length,6
 max_peptide_length,30

--- a/test/params/log_alphadia_1.10.csv
+++ b/test/params/log_alphadia_1.10.csv
@@ -6,15 +6,15 @@ search_engine_version,None
 ident_fdr_psm,None
 ident_fdr_peptide,None
 ident_fdr_protein,None
-enable_match_between_runs,False
-precursor_mass_tolerance,5 
-fragment_mass_tolerance,10 
+enable_match_between_runs,True
+precursor_mass_tolerance,10 
+fragment_mass_tolerance,10
 enzyme,trypsin
 allowed_miscleavages,1
 min_peptide_length,6
-max_peptide_length,40
+max_peptide_length,30
 fixed_mods,Carbamidomethyl@C
-variable_mods,Oxidation@M;Acetyl@Protein N-term
+variable_mods,Oxidation@M;Acetyl@Protein_N-term
 max_mods,1 
 min_precursor_charge,1
 max_precursor_charge,4

--- a/test/params/log_alphadia_1.10.txt
+++ b/test/params/log_alphadia_1.10.txt
@@ -1,0 +1,13858 @@
+0:00:00.013575 PROGRESS:           _      _         ___ ___   _   
+0:00:00.013698 PROGRESS:      __ _| |_ __| |_  __ _|   \_ _| /_\  
+0:00:00.013728 PROGRESS:     / _` | | '_ \ ' \/ _` | |) | | / _ \ 
+0:00:00.013753 PROGRESS:     \__,_|_| .__/_||_\__,_|___/___/_/ \_\
+0:00:00.013781 PROGRESS:            |_|                           
+0:00:00.013803 PROGRESS: 
+0:00:00.013826 PROGRESS: version: 1.10.3
+0:00:00.013860 INFO: hostname: thestral
+0:00:00.013913 INFO: date: 2025-04-18 11:03:14
+0:00:00.013936 INFO: ================ AlphaX Environment ===============
+0:00:00.013957 INFO: alphatims       : 1.0.8
+0:00:00.013975 INFO: alpharaw        : 0.4.5
+0:00:00.013994 INFO: alphabase       : 1.5.0
+0:00:00.014011 INFO: alphapeptdeep   : 1.3.0
+0:00:00.014028 INFO: directlfq       : 0.2.19
+0:00:00.014045 INFO: ===================================================
+0:00:00.014061 INFO: ================= Pip Environment =================
+0:00:00.072435 INFO: alphatims==1.0.8 click==8.1.8 partd==1.4.2 wget==3.2 torchmetrics==1.4.0.post0 uri-template==1.3.0 directlfq==0.2.19 nvidia-nvjitlink-cu12==12.4.127 lxml==5.3.1 alphadia==1.10.3 fsspec==2025.3.0 fqdn==1.5.1 jsonref==1.1.0 simplejson==3.20.1 tornado==6.4.2 s3transfer==0.11.4 pythonnet==3.0.3 tqdm==4.67.1 psutil==7.0.0 urllib3==2.3.0 fonttools==4.56.0 arrow==1.3.0 dask==2024.11.2 numpy==1.26.4 tzdata==2025.1 gitdb==4.0.12 contextlib2==21.6.0 future==1.0.0 toolz==1.0.0 monotonic==1.6 argparse==1.4.0 nvidia-cuda-cupti-cu12==12.4.127 numba==0.59.1 importlib_resources==6.5.2 packaging==24.2 SQLAlchemy==2.0.39 typing_extensions==4.12.2 pyarrow==19.0.1 joblib==1.4.2 requests-oauthlib==2.0.0 rdkit==2024.3.3 webcolors==24.11.1 cffi==1.17.1 nvidia-cuda-nvrtc-cu12==12.4.127 protobuf==5.29.3 pyteomics==4.7.5 mpmath==1.3.0 pytz==2025.1 multiprocess==0.70.17 MarkupSafe==3.0.2 pyzstd==0.16.2 six==1.17.0 cycler==0.12.1 charset-normalizer==3.4.1 pyparsing==3.2.1 tenacity==9.0.0 llvmlite==0.42.0 attrs==25.2.0 pip==23.0.1 requests==2.32.3 triton==3.2.0 h5py==3.13.0 oauthlib==3.2.2 zstandard==0.22.0 pyahocorasick==2.1.0 swagger-spec-validator==3.0.4 blinker==1.9.0 pycparser==2.22 alpharaw==0.4.5 regex==2024.11.6 streamlit-aggrid==1.1.1 streamlit==1.43.2 tokenizers==0.19.1 websocket-client==1.8.0 certifi==2025.1.31 narwhals==1.30.0 isoduration==20.11.0 python-dateutil==2.9.0.post0 peptdeep==1.3.0 botocore==1.37.11 locket==1.0.0 referencing==0.36.2 torch==2.6.0 nvidia-cusparse-cu12==12.3.1.170 rocket-fft==0.2.5 lightning-utilities==0.14.0 neptune==1.10.4 importlib_metadata==8.6.1 cloudpickle==3.1.1 clr_loader==0.2.7.post0 setuptools==66.1.1 pandas==2.2.3 dill==0.3.9 jsonschema-specifications==2024.10.1 networkx==3.4.2 transformers==4.40.2 biopython==1.85 filelock==3.17.0 types-python-dateutil==2.9.0.20241206 seaborn==0.13.2 toml==0.10.2 zipp==3.21.0 rfc3339-validator==0.1.4 altair==5.5.0 greenlet==3.1.1 scipy==1.12.0 matplotlib==3.10.1 contourpy==1.3.1 pydeck==0.9.1 threadpoolctl==3.5.0 Jinja2==3.1.6 bravado-core==6.1.1 msgpack==1.1.0 nvidia-nvtx-cu12==12.4.127 nvidia-cusolver-cu12==11.6.1.9 xxhash==3.4.1 safetensors==0.5.3 idna==3.10 cachetools==5.5.2 huggingface-hub==0.29.3 jsonpointer==3.0.0 rpds-py==0.23.1 nvidia-cufft-cu12==11.2.1.3 jsonschema==4.23.0 watchdog==6.0.0 python-decouple==3.8 sympy==1.13.1 boto3==1.37.11 dask-expr==1.1.19 pillow==11.1.0 plotly==6.0.0 nvidia-cublas-cu12==12.4.5.8 nvidia-cudnn-cu12==9.1.0.70 smmap==5.0.2 nvidia-curand-cu12==10.3.5.147 GitPython==3.1.44 progressbar==2.5 PyJWT==2.10.1 kiwisolver==1.4.8 nvidia-cuda-runtime-cu12==12.4.127 scikit-learn==1.6.1 nvidia-nccl-cu12==2.21.5 jmespath==1.0.1 rfc3986-validator==0.1.1 bravado==11.1.0 nvidia-cusparselt-cu12==0.6.2 alphabase==1.5.0 PyYAML==6.0.2
+0:00:00.072529 INFO: ===================================================
+0:00:00.072560 INFO: Running step 'library'
+0:00:00.072673 INFO: loading config from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/default.yaml
+0:00:00.083240 INFO: loading additional config provided via CLI
+0:00:00.083310 INFO: loading additional config provided via CLI parameters
+0:00:00.083543 INFO: Updating config with 'user defined'
+0:00:00.083623 INFO: Updating config with 'user defined (cli)'
+0:00:00.083646 INFO: Updating config with 'multistep search'
+0:00:00.083684 INFO: ├──version: 1
+0:00:00.083710 INFO: ├──workflow_name: None
+0:00:00.083736 INFO: [32;20m├──output_directory: run_output/alphadia_1.10_defaultMBR/library [multistep search, default: None][0m
+0:00:00.083758 INFO: ├──library_path: None
+0:00:00.083776 INFO: ├──raw_paths:
+0:00:00.083799 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d [user defined (cli), default: None][0m
+0:00:00.083819 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d [user defined (cli), default: None][0m
+0:00:00.083838 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d [user defined (cli), default: None][0m
+0:00:00.083861 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d [user defined (cli), default: None][0m
+0:00:00.083879 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d [user defined (cli), default: None][0m
+0:00:00.083897 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d [user defined (cli), default: None][0m
+0:00:00.083916 INFO: ├──fasta_paths:
+0:00:00.083935 INFO: │   [32;20m- ./ProteoBenchFASTA_DDAQuantification.fasta [user defined (cli), default: None][0m
+0:00:00.083955 INFO: ├──quant_directory: None
+0:00:00.083972 INFO: ├──general
+0:00:00.083991 INFO: │   [32;20m├──thread_count: 100 [user defined, default: 10][0m
+0:00:00.084010 INFO: │   ├──transfer_step_enabled: False
+0:00:00.084028 INFO: │   ├──mbr_step_enabled: True
+0:00:00.084046 INFO: │   ├──reuse_calibration: False
+0:00:00.084064 INFO: │   ├──reuse_quant: False
+0:00:00.084083 INFO: │   ├──astral_ms1: False
+0:00:00.084100 INFO: │   ├──log_level: INFO
+0:00:00.084119 INFO: │   ├──mmap_detector_events: False
+0:00:00.084139 INFO: │   [32;20m├──use_gpu: False [user defined, default: True][0m
+0:00:00.084156 INFO: │   [32;20m├──save_library: False [multistep search, default: True][0m
+0:00:00.084175 INFO: │   └──save_mbr_library: True
+0:00:00.084193 INFO: ├──library_loading
+0:00:00.084211 INFO: │   └──rt_heuristic: 180
+0:00:00.084230 INFO: ├──library_prediction
+0:00:00.084248 INFO: │   [32;20m├──enabled: True [user defined, default: False][0m
+0:00:00.084268 INFO: │   [32;20m├──enzyme: trypsin/p [user defined, default: trypsin][0m
+0:00:00.084289 INFO: │   ├──fixed_modifications: Carbamidomethyl@C
+0:00:00.084308 INFO: │   ├──variable_modifications: Oxidation@M;Acetyl@Protein_N-term
+0:00:00.084326 INFO: │   [32;20m├──max_var_mod_num: 1 [user defined, default: 2][0m
+0:00:00.084345 INFO: │   ├──missed_cleavages: 1
+0:00:00.084363 INFO: │   ├──precursor_len:
+0:00:00.084381 INFO: │   │   [32;20m- 6 [user defined, default: 7][0m
+0:00:00.084400 INFO: │   │   [32;20m- 30 [user defined, default: 35][0m
+0:00:00.084418 INFO: │   ├──precursor_charge:
+0:00:00.084436 INFO: │   │   [32;20m- 1 [user defined, default: 2][0m
+0:00:00.084456 INFO: │   │   [32;20m- 4[0m
+0:00:00.084473 INFO: │   ├──precursor_mz:
+0:00:00.084491 INFO: │   │   [32;20m- 400[0m
+0:00:00.084509 INFO: │   │   [32;20m- 1000 [user defined, default: 1200][0m
+0:00:00.084528 INFO: │   ├──fragment_mz:
+0:00:00.084546 INFO: │   │   [32;20m- 50 [user defined, default: 200][0m
+0:00:00.084564 INFO: │   │   [32;20m- 2000[0m
+0:00:00.084584 INFO: │   ├──nce: 25
+0:00:00.084602 INFO: │   ├──fragment_types:
+0:00:00.084620 INFO: │   │   [32;20m- b[0m
+0:00:00.084637 INFO: │   │   [32;20m- y[0m
+0:00:00.084655 INFO: │   ├──max_fragment_charge: 2
+0:00:00.084673 INFO: │   [32;20m├──instrument: timsTOF [user defined, default: Lumos][0m
+0:00:00.084699 INFO: │   ├──peptdeep_model_path: None
+0:00:00.084718 INFO: │   └──peptdeep_model_type: generic
+0:00:00.084736 INFO: ├──custom_modifications:
+0:00:00.084754 INFO: │   ├──name: Dimethyl:d12@K
+0:00:00.084773 INFO: │   └──composition: H(-2)2H(8)13C(2)
+0:00:00.084792 INFO: │   ├──name: Dimethyl:d12@Any_N-term
+0:00:00.084810 INFO: │   └──composition: H(-2)2H(8)13C(2)
+0:00:00.084828 INFO: │   ├──name: Dimethyl:d12@Protein_N-term
+0:00:00.084845 INFO: │   └──composition: H(-2)2H(8)13C(2)
+0:00:00.084863 INFO: │   ├──name: mTRAQ:d12@K
+0:00:00.084881 INFO: │   └──composition: H(12)C(1)13C(10)15N(2)O(1)
+0:00:00.084900 INFO: │   ├──name: mTRAQ:d12@Any_N-term
+0:00:00.084918 INFO: │   └──composition: H(12)C(1)13C(14)15N(2)O(1)
+0:00:00.084936 INFO: │   ├──name: mTRAQ:d12@Protein_N-term
+0:00:00.084953 INFO: │   └──composition: H(12)C(1)13C(14)15N(2)O(1)
+0:00:00.084970 INFO: │   ├──name: Label:13C(12)@K
+0:00:00.084989 INFO: │   └──composition: C(12)
+0:00:00.085008 INFO: ├──search
+0:00:00.085034 INFO: │   [32;20m├──target_ms1_tolerance: 10 [user defined, default: 5][0m
+0:00:00.085053 INFO: │   [32;20m├──target_ms2_tolerance: 15 [user defined, default: 10][0m
+0:00:00.085071 INFO: │   ├──target_rt_tolerance: 0
+0:00:00.085089 INFO: │   ├──target_mobility_tolerance: 0
+0:00:00.085107 INFO: │   ├──quant_window: 3
+0:00:00.085124 INFO: │   [32;20m├──target_num_candidates: 2 [user defined, default: 3][0m
+0:00:00.085143 INFO: │   ├──channel_filter: 
+0:00:00.085160 INFO: │   ├──exclude_shared_ions: True
+0:00:00.085178 INFO: │   ├──compete_for_fragments: True
+0:00:00.085196 INFO: │   ├──quant_all: True
+0:00:00.085215 INFO: │   ├──top_k_fragments: 12
+0:00:00.085232 INFO: │   └──experimental_xic: True
+0:00:00.085251 INFO: ├──calibration
+0:00:00.085268 INFO: │   ├──batch_size: 8000
+0:00:00.085286 INFO: │   ├──optimization_lock_target: 200
+0:00:00.085305 INFO: │   ├──max_steps: 20
+0:00:00.085322 INFO: │   ├──min_steps: 2
+0:00:00.085340 INFO: │   ├──max_skips: 1
+0:00:00.085359 INFO: │   ├──norm_rt_mode: linear
+0:00:00.085376 INFO: │   ├──max_fragments: 5000
+0:00:00.085398 INFO: │   └──min_correlation: 0.7
+0:00:00.085416 INFO: ├──search_initial
+0:00:00.085433 INFO: │   ├──initial_num_candidates: 1
+0:00:00.085451 INFO: │   ├──initial_ms1_tolerance: 30
+0:00:00.085469 INFO: │   ├──initial_ms2_tolerance: 30
+0:00:00.085487 INFO: │   ├──initial_mobility_tolerance: 0.1
+0:00:00.085505 INFO: │   └──initial_rt_tolerance: 0.5
+0:00:00.085523 INFO: ├──selection_config
+0:00:00.085541 INFO: │   ├──peak_len_rt: 10.0
+0:00:00.085559 INFO: │   ├──sigma_scale_rt: 0.5
+0:00:00.085580 INFO: │   ├──peak_len_mobility: 0.01
+0:00:00.085599 INFO: │   ├──sigma_scale_mobility: 1.0
+0:00:00.085617 INFO: │   ├──top_k_precursors: 3
+0:00:00.085636 INFO: │   ├──kernel_size: 30
+0:00:00.085654 INFO: │   ├──f_mobility: 1.0
+0:00:00.085672 INFO: │   ├──f_rt: 0.99
+0:00:00.085692 INFO: │   ├──center_fraction: 0.5
+0:00:00.085709 INFO: │   ├──min_size_mobility: 8
+0:00:00.085727 INFO: │   ├──min_size_rt: 3
+0:00:00.085746 INFO: │   ├──max_size_mobility: 20
+0:00:00.085764 INFO: │   ├──max_size_rt: 15
+0:00:00.085782 INFO: │   ├──group_channels: False
+0:00:00.085801 INFO: │   ├──use_weighted_score: True
+0:00:00.085819 INFO: │   ├──join_close_candidates: False
+0:00:00.085838 INFO: │   ├──join_close_candidates_scan_threshold: 0.6
+0:00:00.085858 INFO: │   └──join_close_candidates_cycle_threshold: 0.6
+0:00:00.085875 INFO: ├──scoring_config
+0:00:00.085893 INFO: │   ├──score_grouped: False
+0:00:00.085911 INFO: │   ├──top_k_isotopes: 3
+0:00:00.085934 INFO: │   ├──reference_channel: -1
+0:00:00.085952 INFO: │   ├──precursor_mz_tolerance: 10
+0:00:00.085970 INFO: │   └──fragment_mz_tolerance: 15
+0:00:00.085989 INFO: ├──library_multiplexing
+0:00:00.086007 INFO: │   ├──enabled: False
+0:00:00.086025 INFO: │   ├──input_channel: 0
+0:00:00.086042 INFO: │   └──multiplex_mapping:
+0:00:00.086058 INFO: ├──multiplexing
+0:00:00.086076 INFO: │   ├──enabled: False
+0:00:00.086094 INFO: │   ├──target_channels: 4,8
+0:00:00.086111 INFO: │   ├──decoy_channel: 12
+0:00:00.086130 INFO: │   ├──reference_channel: 0
+0:00:00.086147 INFO: │   └──competetive_scoring: True
+0:00:00.086163 INFO: ├──fdr
+0:00:00.086182 INFO: │   ├──fdr: 0.01
+0:00:00.086199 INFO: │   ├──group_level: proteins
+0:00:00.086216 INFO: │   ├──inference_strategy: heuristic
+0:00:00.086234 INFO: │   ├──competetive_scoring: True
+0:00:00.086252 INFO: │   ├──keep_decoys: False
+0:00:00.086269 INFO: │   ├──channel_wise_fdr: False
+0:00:00.086287 INFO: │   ├──enable_two_step_classifier: False
+0:00:00.086306 INFO: │   ├──two_step_classifier_max_iterations: 5
+0:00:00.086323 INFO: │   └──enable_nn_hyperparameter_tuning: False
+0:00:00.086341 INFO: ├──search_output
+0:00:00.086358 INFO: │   ├──file_format: tsv
+0:00:00.086375 INFO: │   ├──peptide_level_lfq: False
+0:00:00.086395 INFO: │   [32;20m├──precursor_level_lfq: True [user defined, default: False][0m
+0:00:00.086414 INFO: │   ├──min_k_fragments: 12
+0:00:00.086432 INFO: │   ├──min_correlation: 0.9
+0:00:00.086450 INFO: │   ├──num_samples_quadratic: 50
+0:00:00.086468 INFO: │   ├──min_nonnan: 3
+0:00:00.086486 INFO: │   ├──normalize_lfq: True
+0:00:00.086504 INFO: │   └──save_fragment_quant_matrix: False
+0:00:00.086522 INFO: ├──optimization
+0:00:00.086540 INFO: │   ├──order_of_optimization: None
+0:00:00.086558 INFO: │   ├──ms2_error
+0:00:00.086576 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+0:00:00.086594 INFO: │   │   ├──targeted_update_factor: 1.0
+0:00:00.086612 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+0:00:00.086630 INFO: │   │   ├──automatic_update_factor: 1.1
+0:00:00.086647 INFO: │   │   ├──try_narrower_values: True
+0:00:00.086666 INFO: │   │   ├──maximal_decrease: 0.5
+0:00:00.086684 INFO: │   │   ├──favour_narrower_optimum: False
+0:00:00.086703 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+0:00:00.086721 INFO: │   ├──ms1_error
+0:00:00.086739 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+0:00:00.086756 INFO: │   │   ├──targeted_update_factor: 1.0
+0:00:00.086774 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+0:00:00.086794 INFO: │   │   ├──automatic_update_factor: 1.1
+0:00:00.086812 INFO: │   │   ├──try_narrower_values: False
+0:00:00.086832 INFO: │   │   ├──maximal_decrease: 0.2
+0:00:00.086850 INFO: │   │   ├──favour_narrower_optimum: False
+0:00:00.086868 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+0:00:00.086886 INFO: │   ├──mobility_error
+0:00:00.086904 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+0:00:00.086921 INFO: │   │   ├──targeted_update_factor: 1.0
+0:00:00.086941 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+0:00:00.086958 INFO: │   │   ├──automatic_update_factor: 1.1
+0:00:00.086976 INFO: │   │   ├──try_narrower_values: False
+0:00:00.086994 INFO: │   │   ├──maximal_decrease: 0.2
+0:00:00.087012 INFO: │   │   ├──favour_narrower_optimum: False
+0:00:00.087030 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+0:00:00.087049 INFO: │   └──rt_error
+0:00:00.087067 INFO: │       ├──targeted_update_percentile_range: 0.95
+0:00:00.087086 INFO: │       ├──targeted_update_factor: 1.0
+0:00:00.087110 INFO: │       ├──automatic_update_percentile_range: 0.99
+0:00:00.087128 INFO: │       ├──automatic_update_factor: 1.1
+0:00:00.087146 INFO: │       ├──try_narrower_values: True
+0:00:00.087165 INFO: │       ├──maximal_decrease: 0.2
+0:00:00.087183 INFO: │       ├──favour_narrower_optimum: True
+0:00:00.087200 INFO: │       └──maximum_decrease_from_maximum: 0.1
+0:00:00.087218 INFO: ├──optimization_manager
+0:00:00.087236 INFO: │   ├──fwhm_rt: 5
+0:00:00.087253 INFO: │   ├──fwhm_mobility: 0.01
+0:00:00.087273 INFO: │   └──score_cutoff: 0
+0:00:00.087289 INFO: ├──transfer_library
+0:00:00.087307 INFO: │   ├──enabled: False
+0:00:00.087326 INFO: │   ├──fragment_types:
+0:00:00.087343 INFO: │   │   [32;20m- b[0m
+0:00:00.087360 INFO: │   │   [32;20m- y[0m
+0:00:00.087378 INFO: │   ├──max_charge: 2
+0:00:00.087395 INFO: │   ├──top_k_samples: 3
+0:00:00.087412 INFO: │   ├──norm_delta_max: True
+0:00:00.087430 INFO: │   ├──precursor_correlation_cutoff: 0.5
+0:00:00.087449 INFO: │   └──fragment_correlation_ratio: 0.75
+0:00:00.087466 INFO: └──transfer_learning
+0:00:00.087484 INFO:     ├──enabled: False
+0:00:00.087501 INFO:     ├──batch_size: 2000
+0:00:00.087518 INFO:     ├──max_lr: 0.0001
+0:00:00.087537 INFO:     ├──train_fraction: 0.7
+0:00:00.087554 INFO:     ├──validation_fraction: 0.2
+0:00:00.087572 INFO:     ├──test_fraction: 0.1
+0:00:00.087590 INFO:     ├──test_interval: 1
+0:00:00.087607 INFO:     ├──lr_patience: 3
+0:00:00.087625 INFO:     ├──epochs: 51
+0:00:00.087643 INFO:     ├──warmup_epochs: 5
+0:00:00.087661 INFO:     ├──nce: 25
+0:00:00.087681 INFO:     [32;20m└──instrument: timsTOF [user defined, default: Lumos][0m
+0:00:00.092294 INFO: Registering 7 custom modifications
+0:00:00.121167 PROGRESS: No library provided. Building library from fasta files.
+0:00:00.121258 INFO: Running FastaDigest
+0:00:00.967935 INFO: Digesting fasta file
+0:00:07.583493 INFO: Adding modifications
+0:01:39.319825 INFO: Removing non-canonical amino acids
+0:01:45.373568 INFO: Fasta library contains 5,215,079 precursors
+0:01:45.373820 PROGRESS: Predicting library properties.
+0:01:45.373897 INFO: Running PeptDeepPrediction
+0:01:45.373972 INFO: Device set to cpu
+0:01:46.281418 INFO: Loading PeptDeep models of type generic
+0:01:47.048252 INFO: Predicting RT, MS2 and mobility
+0:01:47.048419 INFO: Using multiprocessing with 100 processes ...
+0:01:47.425628 INFO: Predicting rt,ms2,mobility ...
+0:07:18.064366 INFO: Adding fragment mz information
+0:07:18.344745 INFO: Adding fragment intensity information
+0:07:18.625608 INFO: Adding precursor information
+0:07:18.950080 INFO: Running PrecursorInitializer
+0:07:18.983123 INFO: Running AnnotateFasta
+0:07:19.129470 INFO: Dropping decoys from input library before annotation
+0:07:45.422943 INFO: Running IsotopeGenerator
+0:08:11.324868 INFO: Running RTNormalization
+0:08:11.325538 WARNING: Input library already contains normalized RT information. Skipping RT normalization
+0:08:11.325639 INFO: Saving library to run_output/alphadia_1.10_defaultMBR/library/speclib.hdf
+0:08:42.802726 INFO: Running DecoyGenerator
+0:10:32.865701 INFO: Running FlattenLibrary
+0:11:00.404921 INFO: Running InitFlatColumns
+0:11:00.591121 INFO: Running LogFlatLibraryStats
+0:11:00.591253 INFO: ============ Library Stats ============
+0:11:00.591291 INFO: Number of precursors: 10,400,392
+0:11:02.016786 INFO: 	thereof targets:5,215,079
+0:11:02.016936 INFO: 	thereof decoys: 5,185,313
+0:11:02.087806 INFO: Number of elution groups: 5,215,079
+0:11:02.087937 INFO: 	average size: 1.99
+0:11:02.422220 INFO: Number of proteins: 117,993
+0:11:02.447512 INFO: Number of channels: 1 ([0])
+0:11:02.447677 INFO: Isotopes Distribution for 4 isotopes
+0:11:02.447705 INFO: =======================================
+0:11:02.455192 INFO: Searching 6 files:
+0:11:02.455305 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:02.455339 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+0:11:02.455358 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+0:11:02.455376 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+0:11:02.455393 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+0:11:02.455410 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+0:11:02.455430 INFO: Using 1 fasta files:
+0:11:02.455448 INFO:   ./ProteoBenchFASTA_DDAQuantification.fasta
+0:11:02.455472 INFO: Using library: None
+0:11:02.455491 INFO: Saving output to: run_output/alphadia_1.10_defaultMBR/library
+0:11:02.455514 PROGRESS: Starting Search Workflows
+0:11:02.455575 PROGRESS: Loading raw file 1/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+0:11:02.455619 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+0:11:02.455675 INFO: Creating parent folder for workflows at run_output/alphadia_1.10_defaultMBR/library/quant
+0:11:02.455791 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+0:11:02.456155 INFO: Initializing RawFileManager
+0:11:02.456256 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:02.456299 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:02.456330 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:02.669260 INFO: Reading 39,128 frames with 2,835,410,867 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.199809 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d...
+0:11:12.204075 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.216608 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.216931 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.217279 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.218947 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.227157 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:12.227340 INFO: Indexing quadrupole dimension
+0:11:12.750655 INFO: Transposing detector events
+0:11:23.092883 INFO: Finished transposing data
+0:11:23.117125 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+0:11:23.118103 INFO: RT (min)            : 0.0 - 70.0
+0:11:23.118146 INFO: RT duration (sec)   : 4199.9
+0:11:23.118170 INFO: RT duration (min)   : 70.0
+0:11:23.118192 INFO: Cycle len (scans)   : 9
+0:11:23.118209 INFO: Cycle len (sec)     : 0.97
+0:11:23.118226 INFO: Number of cycles    : 4347
+0:11:23.118243 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+0:11:24.388867 INFO: Initializing CalibrationManager
+0:11:24.389187 INFO: Loading calibration config
+0:11:24.389307 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6'}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6'}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed']}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed']}], 'name': 'precursor'}]
+0:11:24.389388 INFO: Calibration group :fragment, found 1 estimator(s)
+0:11:24.389515 INFO: Calibration group :precursor, found 3 estimator(s)
+0:11:24.389656 INFO: Initializing OptimizationManager
+0:11:24.389752 INFO: initial parameter: ms1_error = 30
+0:11:24.389805 INFO: initial parameter: ms2_error = 30
+0:11:24.389856 INFO: initial parameter: rt_error = 2099.928159
+0:11:24.389912 INFO: initial parameter: mobility_error = 0.1
+0:11:24.389962 INFO: initial parameter: column_type = library
+0:11:24.390005 INFO: initial parameter: num_candidates = 1
+0:11:24.390047 INFO: initial parameter: classifier_version = -1
+0:11:24.390090 INFO: initial parameter: fwhm_rt = 5
+0:11:24.390133 INFO: initial parameter: fwhm_mobility = 0.01
+0:11:24.390174 INFO: initial parameter: score_cutoff = 0
+0:11:24.390237 INFO: Initializing TimingManager
+0:11:24.390300 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+0:11:24.390413 INFO: FDRManager not loaded from disk.
+0:11:24.390439 INFO: Initializing FDRManager
+0:11:24.390481 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+0:11:25.655167 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+0:11:27.465775 PROGRESS: Starting initial search for precursors.
+0:11:28.345971 INFO: Starting optimization step 0.
+0:11:28.346220 PROGRESS: === Extracting elution groups 0 to 8000 ===
+0:11:28.346315 PROGRESS: Extracting batch of 15771 precursors
+0:11:30.410017 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:11:30.410133 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:11:30.410166 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+0:11:30.410188 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+0:11:34.201686 INFO: Starting candidate selection
+0:14:28.660038 INFO: Starting candidate scoring
+0:22:20.226206 INFO: Finished candidate processing
+0:22:20.226415 INFO: Collecting candidate features
+0:22:20.835553 WARNING: intensity_correlation has 2 NaNs ( 0.01 % out of 13800)
+0:22:20.839242 INFO: Collecting fragment features
+0:22:23.290375 INFO: Finished candidate scoring
+0:22:23.305374 PROGRESS: === Extracted 13800 precursors and 138628 fragments ===
+0:22:23.305741 INFO: performing precursor FDR with 47 features
+0:22:23.305779 INFO: Decoy channel: -1
+0:22:23.305803 INFO: Competetive: True
+0:22:23.309601 INFO: Setting torch num_threads to 2 for FDR classification task
+0:22:23.312070 WARNING: dropped 2 target PSMs due to missing features
+0:22:23.948226 INFO: Test AUC: 0.512
+0:22:23.948348 INFO: Train AUC: 0.522
+0:22:23.948380 INFO: AUC difference: 1.95%
+0:22:24.033337 INFO: Resetting torch num_threads to 128
+0:22:24.033780 INFO: === FDR correction performed with classifier version -1 ===
+0:22:24.035722 PROGRESS: ============================= Precursor FDR =============================
+0:22:24.035815 PROGRESS: Total precursors accumulated: 7,060
+0:22:24.035874 PROGRESS: Target precursors: 3,782 (53.57%)
+0:22:24.035925 PROGRESS: Decoy precursors: 3,278 (46.43%)
+0:22:24.035971 PROGRESS: 
+0:22:24.036016 PROGRESS: Precursor Summary:
+0:22:24.036937 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+0:22:24.037031 PROGRESS: 
+0:22:24.037090 PROGRESS: Protein Summary:
+0:22:24.038036 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+0:22:24.038122 PROGRESS: =========================================================================
+0:22:24.182451 INFO: Starting optimization step 1.
+0:22:24.182701 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+0:22:24.182771 PROGRESS: Extracting batch of 31534 precursors
+0:22:24.189507 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:22:24.189576 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:22:24.189610 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+0:22:24.189632 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+0:22:24.191525 INFO: Starting candidate selection
+0:24:56.506916 INFO: Starting candidate scoring
+0:24:57.993671 INFO: Finished candidate processing
+0:24:57.993861 INFO: Collecting candidate features
+0:24:58.085174 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 27420)
+0:24:58.089432 INFO: Collecting fragment features
+0:24:58.112530 INFO: Finished candidate scoring
+0:24:58.204394 PROGRESS: === Extracted 41220 precursors and 413058 fragments ===
+0:24:58.211066 INFO: performing precursor FDR with 47 features
+0:24:58.211189 INFO: Decoy channel: -1
+0:24:58.211216 INFO: Competetive: True
+0:24:58.234369 INFO: Setting torch num_threads to 2 for FDR classification task
+0:24:58.244698 WARNING: dropped 4 target PSMs due to missing features
+0:24:58.244852 WARNING: dropped 2 decoy PSMs due to missing features
+0:24:59.071791 INFO: Test AUC: 0.547
+0:24:59.072026 INFO: Train AUC: 0.560
+0:24:59.072061 INFO: AUC difference: 2.22%
+0:24:59.165590 INFO: Resetting torch num_threads to 128
+0:24:59.168791 INFO: === FDR correction performed with classifier version -1 ===
+0:24:59.172354 PROGRESS: ============================= Precursor FDR =============================
+0:24:59.172498 PROGRESS: Total precursors accumulated: 21,106
+0:24:59.172565 PROGRESS: Target precursors: 12,160 (57.61%)
+0:24:59.172620 PROGRESS: Decoy precursors: 8,946 (42.39%)
+0:24:59.172669 PROGRESS: 
+0:24:59.172716 PROGRESS: Precursor Summary:
+0:24:59.173832 PROGRESS: Channel   0:	 0.05 FDR:   212; 0.01 FDR:   126; 0.001 FDR:    92
+0:24:59.173925 PROGRESS: 
+0:24:59.173985 PROGRESS: Protein Summary:
+0:24:59.175164 PROGRESS: Channel   0:	 0.05 FDR:   207; 0.01 FDR:   122; 0.001 FDR:    90
+0:24:59.175252 PROGRESS: =========================================================================
+0:24:59.390552 INFO: Starting optimization step 2.
+0:24:59.390814 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+0:24:59.390897 PROGRESS: Extracting batch of 63016 precursors
+0:24:59.405886 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:24:59.406002 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:24:59.406045 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+0:24:59.406067 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+0:24:59.407012 INFO: Starting candidate selection
+0:30:08.045154 INFO: Starting candidate scoring
+0:30:11.007423 INFO: Finished candidate processing
+0:30:11.007588 INFO: Collecting candidate features
+0:30:11.132896 WARNING: intensity_correlation has 13 NaNs ( 0.02 % out of 55011)
+0:30:11.133218 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 55011)
+0:30:11.138120 INFO: Collecting fragment features
+0:30:11.178003 INFO: Finished candidate scoring
+0:30:11.268731 PROGRESS: === Extracted 96231 precursors and 963854 fragments ===
+0:30:11.281568 INFO: performing precursor FDR with 47 features
+0:30:11.281697 INFO: Decoy channel: -1
+0:30:11.281728 INFO: Competetive: True
+0:30:11.327344 INFO: Setting torch num_threads to 2 for FDR classification task
+0:30:11.347596 WARNING: dropped 10 target PSMs due to missing features
+0:30:11.347727 WARNING: dropped 9 decoy PSMs due to missing features
+0:30:13.007945 INFO: Test AUC: 0.552
+0:30:13.008070 INFO: Train AUC: 0.574
+0:30:13.008106 INFO: AUC difference: 3.72%
+0:30:13.099327 INFO: Resetting torch num_threads to 128
+0:30:13.104451 INFO: === FDR correction performed with classifier version -1 ===
+0:30:13.113016 PROGRESS: ============================= Precursor FDR =============================
+0:30:13.113297 PROGRESS: Total precursors accumulated: 49,318
+0:30:13.113384 PROGRESS: Target precursors: 29,361 (59.53%)
+0:30:13.113449 PROGRESS: Decoy precursors: 19,957 (40.47%)
+0:30:13.113510 PROGRESS: 
+0:30:13.113569 PROGRESS: Precursor Summary:
+0:30:13.114962 PROGRESS: Channel   0:	 0.05 FDR:   513; 0.01 FDR:   357; 0.001 FDR:   280
+0:30:13.115073 PROGRESS: 
+0:30:13.115141 PROGRESS: Protein Summary:
+0:30:13.116611 PROGRESS: Channel   0:	 0.05 FDR:   476; 0.01 FDR:   332; 0.001 FDR:   263
+0:30:13.116713 PROGRESS: =========================================================================
+0:30:13.130900 INFO: fragments_df_filtered: 3215
+0:30:13.346711 INFO: calibration group: precursor, fitting mz estimator 
+0:30:13.398381 INFO: calibration group: precursor, fitting rt estimator 
+0:30:13.450402 INFO: calibration group: precursor, fitting mobility estimator 
+0:30:13.510586 INFO: calibration group: fragment, fitting mz estimator 
+0:30:13.745805 INFO: calibration group: precursor, predicting mz
+0:30:13.761294 INFO: calibration group: precursor, predicting rt
+0:30:13.834866 INFO: calibration group: precursor, predicting mobility
+0:30:13.851612 INFO: calibration group: fragment, predicting mz
+0:30:13.990680 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+0:30:13.991012 INFO: Starting optimization step 3.
+0:30:13.991104 PROGRESS: === Extracting elution groups 0 to 56000 ===
+0:30:13.991202 PROGRESS: Extracting batch of 110321 precursors
+0:30:14.030641 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:30:14.030788 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:30:14.030860 INFO: FWHM in RT is 3.17 seconds, sigma is 0.70
+0:30:14.030891 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.01
+0:30:14.041707 INFO: Starting candidate selection
+0:39:06.556201 INFO: Starting candidate scoring
+0:39:16.626737 INFO: Finished candidate processing
+0:39:16.626912 INFO: Collecting candidate features
+0:39:17.072323 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 189250)
+0:39:17.087318 INFO: Collecting fragment features
+0:39:17.208680 INFO: Finished candidate scoring
+0:39:17.412232 PROGRESS: === Extracted 189250 precursors and 1926296 fragments ===
+0:39:17.412731 INFO: performing precursor FDR with 47 features
+0:39:17.412773 INFO: Decoy channel: -1
+0:39:17.412797 INFO: Competetive: True
+0:39:17.472178 INFO: Setting torch num_threads to 2 for FDR classification task
+0:39:17.504766 WARNING: dropped 1 target PSMs due to missing features
+0:39:20.644804 INFO: Test AUC: 0.565
+0:39:20.645011 INFO: Train AUC: 0.585
+0:39:20.645053 INFO: AUC difference: 3.46%
+0:39:20.743784 INFO: Resetting torch num_threads to 128
+0:39:20.750187 INFO: === FDR correction performed with classifier version 2 ===
+0:39:20.760299 PROGRESS: ============================= Precursor FDR =============================
+0:39:20.760550 PROGRESS: Total precursors accumulated: 50,259
+0:39:20.760616 PROGRESS: Target precursors: 31,560 (62.79%)
+0:39:20.760669 PROGRESS: Decoy precursors: 18,699 (37.21%)
+0:39:20.760716 PROGRESS: 
+0:39:20.760762 PROGRESS: Precursor Summary:
+0:39:20.762211 PROGRESS: Channel   0:	 0.05 FDR:   550; 0.01 FDR:   354; 0.001 FDR:   197
+0:39:20.762319 PROGRESS: 
+0:39:20.762378 PROGRESS: Protein Summary:
+0:39:20.763823 PROGRESS: Channel   0:	 0.05 FDR:   506; 0.01 FDR:   326; 0.001 FDR:   183
+0:39:20.763914 PROGRESS: =========================================================================
+0:39:20.778630 INFO: fragments_df_filtered: 4254
+0:39:20.997275 INFO: calibration group: precursor, fitting mz estimator 
+0:39:21.039268 INFO: calibration group: precursor, fitting rt estimator 
+0:39:21.079803 INFO: calibration group: precursor, fitting mobility estimator 
+0:39:21.121862 INFO: calibration group: fragment, fitting mz estimator 
+0:39:21.385606 INFO: calibration group: precursor, predicting mz
+0:39:21.401090 INFO: calibration group: precursor, predicting rt
+0:39:21.471919 INFO: calibration group: precursor, predicting mobility
+0:39:21.489889 INFO: calibration group: fragment, predicting mz
+0:39:21.649795 INFO: === checking if optimization conditions were reached ===
+0:39:21.652556 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+0:39:21.653749 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+0:39:21.653805 INFO: ==============================================
+0:39:21.653928 INFO: Starting optimization step 4.
+0:39:21.654008 PROGRESS: === Extracting elution groups 0 to 56000 ===
+0:39:21.654123 PROGRESS: Extracting batch of 110321 precursors
+0:39:21.702082 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:39:21.702242 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:39:21.702340 INFO: FWHM in RT is 3.42 seconds, sigma is 0.75
+0:39:21.702368 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.18
+0:39:21.703325 INFO: Starting candidate selection
+0:47:23.634869 INFO: Starting candidate scoring
+0:47:29.388422 INFO: Finished candidate processing
+0:47:29.388588 INFO: Collecting candidate features
+0:47:29.730146 WARNING: intensity_correlation has 11 NaNs ( 0.01 % out of 189091)
+0:47:29.730555 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 189091)
+0:47:29.740349 INFO: Collecting fragment features
+0:47:29.854435 INFO: Finished candidate scoring
+0:47:29.960553 PROGRESS: === Extracted 189091 precursors and 1858584 fragments ===
+0:47:29.960949 INFO: performing precursor FDR with 47 features
+0:47:29.960994 INFO: Decoy channel: -1
+0:47:29.961020 INFO: Competetive: True
+0:47:30.015150 INFO: Setting torch num_threads to 2 for FDR classification task
+0:47:30.047873 WARNING: dropped 6 target PSMs due to missing features
+0:47:30.048011 WARNING: dropped 7 decoy PSMs due to missing features
+0:47:33.161277 INFO: Test AUC: 0.556
+0:47:33.161398 INFO: Train AUC: 0.585
+0:47:33.161429 INFO: AUC difference: 5.03%
+0:47:33.161451 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:47:33.255042 INFO: Resetting torch num_threads to 128
+0:47:33.260261 INFO: === FDR correction performed with classifier version 3 ===
+0:47:33.268644 PROGRESS: ============================= Precursor FDR =============================
+0:47:33.268893 PROGRESS: Total precursors accumulated: 50,227
+0:47:33.268959 PROGRESS: Target precursors: 31,049 (61.82%)
+0:47:33.269013 PROGRESS: Decoy precursors: 19,178 (38.18%)
+0:47:33.269074 PROGRESS: 
+0:47:33.269121 PROGRESS: Precursor Summary:
+0:47:33.270563 PROGRESS: Channel   0:	 0.05 FDR:   907; 0.01 FDR:   628; 0.001 FDR:   162
+0:47:33.270658 PROGRESS: 
+0:47:33.270716 PROGRESS: Protein Summary:
+0:47:33.272248 PROGRESS: Channel   0:	 0.05 FDR:   829; 0.01 FDR:   574; 0.001 FDR:   150
+0:47:33.272338 PROGRESS: =========================================================================
+0:47:33.285713 INFO: fragments_df_filtered: 5000
+0:47:33.458680 INFO: calibration group: precursor, fitting mz estimator 
+0:47:33.510073 INFO: calibration group: precursor, fitting rt estimator 
+0:47:33.566007 INFO: calibration group: precursor, fitting mobility estimator 
+0:47:33.620777 INFO: calibration group: fragment, fitting mz estimator 
+0:47:34.037389 INFO: calibration group: precursor, predicting mz
+0:47:34.044247 INFO: calibration group: precursor, predicting rt
+0:47:34.072219 INFO: calibration group: precursor, predicting mobility
+0:47:34.078389 INFO: calibration group: fragment, predicting mz
+0:47:34.128410 INFO: === checking if optimization conditions were reached ===
+0:47:34.130836 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+0:47:34.132020 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+0:47:34.132073 INFO: ==============================================
+0:47:34.132180 PROGRESS: Optimization finished for ms2_error, ms1_error.
+0:47:34.305323 INFO: calibration group: precursor, predicting mz
+0:47:34.312413 INFO: calibration group: precursor, predicting rt
+0:47:34.340440 INFO: calibration group: precursor, predicting mobility
+0:47:34.346624 INFO: calibration group: fragment, predicting mz
+0:47:34.395638 INFO: Starting optimization step 0.
+0:47:34.395890 PROGRESS: === Extracting elution groups 0 to 24000 ===
+0:47:34.395978 PROGRESS: Extracting batch of 47305 precursors
+0:47:34.412686 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:47:34.412818 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:47:34.412878 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+0:47:34.412905 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.24
+0:47:34.421674 INFO: Starting candidate selection
+0:51:03.942048 INFO: Starting candidate scoring
+0:51:06.444516 INFO: Finished candidate processing
+0:51:06.444622 INFO: Collecting candidate features
+0:51:06.574752 WARNING: intensity_correlation has 2 NaNs ( 0.00 % out of 81093)
+0:51:06.581255 INFO: Collecting fragment features
+0:51:06.637916 INFO: Finished candidate scoring
+0:51:06.681484 PROGRESS: === Extracted 81093 precursors and 794933 fragments ===
+0:51:06.681940 INFO: performing precursor FDR with 47 features
+0:51:06.681980 INFO: Decoy channel: -1
+0:51:06.682004 INFO: Competetive: True
+0:51:06.706305 INFO: Setting torch num_threads to 2 for FDR classification task
+0:51:06.719466 WARNING: dropped 2 decoy PSMs due to missing features
+0:51:07.957144 INFO: Test AUC: 0.567
+0:51:07.957268 INFO: Train AUC: 0.604
+0:51:07.957298 INFO: AUC difference: 6.01%
+0:51:07.957319 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:51:08.054497 INFO: Resetting torch num_threads to 128
+0:51:08.057003 INFO: === FDR correction performed with classifier version 4 ===
+0:51:08.060534 PROGRESS: ============================= Precursor FDR =============================
+0:51:08.060677 PROGRESS: Total precursors accumulated: 21,525
+0:51:08.060743 PROGRESS: Target precursors: 13,687 (63.59%)
+0:51:08.060797 PROGRESS: Decoy precursors: 7,838 (36.41%)
+0:51:08.060845 PROGRESS: 
+0:51:08.060890 PROGRESS: Precursor Summary:
+0:51:08.062040 PROGRESS: Channel   0:	 0.05 FDR:   453; 0.01 FDR:   285; 0.001 FDR:   241
+0:51:08.062140 PROGRESS: 
+0:51:08.062202 PROGRESS: Protein Summary:
+0:51:08.063487 PROGRESS: Channel   0:	 0.05 FDR:   439; 0.01 FDR:   275; 0.001 FDR:   233
+0:51:08.063578 PROGRESS: =========================================================================
+0:51:08.093283 INFO: fragments_df_filtered: 3170
+0:51:08.260699 INFO: calibration group: precursor, fitting mz estimator 
+0:51:08.302313 INFO: calibration group: precursor, fitting rt estimator 
+0:51:08.340787 INFO: calibration group: precursor, fitting mobility estimator 
+0:51:08.378821 INFO: calibration group: fragment, fitting mz estimator 
+0:51:08.542900 INFO: calibration group: precursor, predicting mz
+0:51:08.550414 INFO: calibration group: precursor, predicting rt
+0:51:08.579051 INFO: calibration group: precursor, predicting mobility
+0:51:08.585569 INFO: calibration group: fragment, predicting mz
+0:51:08.637850 INFO: === checking if optimization conditions were reached ===
+0:51:08.638097 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+0:51:08.640391 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 657.5069.
+0:51:08.640452 INFO: ==============================================
+0:51:08.640549 INFO: Starting optimization step 1.
+0:51:08.640623 PROGRESS: === Extracting elution groups 0 to 24000 ===
+0:51:08.640701 PROGRESS: Extracting batch of 47305 precursors
+0:51:08.651881 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:51:08.651993 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:51:08.652048 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+0:51:08.652076 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+0:51:08.660801 INFO: Starting candidate selection
+0:52:22.272565 INFO: Starting candidate scoring
+0:52:24.690182 INFO: Finished candidate processing
+0:52:24.690374 INFO: Collecting candidate features
+0:52:24.864012 WARNING: intensity_correlation has 20 NaNs ( 0.03 % out of 79549)
+0:52:24.864369 WARNING: height_correlation has 3 NaNs ( 0.00 % out of 79549)
+0:52:24.870974 INFO: Collecting fragment features
+0:52:24.931449 INFO: Finished candidate scoring
+0:52:24.984003 PROGRESS: === Extracted 79549 precursors and 767799 fragments ===
+0:52:24.984651 INFO: performing precursor FDR with 47 features
+0:52:24.984698 INFO: Decoy channel: -1
+0:52:24.984724 INFO: Competetive: True
+0:52:25.025754 INFO: Setting torch num_threads to 2 for FDR classification task
+0:52:25.046398 WARNING: dropped 10 target PSMs due to missing features
+0:52:25.046552 WARNING: dropped 13 decoy PSMs due to missing features
+0:52:26.544764 INFO: Test AUC: 0.556
+0:52:26.544923 INFO: Train AUC: 0.591
+0:52:26.544953 INFO: AUC difference: 5.93%
+0:52:26.544975 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:52:26.643042 INFO: Resetting torch num_threads to 128
+0:52:26.646982 INFO: === FDR correction performed with classifier version 4 ===
+0:52:26.651376 PROGRESS: ============================= Precursor FDR =============================
+0:52:26.651546 PROGRESS: Total precursors accumulated: 21,276
+0:52:26.651610 PROGRESS: Target precursors: 13,053 (61.35%)
+0:52:26.651662 PROGRESS: Decoy precursors: 8,223 (38.65%)
+0:52:26.651710 PROGRESS: 
+0:52:26.651762 PROGRESS: Precursor Summary:
+0:52:26.652915 PROGRESS: Channel   0:	 0.05 FDR:   370; 0.01 FDR:   253; 0.001 FDR:   158
+0:52:26.653016 PROGRESS: 
+0:52:26.653092 PROGRESS: Protein Summary:
+0:52:26.654350 PROGRESS: Channel   0:	 0.05 FDR:   358; 0.01 FDR:   245; 0.001 FDR:   152
+0:52:26.654441 PROGRESS: =========================================================================
+0:52:26.661285 INFO: fragments_df_filtered: 2853
+0:52:26.861241 INFO: calibration group: precursor, fitting mz estimator 
+0:52:26.912239 INFO: calibration group: precursor, fitting rt estimator 
+0:52:26.953239 INFO: calibration group: precursor, fitting mobility estimator 
+0:52:26.992040 INFO: calibration group: fragment, fitting mz estimator 
+0:52:27.140834 INFO: calibration group: precursor, predicting mz
+0:52:27.148912 INFO: calibration group: precursor, predicting rt
+0:52:27.177733 INFO: calibration group: precursor, predicting mobility
+0:52:27.184748 INFO: calibration group: fragment, predicting mz
+0:52:27.239184 INFO: === checking if optimization conditions were reached ===
+0:52:27.239506 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+0:52:27.242004 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 427.6862.
+0:52:27.242079 INFO: ==============================================
+0:52:27.242186 INFO: Starting optimization step 2.
+0:52:27.242265 PROGRESS: === Extracting elution groups 0 to 24000 ===
+0:52:27.242358 PROGRESS: Extracting batch of 47305 precursors
+0:52:27.259036 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:52:27.259183 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:52:27.259263 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+0:52:27.259290 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.20
+0:52:27.268220 INFO: Starting candidate selection
+0:53:10.244527 INFO: Starting candidate scoring
+0:53:11.425505 INFO: Finished candidate processing
+0:53:11.425606 INFO: Collecting candidate features
+0:53:11.569908 WARNING: intensity_correlation has 513 NaNs ( 0.72 % out of 71163)
+0:53:11.570205 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 71163)
+0:53:11.575846 INFO: Collecting fragment features
+0:53:11.610558 INFO: Finished candidate scoring
+0:53:11.650272 PROGRESS: === Extracted 71163 precursors and 364943 fragments ===
+0:53:11.650737 INFO: performing precursor FDR with 47 features
+0:53:11.650777 INFO: Decoy channel: -1
+0:53:11.650801 INFO: Competetive: True
+0:53:11.673014 INFO: Setting torch num_threads to 2 for FDR classification task
+0:53:11.685835 WARNING: dropped 258 target PSMs due to missing features
+0:53:11.685956 WARNING: dropped 259 decoy PSMs due to missing features
+0:53:12.806444 INFO: Test AUC: 0.529
+0:53:12.806566 INFO: Train AUC: 0.559
+0:53:12.806596 INFO: AUC difference: 5.38%
+0:53:12.806619 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:53:12.896770 INFO: Resetting torch num_threads to 128
+0:53:12.899144 INFO: === FDR correction performed with classifier version 4 ===
+0:53:12.902451 PROGRESS: ============================= Precursor FDR =============================
+0:53:12.902584 PROGRESS: Total precursors accumulated: 20,332
+0:53:12.902647 PROGRESS: Target precursors: 11,521 (56.66%)
+0:53:12.902699 PROGRESS: Decoy precursors: 8,811 (43.34%)
+0:53:12.902746 PROGRESS: 
+0:53:12.902792 PROGRESS: Precursor Summary:
+0:53:12.903774 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+0:53:12.903862 PROGRESS: 
+0:53:12.903917 PROGRESS: Protein Summary:
+0:53:12.904967 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+0:53:12.905076 PROGRESS: =========================================================================
+0:53:13.104319 INFO: calibration group: precursor, predicting mz
+0:53:13.113791 INFO: calibration group: precursor, predicting rt
+0:53:13.153474 INFO: calibration group: precursor, predicting mobility
+0:53:13.165237 INFO: calibration group: fragment, predicting mz
+0:53:13.238726 INFO: === skipping optimization until target number of precursors are found ===
+0:53:13.239092 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+0:53:13.239176 INFO: Starting optimization step 3.
+0:53:13.239249 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+0:53:13.239329 PROGRESS: Extracting batch of 63016 precursors
+0:53:13.261367 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:53:13.261519 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:53:13.261574 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+0:53:13.261598 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.20
+0:53:13.262639 INFO: Starting candidate selection
+0:54:13.355608 INFO: Starting candidate scoring
+0:54:14.903696 INFO: Finished candidate processing
+0:54:14.903888 INFO: Collecting candidate features
+0:54:15.134936 WARNING: intensity_correlation has 750 NaNs ( 0.79 % out of 94887)
+0:54:15.135314 WARNING: height_correlation has 8 NaNs ( 0.01 % out of 94887)
+0:54:15.142328 INFO: Collecting fragment features
+0:54:15.202347 INFO: Finished candidate scoring
+0:54:15.382699 PROGRESS: === Extracted 166050 precursors and 853859 fragments ===
+0:54:15.402530 INFO: performing precursor FDR with 47 features
+0:54:15.402682 INFO: Decoy channel: -1
+0:54:15.402711 INFO: Competetive: True
+0:54:15.494665 INFO: Setting torch num_threads to 2 for FDR classification task
+0:54:15.537174 WARNING: dropped 654 target PSMs due to missing features
+0:54:15.537331 WARNING: dropped 616 decoy PSMs due to missing features
+0:54:18.970560 INFO: Test AUC: 0.526
+0:54:18.970877 INFO: Train AUC: 0.562
+0:54:18.970931 INFO: AUC difference: 6.52%
+0:54:18.970954 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:54:19.072313 INFO: Resetting torch num_threads to 128
+0:54:19.083011 INFO: === FDR correction performed with classifier version 4 ===
+0:54:19.093629 PROGRESS: ============================= Precursor FDR =============================
+0:54:19.093939 PROGRESS: Total precursors accumulated: 47,422
+0:54:19.094008 PROGRESS: Target precursors: 27,002 (56.94%)
+0:54:19.094064 PROGRESS: Decoy precursors: 20,420 (43.06%)
+0:54:19.094115 PROGRESS: 
+0:54:19.094163 PROGRESS: Precursor Summary:
+0:54:19.095481 PROGRESS: Channel   0:	 0.05 FDR:    86; 0.01 FDR:    12; 0.001 FDR:    12
+0:54:19.095574 PROGRESS: 
+0:54:19.095633 PROGRESS: Protein Summary:
+0:54:19.096891 PROGRESS: Channel   0:	 0.05 FDR:    85; 0.01 FDR:    12; 0.001 FDR:    12
+0:54:19.097003 PROGRESS: =========================================================================
+0:54:19.749760 INFO: calibration group: precursor, predicting mz
+0:54:19.768405 INFO: calibration group: precursor, predicting rt
+0:54:19.843756 INFO: calibration group: precursor, predicting mobility
+0:54:19.862426 INFO: calibration group: fragment, predicting mz
+0:54:20.018857 INFO: === skipping optimization until target number of precursors are found ===
+0:54:20.019222 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+0:54:20.020183 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 2099.9282 found after 2 searches.
+0:54:20.020276 PROGRESS: Optimization finished for rt_error.
+0:54:20.219248 INFO: calibration group: precursor, predicting mz
+0:54:20.227492 INFO: calibration group: precursor, predicting rt
+0:54:20.256586 INFO: calibration group: precursor, predicting mobility
+0:54:20.263814 INFO: calibration group: fragment, predicting mz
+0:54:20.349192 INFO: Starting optimization step 0.
+0:54:20.349452 PROGRESS: === Extracting elution groups 0 to 24000 ===
+0:54:20.349549 PROGRESS: Extracting batch of 47305 precursors
+0:54:20.365434 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:54:20.365590 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:54:20.365644 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+0:54:20.365668 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+0:54:20.366864 INFO: Starting candidate selection
+0:57:46.835896 INFO: Starting candidate scoring
+0:57:48.048880 INFO: Finished candidate processing
+0:57:48.049080 INFO: Collecting candidate features
+0:57:48.216952 WARNING: intensity_correlation has 413 NaNs ( 0.55 % out of 75065)
+0:57:48.217313 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 75065)
+0:57:48.223492 INFO: Collecting fragment features
+0:57:48.265490 INFO: Finished candidate scoring
+0:57:48.313667 PROGRESS: === Extracted 75065 precursors and 393423 fragments ===
+0:57:48.314221 INFO: performing precursor FDR with 47 features
+0:57:48.314264 INFO: Decoy channel: -1
+0:57:48.314288 INFO: Competetive: True
+0:57:48.343859 INFO: Setting torch num_threads to 2 for FDR classification task
+0:57:48.359433 WARNING: dropped 199 target PSMs due to missing features
+0:57:48.359564 WARNING: dropped 215 decoy PSMs due to missing features
+0:57:49.735950 INFO: Test AUC: 0.526
+0:57:49.736091 INFO: Train AUC: 0.571
+0:57:49.736122 INFO: AUC difference: 7.84%
+0:57:49.736143 WARNING: AUC difference > 5%. This may indicate overfitting.
+0:57:49.827793 INFO: Resetting torch num_threads to 128
+0:57:49.830765 INFO: === FDR correction performed with classifier version 5 ===
+0:57:49.834527 PROGRESS: ============================= Precursor FDR =============================
+0:57:49.834679 PROGRESS: Total precursors accumulated: 21,013
+0:57:49.834743 PROGRESS: Target precursors: 12,273 (58.41%)
+0:57:49.834794 PROGRESS: Decoy precursors: 8,740 (41.59%)
+0:57:49.834842 PROGRESS: 
+0:57:49.834890 PROGRESS: Precursor Summary:
+0:57:49.835905 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+0:57:49.835994 PROGRESS: 
+0:57:49.836051 PROGRESS: Protein Summary:
+0:57:49.837106 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+0:57:49.837199 PROGRESS: =========================================================================
+0:57:50.065747 INFO: calibration group: precursor, predicting mz
+0:57:50.075745 INFO: calibration group: precursor, predicting rt
+0:57:50.114841 INFO: calibration group: precursor, predicting mobility
+0:57:50.125766 INFO: calibration group: fragment, predicting mz
+0:57:50.203429 INFO: === skipping optimization until target number of precursors are found ===
+0:57:50.203791 PROGRESS: === Optimization of mobility_error has been skipped 1 time(s); maximum number is 1 ===
+0:57:50.203875 INFO: Starting optimization step 1.
+0:57:50.203954 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+0:57:50.204042 PROGRESS: Extracting batch of 63016 precursors
+0:57:50.229332 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+0:57:50.229498 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+0:57:50.229564 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+0:57:50.229593 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+0:57:50.242531 INFO: Starting candidate selection
+1:02:36.467374 INFO: Starting candidate scoring
+1:02:40.326386 INFO: Finished candidate processing
+1:02:40.326529 INFO: Collecting candidate features
+1:02:40.558748 WARNING: intensity_correlation has 602 NaNs ( 0.60 % out of 100375)
+1:02:40.559103 WARNING: height_correlation has 15 NaNs ( 0.01 % out of 100375)
+1:02:40.566093 INFO: Collecting fragment features
+1:02:40.620199 INFO: Finished candidate scoring
+1:02:40.769282 PROGRESS: === Extracted 175440 precursors and 921603 fragments ===
+1:02:40.788192 INFO: performing precursor FDR with 47 features
+1:02:40.788341 INFO: Decoy channel: -1
+1:02:40.788368 INFO: Competetive: True
+1:02:40.876392 INFO: Setting torch num_threads to 2 for FDR classification task
+1:02:40.915560 WARNING: dropped 500 target PSMs due to missing features
+1:02:40.915713 WARNING: dropped 522 decoy PSMs due to missing features
+1:02:43.940989 INFO: Test AUC: 0.535
+1:02:43.941716 INFO: Train AUC: 0.566
+1:02:43.941756 INFO: AUC difference: 5.58%
+1:02:43.941799 WARNING: AUC difference > 5%. This may indicate overfitting.
+1:02:44.920984 INFO: Resetting torch num_threads to 128
+1:02:44.929202 INFO: === FDR correction performed with classifier version 5 ===
+1:02:44.938930 PROGRESS: ============================= Precursor FDR =============================
+1:02:44.939239 PROGRESS: Total precursors accumulated: 49,070
+1:02:44.939312 PROGRESS: Target precursors: 28,614 (58.31%)
+1:02:44.939372 PROGRESS: Decoy precursors: 20,456 (41.69%)
+1:02:44.939427 PROGRESS: 
+1:02:44.939480 PROGRESS: Precursor Summary:
+1:02:44.940750 PROGRESS: Channel   0:	 0.05 FDR:    40; 0.01 FDR:    33; 0.001 FDR:    33
+1:02:44.940845 PROGRESS: 
+1:02:44.940907 PROGRESS: Protein Summary:
+1:02:44.942304 PROGRESS: Channel   0:	 0.05 FDR:    40; 0.01 FDR:    33; 0.001 FDR:    33
+1:02:44.942400 PROGRESS: =========================================================================
+1:02:45.353721 INFO: calibration group: precursor, predicting mz
+1:02:45.374138 INFO: calibration group: precursor, predicting rt
+1:02:45.450009 INFO: calibration group: precursor, predicting mobility
+1:02:45.470914 INFO: calibration group: fragment, predicting mz
+1:02:45.640079 INFO: === skipping optimization until target number of precursors are found ===
+1:02:45.640405 PROGRESS: === Optimization of mobility_error has been skipped 2 time(s); maximum number is 1 ===
+1:02:45.640476 INFO: Starting optimization step 2.
+1:02:45.640550 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+1:02:45.640624 PROGRESS: Extracting batch of 126066 precursors
+1:02:45.688194 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1:02:45.688340 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1:02:45.688390 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1:02:45.688413 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1:02:45.689461 INFO: Starting candidate selection
+1:11:48.958948 INFO: Starting candidate scoring
+1:11:52.102490 INFO: Finished candidate processing
+1:11:52.102604 INFO: Collecting candidate features
+1:11:52.462605 WARNING: intensity_correlation has 1059 NaNs ( 0.53 % out of 200647)
+1:11:52.463029 WARNING: height_correlation has 33 NaNs ( 0.02 % out of 200647)
+1:11:52.473134 INFO: Collecting fragment features
+1:11:52.578685 INFO: Finished candidate scoring
+1:11:52.849957 PROGRESS: === Extracted 376087 precursors and 1976873 fragments ===
+1:11:52.889613 INFO: performing precursor FDR with 47 features
+1:11:52.889766 INFO: Decoy channel: -1
+1:11:52.889793 INFO: Competetive: True
+1:11:53.054452 INFO: Setting torch num_threads to 2 for FDR classification task
+1:11:53.129746 WARNING: dropped 1059 target PSMs due to missing features
+1:11:53.129896 WARNING: dropped 1040 decoy PSMs due to missing features
+1:11:59.986587 INFO: Test AUC: 0.534
+1:11:59.986753 INFO: Train AUC: 0.561
+1:11:59.986784 INFO: AUC difference: 4.83%
+1:12:00.102601 INFO: Resetting torch num_threads to 128
+1:12:00.123347 INFO: === FDR correction performed with classifier version 5 ===
+1:12:00.144675 PROGRESS: ============================= Precursor FDR =============================
+1:12:00.145000 PROGRESS: Total precursors accumulated: 105,197
+1:12:00.145075 PROGRESS: Target precursors: 60,433 (57.45%)
+1:12:00.145128 PROGRESS: Decoy precursors: 44,764 (42.55%)
+1:12:00.145174 PROGRESS: 
+1:12:00.145219 PROGRESS: Precursor Summary:
+1:12:00.146826 PROGRESS: Channel   0:	 0.05 FDR:     9; 0.01 FDR:     9; 0.001 FDR:     9
+1:12:00.146936 PROGRESS: 
+1:12:00.146994 PROGRESS: Protein Summary:
+1:12:00.148462 PROGRESS: Channel   0:	 0.05 FDR:     9; 0.01 FDR:     9; 0.001 FDR:     9
+1:12:00.148554 PROGRESS: =========================================================================
+1:12:00.614668 INFO: calibration group: precursor, predicting mz
+1:12:00.650013 INFO: calibration group: precursor, predicting rt
+1:12:00.803391 INFO: calibration group: precursor, predicting mobility
+1:12:00.839725 INFO: calibration group: fragment, predicting mz
+1:12:01.142419 INFO: === skipping optimization until target number of precursors are found ===
+1:12:01.142808 PROGRESS: === Optimization of mobility_error has been skipped 3 time(s); maximum number is 1 ===
+1:12:01.142882 INFO: Starting optimization step 3.
+1:12:01.142950 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+1:12:01.143025 PROGRESS: Extracting batch of 252186 precursors
+1:12:01.206981 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1:12:01.207128 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1:12:01.207181 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1:12:01.207204 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1:12:01.208116 INFO: Starting candidate selection
+1:30:07.317619 INFO: Starting candidate scoring
+1:30:13.269396 INFO: Finished candidate processing
+1:30:13.269710 INFO: Collecting candidate features
+1:30:14.316409 WARNING: intensity_correlation has 2167 NaNs ( 0.54 % out of 401465)
+1:30:14.317154 WARNING: height_correlation has 44 NaNs ( 0.01 % out of 401465)
+1:30:14.334482 INFO: Collecting fragment features
+1:30:14.544478 INFO: Finished candidate scoring
+1:30:15.135372 PROGRESS: === Extracted 777552 precursors and 4085872 fragments ===
+1:30:15.213188 INFO: performing precursor FDR with 47 features
+1:30:15.213333 INFO: Decoy channel: -1
+1:30:15.213365 INFO: Competetive: True
+1:30:15.572729 INFO: Setting torch num_threads to 2 for FDR classification task
+1:30:15.731577 WARNING: dropped 2171 target PSMs due to missing features
+1:30:15.731722 WARNING: dropped 2113 decoy PSMs due to missing features
+1:30:30.211701 INFO: Test AUC: 0.540
+1:30:30.212241 INFO: Train AUC: 0.554
+1:30:30.212278 INFO: AUC difference: 2.50%
+1:30:30.358061 INFO: Resetting torch num_threads to 128
+1:30:30.400563 INFO: === FDR correction performed with classifier version 5 ===
+1:30:30.442867 PROGRESS: ============================= Precursor FDR =============================
+1:30:30.443198 PROGRESS: Total precursors accumulated: 217,382
+1:30:30.443268 PROGRESS: Target precursors: 124,222 (57.14%)
+1:30:30.443322 PROGRESS: Decoy precursors: 93,160 (42.86%)
+1:30:30.443373 PROGRESS: 
+1:30:30.443420 PROGRESS: Precursor Summary:
+1:30:30.445616 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1:30:30.445714 PROGRESS: 
+1:30:30.445773 PROGRESS: Protein Summary:
+1:30:30.447724 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1:30:30.447816 PROGRESS: =========================================================================
+1:30:31.109444 INFO: calibration group: precursor, predicting mz
+1:30:31.176859 INFO: calibration group: precursor, predicting rt
+1:30:31.488518 INFO: calibration group: precursor, predicting mobility
+1:30:31.555471 INFO: calibration group: fragment, predicting mz
+1:30:32.154299 INFO: === skipping optimization until target number of precursors are found ===
+1:30:32.154642 PROGRESS: === Optimization of mobility_error has been skipped 4 time(s); maximum number is 1 ===
+1:30:32.154726 INFO: Starting optimization step 4.
+1:30:32.154800 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+1:30:32.154877 PROGRESS: Extracting batch of 504181 precursors
+1:30:32.284122 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1:30:32.284264 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1:30:32.284313 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1:30:32.284338 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1:30:32.285355 INFO: Starting candidate selection
+2:07:02.324940 INFO: Starting candidate scoring
+2:07:13.554530 INFO: Finished candidate processing
+2:07:13.554655 INFO: Collecting candidate features
+2:07:15.417050 WARNING: intensity_correlation has 4290 NaNs ( 0.53 % out of 802989)
+2:07:15.417975 WARNING: height_correlation has 94 NaNs ( 0.01 % out of 802989)
+2:07:15.446930 INFO: Collecting fragment features
+2:07:15.856626 INFO: Finished candidate scoring
+2:07:16.947586 PROGRESS: === Extracted 1580541 precursors and 8301822 fragments ===
+2:07:17.106165 INFO: performing precursor FDR with 47 features
+2:07:17.106329 INFO: Decoy channel: -1
+2:07:17.106357 INFO: Competetive: True
+2:07:17.947540 INFO: Setting torch num_threads to 2 for FDR classification task
+2:07:18.322565 WARNING: dropped 4399 target PSMs due to missing features
+2:07:18.322745 WARNING: dropped 4223 decoy PSMs due to missing features
+2:07:53.171002 INFO: Test AUC: 0.540
+2:07:53.172180 INFO: Train AUC: 0.550
+2:07:53.172230 INFO: AUC difference: 1.83%
+2:07:53.388579 INFO: Resetting torch num_threads to 128
+2:07:53.466345 INFO: === FDR correction performed with classifier version 5 ===
+2:07:53.559738 PROGRESS: ============================= Precursor FDR =============================
+2:07:53.560057 PROGRESS: Total precursors accumulated: 442,047
+2:07:53.560130 PROGRESS: Target precursors: 251,126 (56.81%)
+2:07:53.560183 PROGRESS: Decoy precursors: 190,921 (43.19%)
+2:07:53.560230 PROGRESS: 
+2:07:53.560276 PROGRESS: Precursor Summary:
+2:07:53.563836 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+2:07:53.563973 PROGRESS: 
+2:07:53.564032 PROGRESS: Protein Summary:
+2:07:53.567029 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+2:07:53.567127 PROGRESS: =========================================================================
+2:07:55.017123 INFO: calibration group: precursor, predicting mz
+2:07:55.177324 INFO: calibration group: precursor, predicting rt
+2:07:55.844507 INFO: calibration group: precursor, predicting mobility
+2:07:55.985459 INFO: calibration group: fragment, predicting mz
+2:07:57.252331 INFO: === skipping optimization until target number of precursors are found ===
+2:07:57.252667 PROGRESS: === Optimization of mobility_error has been skipped 5 time(s); maximum number is 1 ===
+2:07:57.252758 INFO: Starting optimization step 5.
+2:07:57.252828 PROGRESS: === Extracting elution groups 504000 to 1016000 ===
+2:07:57.252923 PROGRESS: Extracting batch of 1008477 precursors
+2:07:57.515118 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+2:07:57.515259 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+2:07:57.515322 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+2:07:57.515347 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+2:07:57.519940 INFO: Starting candidate selection
+3:19:07.848990 INFO: Starting candidate scoring
+3:19:30.882062 INFO: Finished candidate processing
+3:19:30.883003 INFO: Collecting candidate features
+3:19:34.189100 WARNING: intensity_correlation has 8870 NaNs ( 0.55 % out of 1605760)
+3:19:34.190666 WARNING: height_correlation has 190 NaNs ( 0.01 % out of 1605760)
+3:19:34.244178 INFO: Collecting fragment features
+3:19:35.140599 INFO: Finished candidate scoring
+3:19:37.694389 PROGRESS: === Extracted 3186301 precursors and 16729805 fragments ===
+3:19:37.999759 INFO: performing precursor FDR with 47 features
+3:19:37.999918 INFO: Decoy channel: -1
+3:19:37.999948 INFO: Competetive: True
+3:19:39.469643 INFO: Setting torch num_threads to 2 for FDR classification task
+3:19:40.082896 WARNING: dropped 8878 target PSMs due to missing features
+3:19:40.083056 WARNING: dropped 8722 decoy PSMs due to missing features
+3:20:39.324523 INFO: Test AUC: 0.543
+3:20:39.324847 INFO: Train AUC: 0.548
+3:20:39.324890 INFO: AUC difference: 0.87%
+3:20:39.647635 INFO: Resetting torch num_threads to 128
+3:20:39.808903 INFO: === FDR correction performed with classifier version 5 ===
+3:20:39.983328 PROGRESS: ============================= Precursor FDR =============================
+3:20:39.983709 PROGRESS: Total precursors accumulated: 891,162
+3:20:39.983793 PROGRESS: Target precursors: 505,948 (56.77%)
+3:20:39.983847 PROGRESS: Decoy precursors: 385,214 (43.23%)
+3:20:39.983898 PROGRESS: 
+3:20:39.983946 PROGRESS: Precursor Summary:
+3:20:39.989108 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+3:20:39.989231 PROGRESS: 
+3:20:39.989288 PROGRESS: Protein Summary:
+3:20:39.993819 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+3:20:39.993933 PROGRESS: =========================================================================
+3:20:41.813332 INFO: calibration group: precursor, predicting mz
+3:20:42.150891 INFO: calibration group: precursor, predicting rt
+3:20:43.435355 INFO: calibration group: precursor, predicting mobility
+3:20:43.726228 INFO: calibration group: fragment, predicting mz
+3:20:46.217619 INFO: === skipping optimization until target number of precursors are found ===
+3:20:46.217949 PROGRESS: === Optimization of mobility_error has been skipped 6 time(s); maximum number is 1 ===
+3:20:46.218030 INFO: Starting optimization step 6.
+3:20:46.218100 PROGRESS: === Extracting elution groups 1016000 to 2040000 ===
+3:20:46.218193 PROGRESS: Extracting batch of 2017059 precursors
+3:20:46.707590 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+3:20:46.707734 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+3:20:46.707785 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+3:20:46.707810 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+3:20:46.708819 INFO: Starting candidate selection
+5:42:18.902237 INFO: Starting candidate scoring
+5:43:05.520154 INFO: Finished candidate processing
+5:43:05.520736 INFO: Collecting candidate features
+5:43:12.054885 WARNING: intensity_correlation has 17757 NaNs ( 0.55 % out of 3211952)
+5:43:12.057824 WARNING: height_correlation has 401 NaNs ( 0.01 % out of 3211952)
+5:43:12.164128 INFO: Collecting fragment features
+5:43:13.970177 INFO: Finished candidate scoring
+5:43:18.076760 PROGRESS: === Extracted 6398253 precursors and 33591196 fragments ===
+5:43:18.707494 INFO: performing precursor FDR with 47 features
+5:43:18.707651 INFO: Decoy channel: -1
+5:43:18.707682 INFO: Competetive: True
+5:43:21.570783 INFO: Setting torch num_threads to 2 for FDR classification task
+5:43:22.975197 WARNING: dropped 18002 target PSMs due to missing features
+5:43:22.975350 WARNING: dropped 17574 decoy PSMs due to missing features
+5:45:44.378172 INFO: Test AUC: 0.548
+5:45:44.378703 INFO: Train AUC: 0.551
+5:45:44.378747 INFO: AUC difference: 0.47%
+5:45:44.896162 INFO: Resetting torch num_threads to 128
+5:45:45.267864 INFO: === FDR correction performed with classifier version 5 ===
+5:45:45.613115 PROGRESS: ============================= Precursor FDR =============================
+5:45:45.613502 PROGRESS: Total precursors accumulated: 1,789,439
+5:45:45.613572 PROGRESS: Target precursors: 1,019,993 (57.00%)
+5:45:45.613646 PROGRESS: Decoy precursors: 769,446 (43.00%)
+5:45:45.613699 PROGRESS: 
+5:45:45.613745 PROGRESS: Precursor Summary:
+5:45:45.622937 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+5:45:45.623115 PROGRESS: 
+5:45:45.623174 PROGRESS: Protein Summary:
+5:45:45.631536 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+5:45:45.631694 PROGRESS: =========================================================================
+5:45:49.152978 INFO: calibration group: precursor, predicting mz
+5:45:49.716976 INFO: calibration group: precursor, predicting rt
+5:45:52.274537 INFO: calibration group: precursor, predicting mobility
+5:45:52.831982 INFO: calibration group: fragment, predicting mz
+5:45:57.820853 INFO: === skipping optimization until target number of precursors are found ===
+5:45:57.821237 PROGRESS: === Optimization of mobility_error has been skipped 7 time(s); maximum number is 1 ===
+5:45:57.821340 INFO: Starting optimization step 7.
+5:45:57.821420 PROGRESS: === Extracting elution groups 2040000 to 4088000 ===
+5:45:57.821523 PROGRESS: Extracting batch of 4034279 precursors
+5:45:59.068232 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+5:45:59.068421 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+5:45:59.068495 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+5:45:59.068528 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+5:45:59.074066 INFO: Starting candidate selection
+10:27:28.114071 INFO: Starting candidate scoring
+10:29:02.017102 INFO: Finished candidate processing
+10:29:02.018110 INFO: Collecting candidate features
+10:29:15.419712 WARNING: intensity_correlation has 35210 NaNs ( 0.55 % out of 6424454)
+10:29:15.426100 WARNING: height_correlation has 807 NaNs ( 0.01 % out of 6424454)
+10:29:15.638309 INFO: Collecting fragment features
+10:29:19.292155 INFO: Finished candidate scoring
+10:29:30.479921 PROGRESS: === Extracted 12822707 precursors and 67325241 fragments ===
+10:29:31.762975 INFO: performing precursor FDR with 47 features
+10:29:31.763112 INFO: Decoy channel: -1
+10:29:31.763140 INFO: Competetive: True
+10:29:36.911824 INFO: Setting torch num_threads to 2 for FDR classification task
+10:29:39.276779 WARNING: dropped 36160 target PSMs due to missing features
+10:29:39.276925 WARNING: dropped 35076 decoy PSMs due to missing features
+10:33:50.961308 INFO: Test AUC: 0.548
+10:33:50.961551 INFO: Train AUC: 0.553
+10:33:50.961592 INFO: AUC difference: 0.96%
+10:33:51.789894 INFO: Resetting torch num_threads to 128
+10:33:52.416725 INFO: === FDR correction performed with classifier version 5 ===
+10:33:53.051484 PROGRESS: ============================= Precursor FDR =============================
+10:33:53.051805 PROGRESS: Total precursors accumulated: 3,586,209
+10:33:53.051872 PROGRESS: Target precursors: 2,036,853 (56.80%)
+10:33:53.051923 PROGRESS: Decoy precursors: 1,549,356 (43.20%)
+10:33:53.051972 PROGRESS: 
+10:33:53.052022 PROGRESS: Precursor Summary:
+10:33:53.070100 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+10:33:53.070367 PROGRESS: 
+10:33:53.070432 PROGRESS: Protein Summary:
+10:33:53.087967 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+10:33:53.088191 PROGRESS: =========================================================================
+10:33:55.133592 INFO: calibration group: precursor, predicting mz
+10:33:55.444574 INFO: calibration group: precursor, predicting rt
+10:33:56.850198 INFO: calibration group: precursor, predicting mobility
+10:33:57.158901 INFO: calibration group: fragment, predicting mz
+10:33:59.916966 INFO: === skipping optimization until target number of precursors are found ===
+10:33:59.917256 PROGRESS: === Optimization of mobility_error has been skipped 8 time(s); maximum number is 1 ===
+10:33:59.917342 INFO: Starting optimization step 8.
+10:33:59.918074 PROGRESS: === Extracting elution groups 4088000 to 5215079 ===
+10:33:59.918162 PROGRESS: Extracting batch of 2220101 precursors
+10:34:00.431594 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+10:34:00.431721 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+10:34:00.431770 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+10:34:00.431794 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+10:34:00.433185 INFO: Starting candidate selection
+13:08:54.923277 INFO: Starting candidate scoring
+13:09:47.501815 INFO: Finished candidate processing
+13:09:47.502527 INFO: Collecting candidate features
+13:09:54.584251 WARNING: intensity_correlation has 19187 NaNs ( 0.54 % out of 3537316)
+13:09:54.587495 WARNING: height_correlation has 474 NaNs ( 0.01 % out of 3537316)
+13:09:54.705083 INFO: Collecting fragment features
+13:09:56.748783 INFO: Finished candidate scoring
+13:10:06.000874 PROGRESS: === Extracted 16360023 precursors and 85888408 fragments ===
+13:10:07.556221 INFO: performing precursor FDR with 47 features
+13:10:07.556359 INFO: Decoy channel: -1
+13:10:07.556392 INFO: Competetive: True
+13:10:14.230803 INFO: Setting torch num_threads to 2 for FDR classification task
+13:10:17.244230 WARNING: dropped 46153 target PSMs due to missing features
+13:10:17.244375 WARNING: dropped 44562 decoy PSMs due to missing features
+13:16:08.569692 INFO: Test AUC: 0.538
+13:16:08.569964 INFO: Train AUC: 0.554
+13:16:08.570015 INFO: AUC difference: 2.98%
+13:16:09.550333 INFO: Resetting torch num_threads to 128
+13:16:10.544191 INFO: === FDR correction performed with classifier version 5 ===
+13:16:11.386899 PROGRESS: ============================= Precursor FDR =============================
+13:16:11.387202 PROGRESS: Total precursors accumulated: 4,575,603
+13:16:11.387269 PROGRESS: Target precursors: 2,598,453 (56.79%)
+13:16:11.387330 PROGRESS: Decoy precursors: 1,977,150 (43.21%)
+13:16:11.387379 PROGRESS: 
+13:16:11.387424 PROGRESS: Precursor Summary:
+13:16:11.410981 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+13:16:11.411250 PROGRESS: 
+13:16:11.411315 PROGRESS: Protein Summary:
+13:16:11.433956 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+13:16:11.434185 PROGRESS: =========================================================================
+13:16:11.535534 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+13:16:11.535851 PROGRESS: ==============================================
+13:16:12.025543 INFO: fragments_df_filtered: 0
+13:16:12.488140 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+13:16:12.488422 WARNING: Using current optimal value for ms2_error: 15.00.
+13:16:12.957860 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+13:16:12.958113 WARNING: Using current optimal value for ms1_error: 10.00.
+13:16:13.419358 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+13:16:13.421469 WARNING: Using current optimal value for rt_error: 2099.93.
+13:16:13.892861 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+13:16:13.894003 WARNING: Using current optimal value for mobility_error: 0.10.
+13:16:13.900912 PROGRESS: ms2_error      : 15.0000
+13:16:13.901131 PROGRESS: ms1_error      : 10.0000
+13:16:13.901196 PROGRESS: rt_error       : 2099.9282
+13:16:13.901247 PROGRESS: mobility_error : 0.1000
+13:16:13.901293 PROGRESS: ==============================================
+13:16:14.166251 INFO: calibration group: precursor, predicting mz
+13:16:15.669114 INFO: calibration group: precursor, predicting rt
+13:16:22.119638 INFO: calibration group: precursor, predicting mobility
+13:16:23.610231 INFO: calibration group: fragment, predicting mz
+13:16:36.110446 PROGRESS: Extracting batch of 10272670 precursors
+13:16:38.524239 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+13:16:38.524372 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+13:16:38.524433 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+13:16:38.524460 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+13:16:38.525644 INFO: Starting candidate selection
+1 day, 1:06:26.819884 INFO: Applying score cutoff of 37.72792678833008
+1 day, 1:06:26.848193 INFO: Removed 17625041 precursors with score below cutoff
+1 day, 1:06:29.292562 INFO: Starting candidate scoring
+1 day, 1:06:34.365007 INFO: Finished candidate processing
+1 day, 1:06:34.366084 INFO: Collecting candidate features
+1 day, 1:06:36.803639 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 250134)
+1 day, 1:06:36.804151 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 250134)
+1 day, 1:06:36.820106 INFO: Collecting fragment features
+1 day, 1:06:37.373019 INFO: Finished candidate scoring
+1 day, 1:06:38.134122 INFO: === FDR correction performed with classifier version 17 ===
+1 day, 1:06:38.135711 INFO: performing precursor FDR with 47 features
+1 day, 1:06:38.135753 INFO: Decoy channel: -1
+1 day, 1:06:38.135786 INFO: Competetive: True
+1 day, 1:06:38.265282 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:06:38.365479 WARNING: dropped 1 target PSMs due to missing features
+1 day, 1:06:38.365697 WARNING: FDR calculation for 132360 target and 117773 decoy PSMs
+1 day, 1:06:38.365738 WARNING: FDR calculation may be inaccurate as there is more than 10% difference in the number of target and decoy PSMs
+1 day, 1:06:43.444875 INFO: Test AUC: 0.548
+1 day, 1:06:43.445075 INFO: Train AUC: 0.568
+1 day, 1:06:43.445110 INFO: AUC difference: 3.49%
+1 day, 1:06:43.551962 INFO: Resetting torch num_threads to 128
+1 day, 1:06:43.565067 INFO: Removing fragments below FDR threshold
+1 day, 1:06:43.737351 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:06:43.737613 PROGRESS: Total precursors accumulated: 22
+1 day, 1:06:43.737679 PROGRESS: Target precursors: 22 (100.00%)
+1 day, 1:06:43.737732 PROGRESS: Decoy precursors: 0 (0.00%)
+1 day, 1:06:43.737790 PROGRESS: 
+1 day, 1:06:43.737843 PROGRESS: Precursor Summary:
+1 day, 1:06:43.738857 PROGRESS: Channel   0:	 0.05 FDR:    22; 0.01 FDR:    22; 0.001 FDR:    22
+1 day, 1:06:43.738947 PROGRESS: 
+1 day, 1:06:43.739002 PROGRESS: Protein Summary:
+1 day, 1:06:43.740082 PROGRESS: Channel   0:	 0.05 FDR:    22; 0.01 FDR:    22; 0.001 FDR:    22
+1 day, 1:06:43.740178 PROGRESS: =========================================================================
+1 day, 1:06:43.759561 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 1:06:44.634658 PROGRESS: Loading raw file 2/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 1:06:44.634818 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+1 day, 1:06:44.634901 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 1:06:44.635923 INFO: Initializing RawFileManager
+1 day, 1:06:44.636053 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:44.636106 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:44.636145 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:44.857958 INFO: Reading 39,128 frames with 2,860,596,893 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.510993 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d...
+1 day, 1:06:53.512442 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.515754 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.515990 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.516342 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.518069 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.533038 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:06:53.533262 INFO: Indexing quadrupole dimension
+1 day, 1:06:54.038338 INFO: Transposing detector events
+1 day, 1:07:02.817459 INFO: Finished transposing data
+1 day, 1:07:02.856778 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 1:07:02.858984 INFO: RT (min)            : 0.0 - 70.0
+1 day, 1:07:02.859082 INFO: RT duration (sec)   : 4199.8
+1 day, 1:07:02.859140 INFO: RT duration (min)   : 70.0
+1 day, 1:07:02.859195 INFO: Cycle len (scans)   : 9
+1 day, 1:07:02.859241 INFO: Cycle len (sec)     : 0.97
+1 day, 1:07:02.859285 INFO: Number of cycles    : 4347
+1 day, 1:07:02.859329 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 1:07:04.148746 INFO: Initializing CalibrationManager
+1 day, 1:07:04.149036 INFO: Loading calibration config
+1 day, 1:07:04.150441 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 1:07:04.150574 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 1:07:04.150699 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 1:07:04.150898 INFO: Initializing OptimizationManager
+1 day, 1:07:04.151052 INFO: initial parameter: ms1_error = 30
+1 day, 1:07:04.151109 INFO: initial parameter: ms2_error = 30
+1 day, 1:07:04.151170 INFO: initial parameter: rt_error = 2099.894844
+1 day, 1:07:04.151220 INFO: initial parameter: mobility_error = 0.1
+1 day, 1:07:04.151267 INFO: initial parameter: column_type = library
+1 day, 1:07:04.151309 INFO: initial parameter: num_candidates = 1
+1 day, 1:07:04.151352 INFO: initial parameter: classifier_version = -1
+1 day, 1:07:04.151393 INFO: initial parameter: fwhm_rt = 5
+1 day, 1:07:04.151435 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 1:07:04.151478 INFO: initial parameter: score_cutoff = 0
+1 day, 1:07:04.151547 INFO: Initializing TimingManager
+1 day, 1:07:04.151609 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 1:07:04.151723 INFO: FDRManager not loaded from disk.
+1 day, 1:07:04.151749 INFO: Initializing FDRManager
+1 day, 1:07:04.151783 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 1:07:05.442800 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+1 day, 1:07:07.300380 PROGRESS: Starting initial search for precursors.
+1 day, 1:07:07.563779 INFO: Starting optimization step 0.
+1 day, 1:07:07.564022 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 1:07:07.564100 PROGRESS: Extracting batch of 15771 precursors
+1 day, 1:07:07.567754 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:07:07.567813 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:07:07.567847 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 1:07:07.567869 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 1:07:07.568953 INFO: Starting candidate selection
+1 day, 1:08:28.569718 INFO: Starting candidate scoring
+1 day, 1:08:29.344234 INFO: Finished candidate processing
+1 day, 1:08:29.344337 INFO: Collecting candidate features
+1 day, 1:08:29.377996 INFO: Collecting fragment features
+1 day, 1:08:29.391760 INFO: Finished candidate scoring
+1 day, 1:08:29.400192 PROGRESS: === Extracted 13798 precursors and 138660 fragments ===
+1 day, 1:08:29.400597 INFO: performing precursor FDR with 47 features
+1 day, 1:08:29.400635 INFO: Decoy channel: -1
+1 day, 1:08:29.400658 INFO: Competetive: True
+1 day, 1:08:29.406198 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:08:29.558410 INFO: Test AUC: 0.498
+1 day, 1:08:29.558531 INFO: Train AUC: 0.507
+1 day, 1:08:29.558565 INFO: AUC difference: 1.80%
+1 day, 1:08:29.645404 INFO: Resetting torch num_threads to 100
+1 day, 1:08:29.646520 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 1:08:29.647943 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:08:29.648055 PROGRESS: Total precursors accumulated: 7,064
+1 day, 1:08:29.648117 PROGRESS: Target precursors: 3,719 (52.65%)
+1 day, 1:08:29.648168 PROGRESS: Decoy precursors: 3,345 (47.35%)
+1 day, 1:08:29.648215 PROGRESS: 
+1 day, 1:08:29.648263 PROGRESS: Precursor Summary:
+1 day, 1:08:29.649171 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 1:08:29.649262 PROGRESS: 
+1 day, 1:08:29.649321 PROGRESS: Protein Summary:
+1 day, 1:08:29.650286 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 1:08:29.650376 PROGRESS: =========================================================================
+1 day, 1:08:29.809812 INFO: Starting optimization step 1.
+1 day, 1:08:29.810074 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 1:08:29.810189 PROGRESS: Extracting batch of 31534 precursors
+1 day, 1:08:29.817285 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:08:29.817364 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:08:29.817401 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 1:08:29.817423 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 1:08:29.818310 INFO: Starting candidate selection
+1 day, 1:11:02.398656 INFO: Starting candidate scoring
+1 day, 1:11:03.895349 INFO: Finished candidate processing
+1 day, 1:11:03.895456 INFO: Collecting candidate features
+1 day, 1:11:03.948931 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 27432)
+1 day, 1:11:03.953120 INFO: Collecting fragment features
+1 day, 1:11:03.974856 INFO: Finished candidate scoring
+1 day, 1:11:04.015870 PROGRESS: === Extracted 41230 precursors and 413491 fragments ===
+1 day, 1:11:04.021157 INFO: performing precursor FDR with 47 features
+1 day, 1:11:04.021221 INFO: Decoy channel: -1
+1 day, 1:11:04.021246 INFO: Competetive: True
+1 day, 1:11:04.042859 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:11:04.050958 WARNING: dropped 4 target PSMs due to missing features
+1 day, 1:11:04.051078 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 1:11:04.558204 INFO: Test AUC: 0.545
+1 day, 1:11:04.558330 INFO: Train AUC: 0.557
+1 day, 1:11:04.558362 INFO: AUC difference: 2.15%
+1 day, 1:11:04.647245 INFO: Resetting torch num_threads to 100
+1 day, 1:11:04.649602 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 1:11:04.652821 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:11:04.652979 PROGRESS: Total precursors accumulated: 21,126
+1 day, 1:11:04.653060 PROGRESS: Target precursors: 12,187 (57.69%)
+1 day, 1:11:04.653119 PROGRESS: Decoy precursors: 8,939 (42.31%)
+1 day, 1:11:04.653169 PROGRESS: 
+1 day, 1:11:04.653218 PROGRESS: Precursor Summary:
+1 day, 1:11:04.654262 PROGRESS: Channel   0:	 0.05 FDR:   137; 0.01 FDR:    49; 0.001 FDR:    49
+1 day, 1:11:04.654356 PROGRESS: 
+1 day, 1:11:04.654413 PROGRESS: Protein Summary:
+1 day, 1:11:04.655504 PROGRESS: Channel   0:	 0.05 FDR:   135; 0.01 FDR:    48; 0.001 FDR:    48
+1 day, 1:11:04.655596 PROGRESS: =========================================================================
+1 day, 1:11:04.859193 INFO: Starting optimization step 2.
+1 day, 1:11:04.859458 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 1:11:04.859540 PROGRESS: Extracting batch of 63016 precursors
+1 day, 1:11:04.875033 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:11:04.875157 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:11:04.875195 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 1:11:04.875217 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 1:11:04.876609 INFO: Starting candidate selection
+1 day, 1:16:06.751732 INFO: Starting candidate scoring
+1 day, 1:16:09.784554 INFO: Finished candidate processing
+1 day, 1:16:09.784730 INFO: Collecting candidate features
+1 day, 1:16:09.912221 WARNING: intensity_correlation has 3 NaNs ( 0.01 % out of 55032)
+1 day, 1:16:09.917479 INFO: Collecting fragment features
+1 day, 1:16:09.960748 INFO: Finished candidate scoring
+1 day, 1:16:10.048288 PROGRESS: === Extracted 96262 precursors and 964952 fragments ===
+1 day, 1:16:10.061786 INFO: performing precursor FDR with 47 features
+1 day, 1:16:10.061915 INFO: Decoy channel: -1
+1 day, 1:16:10.061947 INFO: Competetive: True
+1 day, 1:16:10.112270 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:16:10.136748 WARNING: dropped 6 target PSMs due to missing features
+1 day, 1:16:10.136879 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 1:16:11.819061 INFO: Test AUC: 0.561
+1 day, 1:16:11.819195 INFO: Train AUC: 0.576
+1 day, 1:16:11.819227 INFO: AUC difference: 2.48%
+1 day, 1:16:11.911075 INFO: Resetting torch num_threads to 100
+1 day, 1:16:11.917570 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 1:16:11.927685 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:16:11.927978 PROGRESS: Total precursors accumulated: 49,371
+1 day, 1:16:11.928044 PROGRESS: Target precursors: 29,448 (59.65%)
+1 day, 1:16:11.928096 PROGRESS: Decoy precursors: 19,923 (40.35%)
+1 day, 1:16:11.928147 PROGRESS: 
+1 day, 1:16:11.928195 PROGRESS: Precursor Summary:
+1 day, 1:16:11.929598 PROGRESS: Channel   0:	 0.05 FDR:   500; 0.01 FDR:   355; 0.001 FDR:   264
+1 day, 1:16:11.929701 PROGRESS: 
+1 day, 1:16:11.929760 PROGRESS: Protein Summary:
+1 day, 1:16:11.931180 PROGRESS: Channel   0:	 0.05 FDR:   465; 0.01 FDR:   330; 0.001 FDR:   249
+1 day, 1:16:11.931276 PROGRESS: =========================================================================
+1 day, 1:16:11.945161 INFO: fragments_df_filtered: 3185
+1 day, 1:16:12.170446 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:16:12.211876 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:16:12.254721 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:16:12.297554 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:16:12.463502 INFO: calibration group: precursor, predicting mz
+1 day, 1:16:12.479199 INFO: calibration group: precursor, predicting rt
+1 day, 1:16:12.545442 INFO: calibration group: precursor, predicting mobility
+1 day, 1:16:12.561480 INFO: calibration group: fragment, predicting mz
+1 day, 1:16:12.700697 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 1:16:12.701000 INFO: Starting optimization step 3.
+1 day, 1:16:12.701091 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 1:16:12.701165 PROGRESS: Extracting batch of 110321 precursors
+1 day, 1:16:12.733293 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:16:12.733426 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:16:12.733476 INFO: FWHM in RT is 3.37 seconds, sigma is 0.74
+1 day, 1:16:12.733500 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.08
+1 day, 1:16:12.742331 INFO: Starting candidate selection
+1 day, 1:25:03.302301 INFO: Starting candidate scoring
+1 day, 1:25:13.695481 INFO: Finished candidate processing
+1 day, 1:25:13.696210 INFO: Collecting candidate features
+1 day, 1:25:14.056127 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 189241)
+1 day, 1:25:14.066494 INFO: Collecting fragment features
+1 day, 1:25:14.197193 INFO: Finished candidate scoring
+1 day, 1:25:14.411733 PROGRESS: === Extracted 189241 precursors and 1927635 fragments ===
+1 day, 1:25:14.412343 INFO: performing precursor FDR with 47 features
+1 day, 1:25:14.412384 INFO: Decoy channel: -1
+1 day, 1:25:14.412408 INFO: Competetive: True
+1 day, 1:25:14.483477 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:25:14.516521 WARNING: dropped 1 target PSMs due to missing features
+1 day, 1:25:18.521345 INFO: Test AUC: 0.567
+1 day, 1:25:18.521500 INFO: Train AUC: 0.586
+1 day, 1:25:18.521534 INFO: AUC difference: 3.16%
+1 day, 1:25:18.623981 INFO: Resetting torch num_threads to 100
+1 day, 1:25:18.630870 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 1:25:18.640921 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:25:18.641282 PROGRESS: Total precursors accumulated: 50,242
+1 day, 1:25:18.641349 PROGRESS: Target precursors: 31,520 (62.74%)
+1 day, 1:25:18.641404 PROGRESS: Decoy precursors: 18,722 (37.26%)
+1 day, 1:25:18.641455 PROGRESS: 
+1 day, 1:25:18.641504 PROGRESS: Precursor Summary:
+1 day, 1:25:18.642982 PROGRESS: Channel   0:	 0.05 FDR:   646; 0.01 FDR:   354; 0.001 FDR:   323
+1 day, 1:25:18.643082 PROGRESS: 
+1 day, 1:25:18.643139 PROGRESS: Protein Summary:
+1 day, 1:25:18.644686 PROGRESS: Channel   0:	 0.05 FDR:   601; 0.01 FDR:   327; 0.001 FDR:   297
+1 day, 1:25:18.644782 PROGRESS: =========================================================================
+1 day, 1:25:18.660375 INFO: fragments_df_filtered: 4450
+1 day, 1:25:19.192606 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:25:19.241823 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:25:19.280786 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:25:19.320564 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:25:19.608270 INFO: calibration group: precursor, predicting mz
+1 day, 1:25:19.624424 INFO: calibration group: precursor, predicting rt
+1 day, 1:25:19.691678 INFO: calibration group: precursor, predicting mobility
+1 day, 1:25:19.708488 INFO: calibration group: fragment, predicting mz
+1 day, 1:25:19.841377 INFO: === checking if optimization conditions were reached ===
+1 day, 1:25:19.843596 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 1:25:19.844568 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 1:25:19.844617 INFO: ==============================================
+1 day, 1:25:19.844723 INFO: Starting optimization step 4.
+1 day, 1:25:19.844795 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 1:25:19.844868 PROGRESS: Extracting batch of 110321 precursors
+1 day, 1:25:19.876734 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:25:19.876877 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:25:19.876940 INFO: FWHM in RT is 3.18 seconds, sigma is 0.70
+1 day, 1:25:19.876968 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.01
+1 day, 1:25:19.885641 INFO: Starting candidate selection
+1 day, 1:33:34.153246 INFO: Starting candidate scoring
+1 day, 1:33:39.644168 INFO: Finished candidate processing
+1 day, 1:33:39.644355 INFO: Collecting candidate features
+1 day, 1:33:39.986919 WARNING: intensity_correlation has 11 NaNs ( 0.01 % out of 189057)
+1 day, 1:33:39.987333 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 189057)
+1 day, 1:33:39.997160 INFO: Collecting fragment features
+1 day, 1:33:40.118677 INFO: Finished candidate scoring
+1 day, 1:33:40.204024 PROGRESS: === Extracted 189057 precursors and 1857654 fragments ===
+1 day, 1:33:40.204968 INFO: performing precursor FDR with 47 features
+1 day, 1:33:40.205011 INFO: Decoy channel: -1
+1 day, 1:33:40.205088 INFO: Competetive: True
+1 day, 1:33:40.275669 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:33:40.312258 WARNING: dropped 7 target PSMs due to missing features
+1 day, 1:33:40.312403 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 1:33:43.777351 INFO: Test AUC: 0.558
+1 day, 1:33:43.777491 INFO: Train AUC: 0.587
+1 day, 1:33:43.777521 INFO: AUC difference: 4.95%
+1 day, 1:33:43.874303 INFO: Resetting torch num_threads to 100
+1 day, 1:33:43.880453 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 1:33:43.889597 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:33:43.889904 PROGRESS: Total precursors accumulated: 50,230
+1 day, 1:33:43.889969 PROGRESS: Target precursors: 30,931 (61.58%)
+1 day, 1:33:43.890021 PROGRESS: Decoy precursors: 19,299 (38.42%)
+1 day, 1:33:43.890071 PROGRESS: 
+1 day, 1:33:43.890117 PROGRESS: Precursor Summary:
+1 day, 1:33:43.891645 PROGRESS: Channel   0:	 0.05 FDR:   908; 0.01 FDR:   688; 0.001 FDR:   375
+1 day, 1:33:43.891743 PROGRESS: 
+1 day, 1:33:43.891801 PROGRESS: Protein Summary:
+1 day, 1:33:43.893396 PROGRESS: Channel   0:	 0.05 FDR:   833; 0.01 FDR:   624; 0.001 FDR:   346
+1 day, 1:33:43.893495 PROGRESS: =========================================================================
+1 day, 1:33:43.909707 INFO: fragments_df_filtered: 5000
+1 day, 1:33:44.090229 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:33:44.148200 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:33:44.195070 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:33:44.238852 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:33:44.586013 INFO: calibration group: precursor, predicting mz
+1 day, 1:33:44.593305 INFO: calibration group: precursor, predicting rt
+1 day, 1:33:44.621791 INFO: calibration group: precursor, predicting mobility
+1 day, 1:33:44.628364 INFO: calibration group: fragment, predicting mz
+1 day, 1:33:44.684305 INFO: === checking if optimization conditions were reached ===
+1 day, 1:33:44.686734 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 1:33:44.687940 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 1:33:44.687996 INFO: ==============================================
+1 day, 1:33:44.688127 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 1:33:44.861186 INFO: calibration group: precursor, predicting mz
+1 day, 1:33:44.868461 INFO: calibration group: precursor, predicting rt
+1 day, 1:33:44.897036 INFO: calibration group: precursor, predicting mobility
+1 day, 1:33:44.903609 INFO: calibration group: fragment, predicting mz
+1 day, 1:33:44.955577 INFO: Starting optimization step 0.
+1 day, 1:33:44.955865 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:33:44.955988 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:33:44.974459 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:33:44.974605 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:33:44.974684 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 1:33:44.974715 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.19
+1 day, 1:33:44.983655 INFO: Starting candidate selection
+1 day, 1:37:19.996823 INFO: Starting candidate scoring
+1 day, 1:37:22.597631 INFO: Finished candidate processing
+1 day, 1:37:22.597804 INFO: Collecting candidate features
+1 day, 1:37:22.756747 WARNING: intensity_correlation has 4 NaNs ( 0.00 % out of 81003)
+1 day, 1:37:22.763893 INFO: Collecting fragment features
+1 day, 1:37:22.817103 INFO: Finished candidate scoring
+1 day, 1:37:22.855478 PROGRESS: === Extracted 81003 precursors and 794739 fragments ===
+1 day, 1:37:22.855950 INFO: performing precursor FDR with 47 features
+1 day, 1:37:22.855989 INFO: Decoy channel: -1
+1 day, 1:37:22.856013 INFO: Competetive: True
+1 day, 1:37:22.884290 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:37:22.900390 WARNING: dropped 2 target PSMs due to missing features
+1 day, 1:37:22.900533 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 1:37:24.158684 INFO: Test AUC: 0.564
+1 day, 1:37:24.158820 INFO: Train AUC: 0.607
+1 day, 1:37:24.158850 INFO: AUC difference: 7.12%
+1 day, 1:37:24.158873 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:37:24.247398 INFO: Resetting torch num_threads to 100
+1 day, 1:37:24.250448 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:37:24.254225 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:37:24.254376 PROGRESS: Total precursors accumulated: 21,511
+1 day, 1:37:24.254441 PROGRESS: Target precursors: 13,642 (63.42%)
+1 day, 1:37:24.254493 PROGRESS: Decoy precursors: 7,869 (36.58%)
+1 day, 1:37:24.254542 PROGRESS: 
+1 day, 1:37:24.254589 PROGRESS: Precursor Summary:
+1 day, 1:37:24.255694 PROGRESS: Channel   0:	 0.05 FDR:   427; 0.01 FDR:   326; 0.001 FDR:   163
+1 day, 1:37:24.255790 PROGRESS: 
+1 day, 1:37:24.255848 PROGRESS: Protein Summary:
+1 day, 1:37:24.257100 PROGRESS: Channel   0:	 0.05 FDR:   411; 0.01 FDR:   311; 0.001 FDR:   159
+1 day, 1:37:24.257200 PROGRESS: =========================================================================
+1 day, 1:37:24.290535 INFO: fragments_df_filtered: 3406
+1 day, 1:37:24.460176 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:37:24.500651 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:37:24.538359 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:37:24.577261 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:37:24.760518 INFO: calibration group: precursor, predicting mz
+1 day, 1:37:24.767700 INFO: calibration group: precursor, predicting rt
+1 day, 1:37:24.797010 INFO: calibration group: precursor, predicting mobility
+1 day, 1:37:24.803641 INFO: calibration group: fragment, predicting mz
+1 day, 1:37:24.856565 INFO: === checking if optimization conditions were reached ===
+1 day, 1:37:24.856858 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 1:37:24.858745 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 823.9262.
+1 day, 1:37:24.858803 INFO: ==============================================
+1 day, 1:37:24.858903 INFO: Starting optimization step 1.
+1 day, 1:37:24.858974 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:37:24.859046 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:37:24.872496 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:37:24.872621 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:37:24.872670 INFO: FWHM in RT is 3.00 seconds, sigma is 0.66
+1 day, 1:37:24.872693 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.20
+1 day, 1:37:24.881506 INFO: Starting candidate selection
+1 day, 1:39:05.830101 INFO: Starting candidate scoring
+1 day, 1:39:08.305823 INFO: Finished candidate processing
+1 day, 1:39:08.305939 INFO: Collecting candidate features
+1 day, 1:39:08.443850 WARNING: intensity_correlation has 23 NaNs ( 0.03 % out of 79822)
+1 day, 1:39:08.444177 WARNING: height_correlation has 3 NaNs ( 0.00 % out of 79822)
+1 day, 1:39:08.450417 INFO: Collecting fragment features
+1 day, 1:39:08.507312 INFO: Finished candidate scoring
+1 day, 1:39:08.549477 PROGRESS: === Extracted 79822 precursors and 774234 fragments ===
+1 day, 1:39:08.549973 INFO: performing precursor FDR with 47 features
+1 day, 1:39:08.550012 INFO: Decoy channel: -1
+1 day, 1:39:08.550037 INFO: Competetive: True
+1 day, 1:39:08.582925 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:39:08.602288 WARNING: dropped 8 target PSMs due to missing features
+1 day, 1:39:08.602420 WARNING: dropped 15 decoy PSMs due to missing features
+1 day, 1:39:10.170279 INFO: Test AUC: 0.556
+1 day, 1:39:10.170410 INFO: Train AUC: 0.597
+1 day, 1:39:10.170440 INFO: AUC difference: 7.01%
+1 day, 1:39:10.170461 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:39:10.261607 INFO: Resetting torch num_threads to 100
+1 day, 1:39:10.264898 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:39:10.268979 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:39:10.269136 PROGRESS: Total precursors accumulated: 21,339
+1 day, 1:39:10.269202 PROGRESS: Target precursors: 13,320 (62.42%)
+1 day, 1:39:10.269255 PROGRESS: Decoy precursors: 8,019 (37.58%)
+1 day, 1:39:10.269302 PROGRESS: 
+1 day, 1:39:10.269347 PROGRESS: Precursor Summary:
+1 day, 1:39:10.270525 PROGRESS: Channel   0:	 0.05 FDR:   445; 0.01 FDR:   346; 0.001 FDR:   241
+1 day, 1:39:10.270618 PROGRESS: 
+1 day, 1:39:10.270677 PROGRESS: Protein Summary:
+1 day, 1:39:10.271970 PROGRESS: Channel   0:	 0.05 FDR:   427; 0.01 FDR:   330; 0.001 FDR:   233
+1 day, 1:39:10.272061 PROGRESS: =========================================================================
+1 day, 1:39:10.279824 INFO: fragments_df_filtered: 3533
+1 day, 1:39:10.476846 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:39:10.525686 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:39:11.534267 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:39:11.582042 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:39:11.845605 INFO: calibration group: precursor, predicting mz
+1 day, 1:39:11.853485 INFO: calibration group: precursor, predicting rt
+1 day, 1:39:11.882806 INFO: calibration group: precursor, predicting mobility
+1 day, 1:39:11.889495 INFO: calibration group: fragment, predicting mz
+1 day, 1:39:11.945710 INFO: === checking if optimization conditions were reached ===
+1 day, 1:39:11.946018 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 1:39:11.948567 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 518.1030.
+1 day, 1:39:11.948629 INFO: ==============================================
+1 day, 1:39:11.948751 INFO: Starting optimization step 2.
+1 day, 1:39:11.948828 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:39:11.948900 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:39:11.967072 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:39:11.967190 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:39:11.967240 INFO: FWHM in RT is 2.98 seconds, sigma is 0.65
+1 day, 1:39:11.967263 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.14
+1 day, 1:39:11.976152 INFO: Starting candidate selection
+1 day, 1:40:06.666094 INFO: Starting candidate scoring
+1 day, 1:40:09.163707 INFO: Finished candidate processing
+1 day, 1:40:09.163819 INFO: Collecting candidate features
+1 day, 1:40:09.301202 WARNING: intensity_correlation has 24 NaNs ( 0.03 % out of 78716)
+1 day, 1:40:09.301554 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 78716)
+1 day, 1:40:09.309216 INFO: Collecting fragment features
+1 day, 1:40:09.365187 INFO: Finished candidate scoring
+1 day, 1:40:09.401996 PROGRESS: === Extracted 78716 precursors and 757897 fragments ===
+1 day, 1:40:09.402479 INFO: performing precursor FDR with 47 features
+1 day, 1:40:09.402541 INFO: Decoy channel: -1
+1 day, 1:40:09.402566 INFO: Competetive: True
+1 day, 1:40:09.432089 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:40:09.448872 WARNING: dropped 12 target PSMs due to missing features
+1 day, 1:40:09.448999 WARNING: dropped 12 decoy PSMs due to missing features
+1 day, 1:40:10.728510 INFO: Test AUC: 0.558
+1 day, 1:40:10.728653 INFO: Train AUC: 0.597
+1 day, 1:40:10.728686 INFO: AUC difference: 6.52%
+1 day, 1:40:10.728710 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:40:10.819145 INFO: Resetting torch num_threads to 100
+1 day, 1:40:10.822254 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:40:10.826014 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:40:10.826173 PROGRESS: Total precursors accumulated: 21,121
+1 day, 1:40:10.826237 PROGRESS: Target precursors: 13,097 (62.01%)
+1 day, 1:40:10.826291 PROGRESS: Decoy precursors: 8,024 (37.99%)
+1 day, 1:40:10.826340 PROGRESS: 
+1 day, 1:40:10.826389 PROGRESS: Precursor Summary:
+1 day, 1:40:10.827579 PROGRESS: Channel   0:	 0.05 FDR:   519; 0.01 FDR:   332; 0.001 FDR:   253
+1 day, 1:40:10.827686 PROGRESS: 
+1 day, 1:40:10.827744 PROGRESS: Protein Summary:
+1 day, 1:40:10.829042 PROGRESS: Channel   0:	 0.05 FDR:   497; 0.01 FDR:   317; 0.001 FDR:   244
+1 day, 1:40:10.829148 PROGRESS: =========================================================================
+1 day, 1:40:10.836324 INFO: fragments_df_filtered: 3442
+1 day, 1:40:11.008335 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:40:11.054695 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:40:11.104813 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:40:11.153085 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:40:11.340294 INFO: calibration group: precursor, predicting mz
+1 day, 1:40:11.347751 INFO: calibration group: precursor, predicting rt
+1 day, 1:40:11.376126 INFO: calibration group: precursor, predicting mobility
+1 day, 1:40:11.382888 INFO: calibration group: fragment, predicting mz
+1 day, 1:40:11.437297 INFO: === checking if optimization conditions were reached ===
+1 day, 1:40:11.437581 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 1:40:11.439683 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 380.0282.
+1 day, 1:40:11.439736 INFO: ==============================================
+1 day, 1:40:11.439835 INFO: Starting optimization step 3.
+1 day, 1:40:11.439909 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:40:11.439982 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:40:11.452848 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:40:11.452967 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:40:11.453060 INFO: FWHM in RT is 3.02 seconds, sigma is 0.66
+1 day, 1:40:11.453098 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.14
+1 day, 1:40:11.461987 INFO: Starting candidate selection
+1 day, 1:40:51.935110 INFO: Starting candidate scoring
+1 day, 1:40:54.323905 INFO: Finished candidate processing
+1 day, 1:40:54.324095 INFO: Collecting candidate features
+1 day, 1:40:54.495410 WARNING: intensity_correlation has 37 NaNs ( 0.05 % out of 78382)
+1 day, 1:40:54.495765 WARNING: height_correlation has 3 NaNs ( 0.00 % out of 78382)
+1 day, 1:40:54.502121 INFO: Collecting fragment features
+1 day, 1:40:54.577720 INFO: Finished candidate scoring
+1 day, 1:40:54.620772 PROGRESS: === Extracted 78382 precursors and 750977 fragments ===
+1 day, 1:40:54.621476 INFO: performing precursor FDR with 47 features
+1 day, 1:40:54.621517 INFO: Decoy channel: -1
+1 day, 1:40:54.621543 INFO: Competetive: True
+1 day, 1:40:54.663862 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:40:54.682584 WARNING: dropped 18 target PSMs due to missing features
+1 day, 1:40:54.682727 WARNING: dropped 20 decoy PSMs due to missing features
+1 day, 1:40:56.185932 INFO: Test AUC: 0.551
+1 day, 1:40:56.186089 INFO: Train AUC: 0.592
+1 day, 1:40:56.186121 INFO: AUC difference: 7.02%
+1 day, 1:40:56.186143 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:40:56.282261 INFO: Resetting torch num_threads to 100
+1 day, 1:40:56.285672 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:40:56.290038 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:40:56.290195 PROGRESS: Total precursors accumulated: 21,086
+1 day, 1:40:56.290271 PROGRESS: Target precursors: 12,775 (60.59%)
+1 day, 1:40:56.290326 PROGRESS: Decoy precursors: 8,311 (39.41%)
+1 day, 1:40:56.290374 PROGRESS: 
+1 day, 1:40:56.290418 PROGRESS: Precursor Summary:
+1 day, 1:40:56.291607 PROGRESS: Channel   0:	 0.05 FDR:   456; 0.01 FDR:   333; 0.001 FDR:     0
+1 day, 1:40:56.291707 PROGRESS: 
+1 day, 1:40:56.291765 PROGRESS: Protein Summary:
+1 day, 1:40:56.293066 PROGRESS: Channel   0:	 0.05 FDR:   435; 0.01 FDR:   318; 0.001 FDR:     0
+1 day, 1:40:56.293164 PROGRESS: =========================================================================
+1 day, 1:40:56.300754 INFO: fragments_df_filtered: 3473
+1 day, 1:40:56.811049 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:40:56.859920 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:40:56.913254 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:40:56.964430 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:40:57.223657 INFO: calibration group: precursor, predicting mz
+1 day, 1:40:57.231162 INFO: calibration group: precursor, predicting rt
+1 day, 1:40:57.259646 INFO: calibration group: precursor, predicting mobility
+1 day, 1:40:57.266443 INFO: calibration group: fragment, predicting mz
+1 day, 1:40:57.322632 INFO: === checking if optimization conditions were reached ===
+1 day, 1:40:57.322932 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 1:40:57.325479 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 337.2455.
+1 day, 1:40:57.325536 INFO: ==============================================
+1 day, 1:40:57.325649 INFO: Starting optimization step 4.
+1 day, 1:40:57.325734 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:40:57.325824 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:40:57.340997 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:40:57.341140 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:40:57.341217 INFO: FWHM in RT is 3.04 seconds, sigma is 0.67
+1 day, 1:40:57.341245 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.13
+1 day, 1:40:57.350380 INFO: Starting candidate selection
+1 day, 1:41:33.021588 INFO: Starting candidate scoring
+1 day, 1:41:35.484071 INFO: Finished candidate processing
+1 day, 1:41:35.484281 INFO: Collecting candidate features
+1 day, 1:41:35.636871 WARNING: intensity_correlation has 36 NaNs ( 0.05 % out of 78146)
+1 day, 1:41:35.637205 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 78146)
+1 day, 1:41:35.643285 INFO: Collecting fragment features
+1 day, 1:41:35.698951 INFO: Finished candidate scoring
+1 day, 1:41:35.735062 PROGRESS: === Extracted 78146 precursors and 746871 fragments ===
+1 day, 1:41:35.735571 INFO: performing precursor FDR with 47 features
+1 day, 1:41:35.735611 INFO: Decoy channel: -1
+1 day, 1:41:35.735636 INFO: Competetive: True
+1 day, 1:41:35.764736 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:41:35.781274 WARNING: dropped 21 target PSMs due to missing features
+1 day, 1:41:35.781415 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 1:41:37.189786 INFO: Test AUC: 0.546
+1 day, 1:41:37.189925 INFO: Train AUC: 0.585
+1 day, 1:41:37.189956 INFO: AUC difference: 6.67%
+1 day, 1:41:37.189977 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:41:37.282233 INFO: Resetting torch num_threads to 100
+1 day, 1:41:37.285403 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:41:37.289644 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:41:37.289803 PROGRESS: Total precursors accumulated: 21,043
+1 day, 1:41:37.289868 PROGRESS: Target precursors: 12,762 (60.65%)
+1 day, 1:41:37.289920 PROGRESS: Decoy precursors: 8,281 (39.35%)
+1 day, 1:41:37.289969 PROGRESS: 
+1 day, 1:41:37.290015 PROGRESS: Precursor Summary:
+1 day, 1:41:37.291197 PROGRESS: Channel   0:	 0.05 FDR:   486; 0.01 FDR:   366; 0.001 FDR:   319
+1 day, 1:41:37.291293 PROGRESS: 
+1 day, 1:41:37.291348 PROGRESS: Protein Summary:
+1 day, 1:41:37.292636 PROGRESS: Channel   0:	 0.05 FDR:   468; 0.01 FDR:   351; 0.001 FDR:   306
+1 day, 1:41:37.292739 PROGRESS: =========================================================================
+1 day, 1:41:37.300652 INFO: fragments_df_filtered: 3645
+1 day, 1:41:37.491972 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:41:37.532896 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:41:37.575968 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:41:37.615410 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:41:37.818109 INFO: calibration group: precursor, predicting mz
+1 day, 1:41:37.825316 INFO: calibration group: precursor, predicting rt
+1 day, 1:41:37.853242 INFO: calibration group: precursor, predicting mobility
+1 day, 1:41:37.859874 INFO: calibration group: fragment, predicting mz
+1 day, 1:41:37.914095 INFO: === checking if optimization conditions were reached ===
+1 day, 1:41:37.914408 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 1:41:37.916882 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 347.5745.
+1 day, 1:41:37.916946 INFO: ==============================================
+1 day, 1:41:37.917070 INFO: Starting optimization step 5.
+1 day, 1:41:37.917156 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:41:37.917243 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:41:37.935293 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:41:37.935429 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:41:37.935489 INFO: FWHM in RT is 3.02 seconds, sigma is 0.66
+1 day, 1:41:37.935527 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 1:41:37.944500 INFO: Starting candidate selection
+1 day, 1:42:13.178677 INFO: Starting candidate scoring
+1 day, 1:42:15.596127 INFO: Finished candidate processing
+1 day, 1:42:15.596302 INFO: Collecting candidate features
+1 day, 1:42:15.758022 WARNING: intensity_correlation has 40 NaNs ( 0.05 % out of 78164)
+1 day, 1:42:15.758339 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 78164)
+1 day, 1:42:15.764664 INFO: Collecting fragment features
+1 day, 1:42:15.821599 INFO: Finished candidate scoring
+1 day, 1:42:15.858211 PROGRESS: === Extracted 78164 precursors and 746669 fragments ===
+1 day, 1:42:15.858696 INFO: performing precursor FDR with 47 features
+1 day, 1:42:15.858750 INFO: Decoy channel: -1
+1 day, 1:42:15.858778 INFO: Competetive: True
+1 day, 1:42:15.891990 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:42:15.909466 WARNING: dropped 26 target PSMs due to missing features
+1 day, 1:42:15.909604 WARNING: dropped 16 decoy PSMs due to missing features
+1 day, 1:42:17.316033 INFO: Test AUC: 0.548
+1 day, 1:42:17.316173 INFO: Train AUC: 0.595
+1 day, 1:42:17.316204 INFO: AUC difference: 7.96%
+1 day, 1:42:17.316225 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:42:17.407295 INFO: Resetting torch num_threads to 100
+1 day, 1:42:17.410278 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 1:42:17.414194 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:42:17.414340 PROGRESS: Total precursors accumulated: 21,050
+1 day, 1:42:17.414405 PROGRESS: Target precursors: 12,900 (61.28%)
+1 day, 1:42:17.414458 PROGRESS: Decoy precursors: 8,150 (38.72%)
+1 day, 1:42:17.414507 PROGRESS: 
+1 day, 1:42:17.414554 PROGRESS: Precursor Summary:
+1 day, 1:42:17.415739 PROGRESS: Channel   0:	 0.05 FDR:   448; 0.01 FDR:   349; 0.001 FDR:   271
+1 day, 1:42:17.415849 PROGRESS: 
+1 day, 1:42:17.415906 PROGRESS: Protein Summary:
+1 day, 1:42:17.417207 PROGRESS: Channel   0:	 0.05 FDR:   430; 0.01 FDR:   334; 0.001 FDR:   261
+1 day, 1:42:17.417300 PROGRESS: =========================================================================
+1 day, 1:42:17.425318 INFO: fragments_df_filtered: 3572
+1 day, 1:42:17.597734 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:42:17.645982 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:42:17.698230 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:42:17.747763 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:42:18.014642 INFO: calibration group: precursor, predicting mz
+1 day, 1:42:18.022253 INFO: calibration group: precursor, predicting rt
+1 day, 1:42:18.050701 INFO: calibration group: precursor, predicting mobility
+1 day, 1:42:18.057549 INFO: calibration group: fragment, predicting mz
+1 day, 1:42:18.111580 INFO: === checking if optimization conditions were reached ===
+1 day, 1:42:18.111893 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 1:42:18.113412 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 337.2455 found after 6 searches.
+1 day, 1:42:18.113474 INFO: ==============================================
+1 day, 1:42:18.113596 PROGRESS: Optimization finished for rt_error.
+1 day, 1:42:18.278795 INFO: calibration group: precursor, predicting mz
+1 day, 1:42:18.286644 INFO: calibration group: precursor, predicting rt
+1 day, 1:42:18.315283 INFO: calibration group: precursor, predicting mobility
+1 day, 1:42:18.322077 INFO: calibration group: fragment, predicting mz
+1 day, 1:42:18.402932 INFO: Starting optimization step 0.
+1 day, 1:42:18.403171 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:42:18.403260 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:42:18.416943 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:42:18.417060 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:42:18.417121 INFO: FWHM in RT is 3.02 seconds, sigma is 0.66
+1 day, 1:42:18.417152 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 1:42:18.425946 INFO: Starting candidate selection
+1 day, 1:42:54.860210 INFO: Starting candidate scoring
+1 day, 1:42:57.324422 INFO: Finished candidate processing
+1 day, 1:42:57.324527 INFO: Collecting candidate features
+1 day, 1:42:57.481662 WARNING: intensity_correlation has 37 NaNs ( 0.05 % out of 78150)
+1 day, 1:42:57.482189 WARNING: height_correlation has 4 NaNs ( 0.01 % out of 78150)
+1 day, 1:42:57.495326 INFO: Collecting fragment features
+1 day, 1:42:57.550916 INFO: Finished candidate scoring
+1 day, 1:42:57.590486 PROGRESS: === Extracted 78150 precursors and 746286 fragments ===
+1 day, 1:42:57.590968 INFO: performing precursor FDR with 47 features
+1 day, 1:42:57.591006 INFO: Decoy channel: -1
+1 day, 1:42:57.591028 INFO: Competetive: True
+1 day, 1:42:57.616777 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:42:57.631756 WARNING: dropped 22 target PSMs due to missing features
+1 day, 1:42:57.631884 WARNING: dropped 16 decoy PSMs due to missing features
+1 day, 1:42:58.826119 INFO: Test AUC: 0.572
+1 day, 1:42:58.826243 INFO: Train AUC: 0.611
+1 day, 1:42:58.826272 INFO: AUC difference: 6.36%
+1 day, 1:42:58.826293 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:42:58.917226 INFO: Resetting torch num_threads to 100
+1 day, 1:42:58.919756 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 1:42:58.923318 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:42:58.923457 PROGRESS: Total precursors accumulated: 21,046
+1 day, 1:42:58.923536 PROGRESS: Target precursors: 13,390 (63.62%)
+1 day, 1:42:58.923589 PROGRESS: Decoy precursors: 7,656 (36.38%)
+1 day, 1:42:58.923635 PROGRESS: 
+1 day, 1:42:58.923679 PROGRESS: Precursor Summary:
+1 day, 1:42:58.924828 PROGRESS: Channel   0:	 0.05 FDR:   520; 0.01 FDR:   319; 0.001 FDR:   284
+1 day, 1:42:58.924925 PROGRESS: 
+1 day, 1:42:58.924985 PROGRESS: Protein Summary:
+1 day, 1:42:58.926300 PROGRESS: Channel   0:	 0.05 FDR:   499; 0.01 FDR:   305; 0.001 FDR:   273
+1 day, 1:42:58.926394 PROGRESS: =========================================================================
+1 day, 1:42:58.933696 INFO: fragments_df_filtered: 3310
+1 day, 1:42:59.101474 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:42:59.152798 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:42:59.194051 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:42:59.231876 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:42:59.409806 INFO: calibration group: precursor, predicting mz
+1 day, 1:42:59.417966 INFO: calibration group: precursor, predicting rt
+1 day, 1:42:59.446440 INFO: calibration group: precursor, predicting mobility
+1 day, 1:42:59.453419 INFO: calibration group: fragment, predicting mz
+1 day, 1:42:59.509118 INFO: === checking if optimization conditions were reached ===
+1 day, 1:42:59.509450 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 1:42:59.511424 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0869.
+1 day, 1:42:59.511479 INFO: ==============================================
+1 day, 1:42:59.511588 INFO: Starting optimization step 1.
+1 day, 1:42:59.511675 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:42:59.511771 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:42:59.527876 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:42:59.528005 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:42:59.528080 INFO: FWHM in RT is 3.07 seconds, sigma is 0.67
+1 day, 1:42:59.528107 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1 day, 1:42:59.536977 INFO: Starting candidate selection
+1 day, 1:43:29.491840 INFO: Starting candidate scoring
+1 day, 1:43:31.891628 INFO: Finished candidate processing
+1 day, 1:43:31.891798 INFO: Collecting candidate features
+1 day, 1:43:32.045994 WARNING: intensity_correlation has 32 NaNs ( 0.04 % out of 77479)
+1 day, 1:43:32.046315 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 77479)
+1 day, 1:43:32.052404 INFO: Collecting fragment features
+1 day, 1:43:32.102030 INFO: Finished candidate scoring
+1 day, 1:43:32.146395 PROGRESS: === Extracted 77479 precursors and 738454 fragments ===
+1 day, 1:43:32.146826 INFO: performing precursor FDR with 47 features
+1 day, 1:43:32.146865 INFO: Decoy channel: -1
+1 day, 1:43:32.146892 INFO: Competetive: True
+1 day, 1:43:32.173994 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:43:32.188769 WARNING: dropped 20 target PSMs due to missing features
+1 day, 1:43:32.188898 WARNING: dropped 14 decoy PSMs due to missing features
+1 day, 1:43:33.412838 INFO: Test AUC: 0.562
+1 day, 1:43:33.412961 INFO: Train AUC: 0.600
+1 day, 1:43:33.412991 INFO: AUC difference: 6.27%
+1 day, 1:43:33.413013 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:43:33.500075 INFO: Resetting torch num_threads to 100
+1 day, 1:43:33.502806 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 1:43:33.506542 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:43:33.506696 PROGRESS: Total precursors accumulated: 20,899
+1 day, 1:43:33.506772 PROGRESS: Target precursors: 13,080 (62.59%)
+1 day, 1:43:33.506837 PROGRESS: Decoy precursors: 7,819 (37.41%)
+1 day, 1:43:33.506898 PROGRESS: 
+1 day, 1:43:33.506956 PROGRESS: Precursor Summary:
+1 day, 1:43:33.508123 PROGRESS: Channel   0:	 0.05 FDR:   502; 0.01 FDR:   335; 0.001 FDR:   236
+1 day, 1:43:33.508227 PROGRESS: 
+1 day, 1:43:33.508294 PROGRESS: Protein Summary:
+1 day, 1:43:33.509638 PROGRESS: Channel   0:	 0.05 FDR:   481; 0.01 FDR:   322; 0.001 FDR:   228
+1 day, 1:43:33.509743 PROGRESS: =========================================================================
+1 day, 1:43:33.516958 INFO: fragments_df_filtered: 3388
+1 day, 1:43:33.684221 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:43:33.729421 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:43:33.781091 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:43:33.831329 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:43:34.080548 INFO: calibration group: precursor, predicting mz
+1 day, 1:43:34.088078 INFO: calibration group: precursor, predicting rt
+1 day, 1:43:34.116060 INFO: calibration group: precursor, predicting mobility
+1 day, 1:43:34.122843 INFO: calibration group: fragment, predicting mz
+1 day, 1:43:34.174574 INFO: === checking if optimization conditions were reached ===
+1 day, 1:43:34.174867 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 1:43:34.176683 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0655.
+1 day, 1:43:34.176743 INFO: ==============================================
+1 day, 1:43:34.176855 INFO: Starting optimization step 2.
+1 day, 1:43:34.176934 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:43:34.177018 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:43:34.188480 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:43:34.188587 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:43:34.188648 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 1:43:34.188679 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.15
+1 day, 1:43:34.197422 INFO: Starting candidate selection
+1 day, 1:43:56.939150 INFO: Starting candidate scoring
+1 day, 1:43:59.301059 INFO: Finished candidate processing
+1 day, 1:43:59.301192 INFO: Collecting candidate features
+1 day, 1:43:59.479430 WARNING: intensity_correlation has 32 NaNs ( 0.04 % out of 75879)
+1 day, 1:43:59.479734 WARNING: height_correlation has 9 NaNs ( 0.01 % out of 75879)
+1 day, 1:43:59.485777 INFO: Collecting fragment features
+1 day, 1:43:59.534829 INFO: Finished candidate scoring
+1 day, 1:43:59.585652 PROGRESS: === Extracted 75879 precursors and 718384 fragments ===
+1 day, 1:43:59.586121 INFO: performing precursor FDR with 47 features
+1 day, 1:43:59.586159 INFO: Decoy channel: -1
+1 day, 1:43:59.586184 INFO: Competetive: True
+1 day, 1:43:59.609620 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:43:59.624380 WARNING: dropped 18 target PSMs due to missing features
+1 day, 1:43:59.624504 WARNING: dropped 18 decoy PSMs due to missing features
+1 day, 1:44:00.848303 INFO: Test AUC: 0.558
+1 day, 1:44:00.848488 INFO: Train AUC: 0.608
+1 day, 1:44:00.848521 INFO: AUC difference: 8.13%
+1 day, 1:44:00.848544 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:44:01.804227 INFO: Resetting torch num_threads to 100
+1 day, 1:44:01.806788 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 1:44:01.811034 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:44:01.811177 PROGRESS: Total precursors accumulated: 20,521
+1 day, 1:44:01.811249 PROGRESS: Target precursors: 12,699 (61.88%)
+1 day, 1:44:01.811302 PROGRESS: Decoy precursors: 7,822 (38.12%)
+1 day, 1:44:01.811351 PROGRESS: 
+1 day, 1:44:01.811396 PROGRESS: Precursor Summary:
+1 day, 1:44:01.812603 PROGRESS: Channel   0:	 0.05 FDR:   532; 0.01 FDR:   353; 0.001 FDR:   260
+1 day, 1:44:01.812704 PROGRESS: 
+1 day, 1:44:01.812767 PROGRESS: Protein Summary:
+1 day, 1:44:01.814092 PROGRESS: Channel   0:	 0.05 FDR:   511; 0.01 FDR:   338; 0.001 FDR:   252
+1 day, 1:44:01.814197 PROGRESS: =========================================================================
+1 day, 1:44:01.823981 INFO: fragments_df_filtered: 3575
+1 day, 1:44:01.997235 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:44:02.043897 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:44:02.095565 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:44:02.143358 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:44:02.409846 INFO: calibration group: precursor, predicting mz
+1 day, 1:44:02.417338 INFO: calibration group: precursor, predicting rt
+1 day, 1:44:02.445693 INFO: calibration group: precursor, predicting mobility
+1 day, 1:44:02.452688 INFO: calibration group: fragment, predicting mz
+1 day, 1:44:02.507494 INFO: === checking if optimization conditions were reached ===
+1 day, 1:44:02.507747 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 1:44:02.509571 PROGRESS: ❌ mobility_error : optimization incomplete after 3 search(es). Will search with parameter 0.0552.
+1 day, 1:44:02.509627 INFO: ==============================================
+1 day, 1:44:02.509720 INFO: Starting optimization step 3.
+1 day, 1:44:02.509785 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:44:02.509843 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:44:02.522814 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:44:02.522922 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:44:02.522978 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 1:44:02.523002 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.15
+1 day, 1:44:02.531937 INFO: Starting candidate selection
+1 day, 1:44:21.950231 INFO: Starting candidate scoring
+1 day, 1:44:24.348661 INFO: Finished candidate processing
+1 day, 1:44:24.348766 INFO: Collecting candidate features
+1 day, 1:44:24.471056 WARNING: intensity_correlation has 35 NaNs ( 0.05 % out of 75038)
+1 day, 1:44:24.471348 WARNING: height_correlation has 8 NaNs ( 0.01 % out of 75038)
+1 day, 1:44:24.477239 INFO: Collecting fragment features
+1 day, 1:44:24.528026 INFO: Finished candidate scoring
+1 day, 1:44:24.562858 PROGRESS: === Extracted 75038 precursors and 707202 fragments ===
+1 day, 1:44:24.563257 INFO: performing precursor FDR with 47 features
+1 day, 1:44:24.563295 INFO: Decoy channel: -1
+1 day, 1:44:24.563317 INFO: Competetive: True
+1 day, 1:44:24.584832 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:44:24.599190 WARNING: dropped 18 target PSMs due to missing features
+1 day, 1:44:24.599322 WARNING: dropped 21 decoy PSMs due to missing features
+1 day, 1:44:25.705868 INFO: Test AUC: 0.555
+1 day, 1:44:25.705998 INFO: Train AUC: 0.610
+1 day, 1:44:25.706029 INFO: AUC difference: 9.08%
+1 day, 1:44:25.706051 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:44:25.792881 INFO: Resetting torch num_threads to 100
+1 day, 1:44:25.795427 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 1:44:25.798751 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:44:25.798894 PROGRESS: Total precursors accumulated: 20,329
+1 day, 1:44:25.798968 PROGRESS: Target precursors: 12,778 (62.86%)
+1 day, 1:44:25.799021 PROGRESS: Decoy precursors: 7,551 (37.14%)
+1 day, 1:44:25.799069 PROGRESS: 
+1 day, 1:44:25.799113 PROGRESS: Precursor Summary:
+1 day, 1:44:25.800267 PROGRESS: Channel   0:	 0.05 FDR:   465; 0.01 FDR:   361; 0.001 FDR:   295
+1 day, 1:44:25.800703 PROGRESS: 
+1 day, 1:44:25.800764 PROGRESS: Protein Summary:
+1 day, 1:44:25.802064 PROGRESS: Channel   0:	 0.05 FDR:   449; 0.01 FDR:   348; 0.001 FDR:   286
+1 day, 1:44:25.802160 PROGRESS: =========================================================================
+1 day, 1:44:25.809230 INFO: fragments_df_filtered: 3575
+1 day, 1:44:25.974584 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:44:26.022135 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:44:26.062487 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:44:26.098007 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:44:26.296582 INFO: calibration group: precursor, predicting mz
+1 day, 1:44:26.304273 INFO: calibration group: precursor, predicting rt
+1 day, 1:44:26.335050 INFO: calibration group: precursor, predicting mobility
+1 day, 1:44:26.342085 INFO: calibration group: fragment, predicting mz
+1 day, 1:44:26.396200 INFO: === checking if optimization conditions were reached ===
+1 day, 1:44:26.396486 PROGRESS: === Optimization of mobility_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 1:44:26.398653 PROGRESS: ❌ mobility_error : optimization incomplete after 4 search(es). Will search with parameter 0.0472.
+1 day, 1:44:26.398715 INFO: ==============================================
+1 day, 1:44:26.398818 INFO: Starting optimization step 4.
+1 day, 1:44:26.398890 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 1:44:26.398957 PROGRESS: Extracting batch of 47305 precursors
+1 day, 1:44:26.414967 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:44:26.415150 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:44:26.415251 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 1:44:26.415313 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.14
+1 day, 1:44:26.440416 INFO: Starting candidate selection
+1 day, 1:44:43.362312 INFO: Starting candidate scoring
+1 day, 1:44:45.755904 INFO: Finished candidate processing
+1 day, 1:44:45.756098 INFO: Collecting candidate features
+1 day, 1:44:45.923101 WARNING: intensity_correlation has 32 NaNs ( 0.04 % out of 74190)
+1 day, 1:44:45.923475 WARNING: height_correlation has 6 NaNs ( 0.01 % out of 74190)
+1 day, 1:44:45.931390 INFO: Collecting fragment features
+1 day, 1:44:45.981774 INFO: Finished candidate scoring
+1 day, 1:44:46.022688 PROGRESS: === Extracted 74190 precursors and 695272 fragments ===
+1 day, 1:44:46.023166 INFO: performing precursor FDR with 47 features
+1 day, 1:44:46.023229 INFO: Decoy channel: -1
+1 day, 1:44:46.023252 INFO: Competetive: True
+1 day, 1:44:46.053176 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 1:44:46.071937 WARNING: dropped 19 target PSMs due to missing features
+1 day, 1:44:46.072089 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 1:44:47.466031 INFO: Test AUC: 0.551
+1 day, 1:44:47.466198 INFO: Train AUC: 0.608
+1 day, 1:44:47.466230 INFO: AUC difference: 9.42%
+1 day, 1:44:47.466253 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 1:44:47.561101 INFO: Resetting torch num_threads to 100
+1 day, 1:44:47.567058 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 1:44:47.571500 PROGRESS: ============================= Precursor FDR =============================
+1 day, 1:44:47.571673 PROGRESS: Total precursors accumulated: 20,130
+1 day, 1:44:47.571739 PROGRESS: Target precursors: 12,582 (62.50%)
+1 day, 1:44:47.571792 PROGRESS: Decoy precursors: 7,548 (37.50%)
+1 day, 1:44:47.571841 PROGRESS: 
+1 day, 1:44:47.571885 PROGRESS: Precursor Summary:
+1 day, 1:44:47.573146 PROGRESS: Channel   0:	 0.05 FDR:   522; 0.01 FDR:   345; 0.001 FDR:   292
+1 day, 1:44:47.573260 PROGRESS: 
+1 day, 1:44:47.573317 PROGRESS: Protein Summary:
+1 day, 1:44:47.574641 PROGRESS: Channel   0:	 0.05 FDR:   505; 0.01 FDR:   331; 0.001 FDR:   280
+1 day, 1:44:47.574736 PROGRESS: =========================================================================
+1 day, 1:44:47.582315 INFO: fragments_df_filtered: 3488
+1 day, 1:44:48.017382 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 1:44:48.059030 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 1:44:48.103027 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 1:44:48.147646 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 1:44:48.349532 INFO: calibration group: precursor, predicting mz
+1 day, 1:44:48.358721 INFO: calibration group: precursor, predicting rt
+1 day, 1:44:48.387559 INFO: calibration group: precursor, predicting mobility
+1 day, 1:44:48.394340 INFO: calibration group: fragment, predicting mz
+1 day, 1:44:48.450727 INFO: === checking if optimization conditions were reached ===
+1 day, 1:44:48.451146 PROGRESS: === Optimization of mobility_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 1:44:48.452591 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0552 found after 5 searches.
+1 day, 1:44:48.452657 INFO: ==============================================
+1 day, 1:44:48.452793 PROGRESS: Optimization finished for mobility_error.
+1 day, 1:44:48.854022 INFO: calibration group: precursor, predicting mz
+1 day, 1:44:48.864244 INFO: calibration group: precursor, predicting rt
+1 day, 1:44:48.893266 INFO: calibration group: precursor, predicting mobility
+1 day, 1:44:48.900164 INFO: calibration group: fragment, predicting mz
+1 day, 1:44:48.991137 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 1:44:48.992218 PROGRESS: ==============================================
+1 day, 1:44:48.992300 PROGRESS: ms2_error      : 15.0000
+1 day, 1:44:48.992364 PROGRESS: ms1_error      : 10.0000
+1 day, 1:44:48.992420 PROGRESS: rt_error       : 337.2455
+1 day, 1:44:48.992469 PROGRESS: mobility_error : 0.0552
+1 day, 1:44:48.992515 PROGRESS: ==============================================
+1 day, 1:44:48.995860 INFO: calibration group: precursor, predicting mz
+1 day, 1:44:50.475921 INFO: calibration group: precursor, predicting rt
+1 day, 1:44:56.882426 INFO: calibration group: precursor, predicting mobility
+1 day, 1:44:58.306406 INFO: calibration group: fragment, predicting mz
+1 day, 1:45:10.901245 PROGRESS: Extracting batch of 10272670 precursors
+1 day, 1:45:13.434195 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 1:45:13.434339 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 1:45:13.434395 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 1:45:13.434424 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.14
+1 day, 1:45:13.435772 INFO: Starting candidate selection
+1 day, 2:50:32.984135 INFO: Applying score cutoff of 30.928431854248046
+1 day, 2:50:33.450665 INFO: Removed 3994143 precursors with score below cutoff
+1 day, 2:50:36.451672 INFO: Starting candidate scoring
+1 day, 2:56:54.131408 INFO: Finished candidate processing
+1 day, 2:56:54.131826 INFO: Collecting candidate features
+1 day, 2:57:17.770659 WARNING: intensity_correlation has 27 NaNs ( 0.00 % out of 13187751)
+1 day, 2:57:18.217708 INFO: Collecting fragment features
+1 day, 2:57:27.511107 INFO: Finished candidate scoring
+1 day, 2:57:39.545234 INFO: === FDR correction performed with classifier version 14 ===
+1 day, 2:57:39.552114 INFO: performing precursor FDR with 47 features
+1 day, 2:57:39.552194 INFO: Decoy channel: -1
+1 day, 2:57:39.552222 INFO: Competetive: True
+1 day, 2:57:43.067622 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 2:57:45.244787 WARNING: dropped 9 target PSMs due to missing features
+1 day, 2:57:45.244949 WARNING: dropped 18 decoy PSMs due to missing features
+1 day, 3:02:23.097534 INFO: Test AUC: 0.564
+1 day, 3:02:23.097813 INFO: Train AUC: 0.573
+1 day, 3:02:23.097870 INFO: AUC difference: 1.55%
+1 day, 3:02:23.950665 INFO: Resetting torch num_threads to 100
+1 day, 3:02:24.267488 INFO: Removing fragments below FDR threshold
+1 day, 3:02:25.214689 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:02:25.215037 PROGRESS: Total precursors accumulated: 74,760
+1 day, 3:02:25.215105 PROGRESS: Target precursors: 74,020 (99.01%)
+1 day, 3:02:25.215162 PROGRESS: Decoy precursors: 740 (0.99%)
+1 day, 3:02:25.215213 PROGRESS: 
+1 day, 3:02:25.215261 PROGRESS: Precursor Summary:
+1 day, 3:02:25.244607 PROGRESS: Channel   0:	 0.05 FDR: 74,020; 0.01 FDR: 74,020; 0.001 FDR: 53,225
+1 day, 3:02:25.244902 PROGRESS: 
+1 day, 3:02:25.244971 PROGRESS: Protein Summary:
+1 day, 3:02:25.290147 PROGRESS: Channel   0:	 0.05 FDR: 11,487; 0.01 FDR: 11,487; 0.001 FDR: 9,015
+1 day, 3:02:25.290431 PROGRESS: =========================================================================
+1 day, 3:02:25.953989 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 3:02:26.387246 PROGRESS: Loading raw file 3/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 3:02:26.387441 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+1 day, 3:02:26.387538 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 3:02:26.388282 INFO: Initializing RawFileManager
+1 day, 3:02:26.388438 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:26.388517 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:26.388580 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:26.611107 INFO: Reading 39,128 frames with 2,897,842,446 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.889735 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d...
+1 day, 3:02:35.891165 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.893280 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.893534 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.893908 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.895299 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.910779 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:35.911022 INFO: Indexing quadrupole dimension
+1 day, 3:02:36.414557 INFO: Transposing detector events
+1 day, 3:02:46.222103 INFO: Finished transposing data
+1 day, 3:02:46.261180 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 3:02:46.262326 INFO: RT (min)            : 0.0 - 70.0
+1 day, 3:02:46.262418 INFO: RT duration (sec)   : 4199.8
+1 day, 3:02:46.262471 INFO: RT duration (min)   : 70.0
+1 day, 3:02:46.262519 INFO: Cycle len (scans)   : 9
+1 day, 3:02:46.262565 INFO: Cycle len (sec)     : 0.97
+1 day, 3:02:46.262609 INFO: Number of cycles    : 4347
+1 day, 3:02:46.262655 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 3:02:47.531200 INFO: Initializing CalibrationManager
+1 day, 3:02:47.531597 INFO: Loading calibration config
+1 day, 3:02:47.532354 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 3:02:47.532467 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 3:02:47.532585 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 3:02:47.532796 INFO: Initializing OptimizationManager
+1 day, 3:02:47.532936 INFO: initial parameter: ms1_error = 30
+1 day, 3:02:47.532992 INFO: initial parameter: ms2_error = 30
+1 day, 3:02:47.533067 INFO: initial parameter: rt_error = 2099.8992935
+1 day, 3:02:47.533129 INFO: initial parameter: mobility_error = 0.1
+1 day, 3:02:47.533177 INFO: initial parameter: column_type = library
+1 day, 3:02:47.533224 INFO: initial parameter: num_candidates = 1
+1 day, 3:02:47.533267 INFO: initial parameter: classifier_version = -1
+1 day, 3:02:47.533309 INFO: initial parameter: fwhm_rt = 5
+1 day, 3:02:47.533353 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 3:02:47.533395 INFO: initial parameter: score_cutoff = 0
+1 day, 3:02:47.533466 INFO: Initializing TimingManager
+1 day, 3:02:47.533547 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 3:02:47.533679 INFO: FDRManager not loaded from disk.
+1 day, 3:02:47.533707 INFO: Initializing FDRManager
+1 day, 3:02:47.533761 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 3:02:48.956459 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+1 day, 3:02:50.808788 PROGRESS: Starting initial search for precursors.
+1 day, 3:02:51.061202 INFO: Starting optimization step 0.
+1 day, 3:02:51.061476 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 3:02:51.061567 PROGRESS: Extracting batch of 15771 precursors
+1 day, 3:02:51.066211 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:02:51.066268 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:02:51.066307 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 3:02:51.066331 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 3:02:51.067415 INFO: Starting candidate selection
+1 day, 3:04:09.955090 INFO: Starting candidate scoring
+1 day, 3:04:10.746943 INFO: Finished candidate processing
+1 day, 3:04:10.747129 INFO: Collecting candidate features
+1 day, 3:04:10.780493 WARNING: intensity_correlation has 3 NaNs ( 0.02 % out of 13798)
+1 day, 3:04:10.784214 INFO: Collecting fragment features
+1 day, 3:04:10.798366 INFO: Finished candidate scoring
+1 day, 3:04:10.807191 PROGRESS: === Extracted 13798 precursors and 138685 fragments ===
+1 day, 3:04:10.807644 INFO: performing precursor FDR with 47 features
+1 day, 3:04:10.807683 INFO: Decoy channel: -1
+1 day, 3:04:10.807709 INFO: Competetive: True
+1 day, 3:04:10.815042 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:04:10.818130 WARNING: dropped 2 target PSMs due to missing features
+1 day, 3:04:10.818188 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 3:04:10.962376 INFO: Test AUC: 0.526
+1 day, 3:04:10.962511 INFO: Train AUC: 0.540
+1 day, 3:04:10.962548 INFO: AUC difference: 2.54%
+1 day, 3:04:11.053252 INFO: Resetting torch num_threads to 100
+1 day, 3:04:11.054731 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 3:04:11.056532 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:04:11.056646 PROGRESS: Total precursors accumulated: 7,068
+1 day, 3:04:11.056709 PROGRESS: Target precursors: 4,011 (56.75%)
+1 day, 3:04:11.056775 PROGRESS: Decoy precursors: 3,057 (43.25%)
+1 day, 3:04:11.056824 PROGRESS: 
+1 day, 3:04:11.056872 PROGRESS: Precursor Summary:
+1 day, 3:04:11.057793 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 3:04:11.057887 PROGRESS: 
+1 day, 3:04:11.057944 PROGRESS: Protein Summary:
+1 day, 3:04:11.058888 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 3:04:11.058978 PROGRESS: =========================================================================
+1 day, 3:04:11.561580 INFO: Starting optimization step 1.
+1 day, 3:04:11.561885 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 3:04:11.561983 PROGRESS: Extracting batch of 31534 precursors
+1 day, 3:04:11.573162 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:04:11.573254 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:04:11.573293 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 3:04:11.573318 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 3:04:11.574797 INFO: Starting candidate selection
+1 day, 3:06:43.469784 INFO: Starting candidate scoring
+1 day, 3:06:44.971563 INFO: Finished candidate processing
+1 day, 3:06:44.971750 INFO: Collecting candidate features
+1 day, 3:06:45.055761 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 27442)
+1 day, 3:06:45.056042 WARNING: height_correlation has 2 NaNs ( 0.01 % out of 27442)
+1 day, 3:06:45.059855 INFO: Collecting fragment features
+1 day, 3:06:45.079904 INFO: Finished candidate scoring
+1 day, 3:06:45.121184 PROGRESS: === Extracted 41240 precursors and 413448 fragments ===
+1 day, 3:06:45.127169 INFO: performing precursor FDR with 47 features
+1 day, 3:06:45.127268 INFO: Decoy channel: -1
+1 day, 3:06:45.127296 INFO: Competetive: True
+1 day, 3:06:45.151298 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:06:45.161169 WARNING: dropped 4 target PSMs due to missing features
+1 day, 3:06:45.161312 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 3:06:45.887953 INFO: Test AUC: 0.560
+1 day, 3:06:45.888104 INFO: Train AUC: 0.576
+1 day, 3:06:45.888137 INFO: AUC difference: 2.84%
+1 day, 3:06:45.979357 INFO: Resetting torch num_threads to 100
+1 day, 3:06:45.982557 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 3:06:45.985811 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:06:45.985965 PROGRESS: Total precursors accumulated: 21,123
+1 day, 3:06:45.986032 PROGRESS: Target precursors: 12,745 (60.34%)
+1 day, 3:06:45.986086 PROGRESS: Decoy precursors: 8,378 (39.66%)
+1 day, 3:06:45.986136 PROGRESS: 
+1 day, 3:06:45.986185 PROGRESS: Precursor Summary:
+1 day, 3:06:45.987227 PROGRESS: Channel   0:	 0.05 FDR:    68; 0.01 FDR:    19; 0.001 FDR:    19
+1 day, 3:06:45.987322 PROGRESS: 
+1 day, 3:06:45.987383 PROGRESS: Protein Summary:
+1 day, 3:06:45.988453 PROGRESS: Channel   0:	 0.05 FDR:    67; 0.01 FDR:    19; 0.001 FDR:    19
+1 day, 3:06:45.988546 PROGRESS: =========================================================================
+1 day, 3:06:46.224954 INFO: Starting optimization step 2.
+1 day, 3:06:46.225276 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 3:06:46.225400 PROGRESS: Extracting batch of 63016 precursors
+1 day, 3:06:46.244635 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:06:46.244775 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:06:46.244827 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 3:06:46.244854 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 3:06:46.245835 INFO: Starting candidate selection
+1 day, 3:11:44.881603 INFO: Starting candidate scoring
+1 day, 3:11:47.810637 INFO: Finished candidate processing
+1 day, 3:11:47.810740 INFO: Collecting candidate features
+1 day, 3:11:47.936523 WARNING: intensity_correlation has 13 NaNs ( 0.02 % out of 55035)
+1 day, 3:11:47.941748 INFO: Collecting fragment features
+1 day, 3:11:47.982997 INFO: Finished candidate scoring
+1 day, 3:11:48.078864 PROGRESS: === Extracted 96275 precursors and 964711 fragments ===
+1 day, 3:11:48.091734 INFO: performing precursor FDR with 47 features
+1 day, 3:11:48.091834 INFO: Decoy channel: -1
+1 day, 3:11:48.091860 INFO: Competetive: True
+1 day, 3:11:48.138482 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:11:48.160799 WARNING: dropped 13 target PSMs due to missing features
+1 day, 3:11:48.160926 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 3:11:49.838372 INFO: Test AUC: 0.562
+1 day, 3:11:49.838514 INFO: Train AUC: 0.577
+1 day, 3:11:49.838547 INFO: AUC difference: 2.60%
+1 day, 3:11:49.936846 INFO: Resetting torch num_threads to 100
+1 day, 3:11:49.943234 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 3:11:49.953125 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:11:49.953412 PROGRESS: Total precursors accumulated: 49,354
+1 day, 3:11:49.953478 PROGRESS: Target precursors: 29,511 (59.79%)
+1 day, 3:11:49.953531 PROGRESS: Decoy precursors: 19,843 (40.21%)
+1 day, 3:11:49.953581 PROGRESS: 
+1 day, 3:11:49.953630 PROGRESS: Precursor Summary:
+1 day, 3:11:49.955001 PROGRESS: Channel   0:	 0.05 FDR:   475; 0.01 FDR:   329; 0.001 FDR:   132
+1 day, 3:11:49.955097 PROGRESS: 
+1 day, 3:11:49.955157 PROGRESS: Protein Summary:
+1 day, 3:11:49.956564 PROGRESS: Channel   0:	 0.05 FDR:   441; 0.01 FDR:   307; 0.001 FDR:   129
+1 day, 3:11:49.956657 PROGRESS: =========================================================================
+1 day, 3:11:49.970303 INFO: fragments_df_filtered: 3066
+1 day, 3:11:50.200318 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:11:50.247712 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:11:50.300103 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:11:50.352028 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:11:50.532810 INFO: calibration group: precursor, predicting mz
+1 day, 3:11:50.548405 INFO: calibration group: precursor, predicting rt
+1 day, 3:11:50.613152 INFO: calibration group: precursor, predicting mobility
+1 day, 3:11:50.628880 INFO: calibration group: fragment, predicting mz
+1 day, 3:11:50.765596 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 3:11:50.765924 INFO: Starting optimization step 3.
+1 day, 3:11:50.766001 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 3:11:50.766090 PROGRESS: Extracting batch of 110321 precursors
+1 day, 3:11:50.796707 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:11:50.796829 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:11:50.796896 INFO: FWHM in RT is 3.36 seconds, sigma is 0.74
+1 day, 3:11:50.796921 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.28
+1 day, 3:11:50.805794 INFO: Starting candidate selection
+1 day, 3:20:52.528348 INFO: Starting candidate scoring
+1 day, 3:21:03.548522 INFO: Finished candidate processing
+1 day, 3:21:03.548697 INFO: Collecting candidate features
+1 day, 3:21:03.908461 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 189481)
+1 day, 3:21:03.918391 INFO: Collecting fragment features
+1 day, 3:21:04.041554 INFO: Finished candidate scoring
+1 day, 3:21:04.146090 PROGRESS: === Extracted 189481 precursors and 1931263 fragments ===
+1 day, 3:21:04.146608 INFO: performing precursor FDR with 47 features
+1 day, 3:21:04.146650 INFO: Decoy channel: -1
+1 day, 3:21:04.146672 INFO: Competetive: True
+1 day, 3:21:04.234237 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:21:04.273141 WARNING: dropped 1 target PSMs due to missing features
+1 day, 3:21:08.278032 INFO: Test AUC: 0.563
+1 day, 3:21:08.278180 INFO: Train AUC: 0.590
+1 day, 3:21:08.278212 INFO: AUC difference: 4.50%
+1 day, 3:21:09.914309 INFO: Resetting torch num_threads to 100
+1 day, 3:21:09.922220 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 3:21:09.933970 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:21:09.934310 PROGRESS: Total precursors accumulated: 50,306
+1 day, 3:21:09.934376 PROGRESS: Target precursors: 31,706 (63.03%)
+1 day, 3:21:09.934428 PROGRESS: Decoy precursors: 18,600 (36.97%)
+1 day, 3:21:09.934479 PROGRESS: 
+1 day, 3:21:09.934525 PROGRESS: Precursor Summary:
+1 day, 3:21:09.936100 PROGRESS: Channel   0:	 0.05 FDR:   637; 0.01 FDR:   401; 0.001 FDR:   333
+1 day, 3:21:09.936202 PROGRESS: 
+1 day, 3:21:09.936258 PROGRESS: Protein Summary:
+1 day, 3:21:09.937776 PROGRESS: Channel   0:	 0.05 FDR:   589; 0.01 FDR:   374; 0.001 FDR:   308
+1 day, 3:21:09.937877 PROGRESS: =========================================================================
+1 day, 3:21:09.949448 INFO: fragments_df_filtered: 4929
+1 day, 3:21:10.501689 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:21:10.547322 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:21:10.589176 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:21:10.630535 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:21:10.971127 INFO: calibration group: precursor, predicting mz
+1 day, 3:21:10.986646 INFO: calibration group: precursor, predicting rt
+1 day, 3:21:11.053780 INFO: calibration group: precursor, predicting mobility
+1 day, 3:21:11.071177 INFO: calibration group: fragment, predicting mz
+1 day, 3:21:11.205656 INFO: === checking if optimization conditions were reached ===
+1 day, 3:21:11.208418 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 3:21:11.209599 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 3:21:11.209659 INFO: ==============================================
+1 day, 3:21:11.209780 INFO: Starting optimization step 4.
+1 day, 3:21:11.209857 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 3:21:11.209929 PROGRESS: Extracting batch of 110321 precursors
+1 day, 3:21:11.261910 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:21:11.262064 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:21:11.262113 INFO: FWHM in RT is 3.24 seconds, sigma is 0.71
+1 day, 3:21:11.262138 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.11
+1 day, 3:21:11.262957 INFO: Starting candidate selection
+1 day, 3:29:16.312476 INFO: Starting candidate scoring
+1 day, 3:29:22.023467 INFO: Finished candidate processing
+1 day, 3:29:22.023670 INFO: Collecting candidate features
+1 day, 3:29:22.399886 WARNING: intensity_correlation has 7 NaNs ( 0.00 % out of 189216)
+1 day, 3:29:22.400358 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 189216)
+1 day, 3:29:22.410386 INFO: Collecting fragment features
+1 day, 3:29:22.527258 INFO: Finished candidate scoring
+1 day, 3:29:22.625831 PROGRESS: === Extracted 189216 precursors and 1859322 fragments ===
+1 day, 3:29:22.626390 INFO: performing precursor FDR with 47 features
+1 day, 3:29:22.626433 INFO: Decoy channel: -1
+1 day, 3:29:22.626462 INFO: Competetive: True
+1 day, 3:29:22.705777 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:29:22.752223 WARNING: dropped 1 target PSMs due to missing features
+1 day, 3:29:22.752368 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 3:29:26.045501 INFO: Test AUC: 0.563
+1 day, 3:29:26.045644 INFO: Train AUC: 0.591
+1 day, 3:29:26.045674 INFO: AUC difference: 4.71%
+1 day, 3:29:26.146783 INFO: Resetting torch num_threads to 100
+1 day, 3:29:26.154850 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 3:29:26.166547 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:29:26.166884 PROGRESS: Total precursors accumulated: 50,233
+1 day, 3:29:26.166951 PROGRESS: Target precursors: 31,192 (62.09%)
+1 day, 3:29:26.167006 PROGRESS: Decoy precursors: 19,041 (37.91%)
+1 day, 3:29:26.167056 PROGRESS: 
+1 day, 3:29:26.167106 PROGRESS: Precursor Summary:
+1 day, 3:29:26.168756 PROGRESS: Channel   0:	 0.05 FDR:   845; 0.01 FDR:   613; 0.001 FDR:   507
+1 day, 3:29:26.168856 PROGRESS: 
+1 day, 3:29:26.168916 PROGRESS: Protein Summary:
+1 day, 3:29:26.170630 PROGRESS: Channel   0:	 0.05 FDR:   773; 0.01 FDR:   563; 0.001 FDR:   462
+1 day, 3:29:26.170728 PROGRESS: =========================================================================
+1 day, 3:29:26.185362 INFO: fragments_df_filtered: 5000
+1 day, 3:29:26.372616 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:29:26.418720 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:29:26.460413 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:29:26.502450 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:29:26.852413 INFO: calibration group: precursor, predicting mz
+1 day, 3:29:26.860192 INFO: calibration group: precursor, predicting rt
+1 day, 3:29:26.888680 INFO: calibration group: precursor, predicting mobility
+1 day, 3:29:26.895098 INFO: calibration group: fragment, predicting mz
+1 day, 3:29:26.947499 INFO: === checking if optimization conditions were reached ===
+1 day, 3:29:26.949792 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 3:29:26.950829 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 3:29:26.950884 INFO: ==============================================
+1 day, 3:29:26.951008 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 3:29:27.121891 INFO: calibration group: precursor, predicting mz
+1 day, 3:29:27.129837 INFO: calibration group: precursor, predicting rt
+1 day, 3:29:27.158461 INFO: calibration group: precursor, predicting mobility
+1 day, 3:29:27.164910 INFO: calibration group: fragment, predicting mz
+1 day, 3:29:27.219252 INFO: Starting optimization step 0.
+1 day, 3:29:27.219551 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:29:27.219679 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:29:27.236205 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:29:27.236329 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:29:27.236397 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:29:27.236427 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1 day, 3:29:27.242335 INFO: Starting candidate selection
+1 day, 3:32:59.271960 INFO: Starting candidate scoring
+1 day, 3:33:01.885791 INFO: Finished candidate processing
+1 day, 3:33:01.885968 INFO: Collecting candidate features
+1 day, 3:33:02.046961 WARNING: intensity_correlation has 5 NaNs ( 0.01 % out of 80948)
+1 day, 3:33:02.053521 INFO: Collecting fragment features
+1 day, 3:33:02.110731 INFO: Finished candidate scoring
+1 day, 3:33:02.149791 PROGRESS: === Extracted 80948 precursors and 793851 fragments ===
+1 day, 3:33:02.150299 INFO: performing precursor FDR with 47 features
+1 day, 3:33:02.150343 INFO: Decoy channel: -1
+1 day, 3:33:02.150376 INFO: Competetive: True
+1 day, 3:33:02.177706 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:33:02.194205 WARNING: dropped 2 target PSMs due to missing features
+1 day, 3:33:02.194346 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 3:33:03.489976 INFO: Test AUC: 0.571
+1 day, 3:33:03.490115 INFO: Train AUC: 0.617
+1 day, 3:33:03.490150 INFO: AUC difference: 7.46%
+1 day, 3:33:03.490178 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:33:03.584275 INFO: Resetting torch num_threads to 100
+1 day, 3:33:03.587397 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:33:03.591443 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:33:03.591614 PROGRESS: Total precursors accumulated: 21,509
+1 day, 3:33:03.591687 PROGRESS: Target precursors: 13,862 (64.45%)
+1 day, 3:33:03.591755 PROGRESS: Decoy precursors: 7,647 (35.55%)
+1 day, 3:33:03.591814 PROGRESS: 
+1 day, 3:33:03.591870 PROGRESS: Precursor Summary:
+1 day, 3:33:03.593070 PROGRESS: Channel   0:	 0.05 FDR:   412; 0.01 FDR:   303; 0.001 FDR:   272
+1 day, 3:33:03.593176 PROGRESS: 
+1 day, 3:33:03.593244 PROGRESS: Protein Summary:
+1 day, 3:33:03.594556 PROGRESS: Channel   0:	 0.05 FDR:   394; 0.01 FDR:   290; 0.001 FDR:   261
+1 day, 3:33:03.594659 PROGRESS: =========================================================================
+1 day, 3:33:03.703060 INFO: fragments_df_filtered: 3426
+1 day, 3:33:03.875810 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:33:03.920367 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:33:03.970046 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:33:04.019847 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:33:04.226938 INFO: calibration group: precursor, predicting mz
+1 day, 3:33:04.234389 INFO: calibration group: precursor, predicting rt
+1 day, 3:33:04.262859 INFO: calibration group: precursor, predicting mobility
+1 day, 3:33:04.269786 INFO: calibration group: fragment, predicting mz
+1 day, 3:33:04.325547 INFO: === checking if optimization conditions were reached ===
+1 day, 3:33:04.325863 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 3:33:04.328012 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 573.1103.
+1 day, 3:33:04.328086 INFO: ==============================================
+1 day, 3:33:04.328197 INFO: Starting optimization step 1.
+1 day, 3:33:04.328273 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:33:04.328352 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:33:04.344582 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:33:04.344708 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:33:04.344760 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:33:04.344782 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.14
+1 day, 3:33:04.353748 INFO: Starting candidate selection
+1 day, 3:34:01.495453 INFO: Starting candidate scoring
+1 day, 3:34:04.001189 INFO: Finished candidate processing
+1 day, 3:34:04.002506 INFO: Collecting candidate features
+1 day, 3:34:04.171015 WARNING: intensity_correlation has 18 NaNs ( 0.02 % out of 78858)
+1 day, 3:34:04.182371 INFO: Collecting fragment features
+1 day, 3:34:04.249315 INFO: Finished candidate scoring
+1 day, 3:34:04.330499 PROGRESS: === Extracted 78858 precursors and 759378 fragments ===
+1 day, 3:34:04.331185 INFO: performing precursor FDR with 47 features
+1 day, 3:34:04.331228 INFO: Decoy channel: -1
+1 day, 3:34:04.331255 INFO: Competetive: True
+1 day, 3:34:04.370842 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:34:04.389201 WARNING: dropped 10 target PSMs due to missing features
+1 day, 3:34:04.389347 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 3:34:06.001616 INFO: Test AUC: 0.560
+1 day, 3:34:06.001757 INFO: Train AUC: 0.604
+1 day, 3:34:06.001788 INFO: AUC difference: 7.28%
+1 day, 3:34:06.001810 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:34:06.100820 INFO: Resetting torch num_threads to 100
+1 day, 3:34:06.104133 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:34:06.108193 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:34:06.108357 PROGRESS: Total precursors accumulated: 21,175
+1 day, 3:34:06.108424 PROGRESS: Target precursors: 13,241 (62.53%)
+1 day, 3:34:06.108482 PROGRESS: Decoy precursors: 7,934 (37.47%)
+1 day, 3:34:06.108531 PROGRESS: 
+1 day, 3:34:06.108583 PROGRESS: Precursor Summary:
+1 day, 3:34:06.109767 PROGRESS: Channel   0:	 0.05 FDR:   402; 0.01 FDR:   257; 0.001 FDR:   248
+1 day, 3:34:06.109866 PROGRESS: 
+1 day, 3:34:06.109925 PROGRESS: Protein Summary:
+1 day, 3:34:06.111209 PROGRESS: Channel   0:	 0.05 FDR:   384; 0.01 FDR:   248; 0.001 FDR:   239
+1 day, 3:34:06.111305 PROGRESS: =========================================================================
+1 day, 3:34:06.117872 INFO: fragments_df_filtered: 2969
+1 day, 3:34:06.321497 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:34:06.367491 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:34:06.406537 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:34:06.444776 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:34:06.592945 INFO: calibration group: precursor, predicting mz
+1 day, 3:34:06.600781 INFO: calibration group: precursor, predicting rt
+1 day, 3:34:06.629724 INFO: calibration group: precursor, predicting mobility
+1 day, 3:34:06.636762 INFO: calibration group: fragment, predicting mz
+1 day, 3:34:06.692641 INFO: === checking if optimization conditions were reached ===
+1 day, 3:34:06.692991 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 3:34:06.695544 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 299.9589.
+1 day, 3:34:06.695605 INFO: ==============================================
+1 day, 3:34:06.695719 INFO: Starting optimization step 2.
+1 day, 3:34:06.695796 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:34:06.695894 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:34:06.714781 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:34:06.714921 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:34:06.714984 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 3:34:06.715010 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.24
+1 day, 3:34:06.724020 INFO: Starting candidate selection
+1 day, 3:34:38.603897 INFO: Starting candidate scoring
+1 day, 3:34:40.880422 INFO: Finished candidate processing
+1 day, 3:34:40.880736 INFO: Collecting candidate features
+1 day, 3:34:41.046925 WARNING: intensity_correlation has 31 NaNs ( 0.04 % out of 77860)
+1 day, 3:34:41.047252 WARNING: height_correlation has 6 NaNs ( 0.01 % out of 77860)
+1 day, 3:34:41.053271 INFO: Collecting fragment features
+1 day, 3:34:41.119005 INFO: Finished candidate scoring
+1 day, 3:34:41.158962 PROGRESS: === Extracted 77860 precursors and 740519 fragments ===
+1 day, 3:34:41.159499 INFO: performing precursor FDR with 47 features
+1 day, 3:34:41.159539 INFO: Decoy channel: -1
+1 day, 3:34:41.159563 INFO: Competetive: True
+1 day, 3:34:41.190389 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:34:41.205938 WARNING: dropped 16 target PSMs due to missing features
+1 day, 3:34:41.206078 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 3:34:42.494284 INFO: Test AUC: 0.551
+1 day, 3:34:42.494419 INFO: Train AUC: 0.594
+1 day, 3:34:42.494449 INFO: AUC difference: 7.25%
+1 day, 3:34:42.494472 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:34:42.580986 INFO: Resetting torch num_threads to 100
+1 day, 3:34:42.584033 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:34:42.587924 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:34:42.588079 PROGRESS: Total precursors accumulated: 20,993
+1 day, 3:34:42.588143 PROGRESS: Target precursors: 13,009 (61.97%)
+1 day, 3:34:42.588197 PROGRESS: Decoy precursors: 7,984 (38.03%)
+1 day, 3:34:42.588247 PROGRESS: 
+1 day, 3:34:42.588292 PROGRESS: Precursor Summary:
+1 day, 3:34:42.589462 PROGRESS: Channel   0:	 0.05 FDR:   401; 0.01 FDR:   331; 0.001 FDR:   286
+1 day, 3:34:42.589561 PROGRESS: 
+1 day, 3:34:42.589619 PROGRESS: Protein Summary:
+1 day, 3:34:42.590883 PROGRESS: Channel   0:	 0.05 FDR:   383; 0.01 FDR:   317; 0.001 FDR:   274
+1 day, 3:34:42.590980 PROGRESS: =========================================================================
+1 day, 3:34:42.597949 INFO: fragments_df_filtered: 3563
+1 day, 3:34:42.766155 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:34:42.803023 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:34:42.842141 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:34:42.879969 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:34:43.076808 INFO: calibration group: precursor, predicting mz
+1 day, 3:34:43.084454 INFO: calibration group: precursor, predicting rt
+1 day, 3:34:43.113133 INFO: calibration group: precursor, predicting mobility
+1 day, 3:34:43.119933 INFO: calibration group: fragment, predicting mz
+1 day, 3:34:43.174365 INFO: === checking if optimization conditions were reached ===
+1 day, 3:34:43.174664 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 3:34:43.176682 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 176.8322.
+1 day, 3:34:43.176736 INFO: ==============================================
+1 day, 3:34:43.176831 INFO: Starting optimization step 3.
+1 day, 3:34:43.176899 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:34:43.176971 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:34:43.189211 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:34:43.189325 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:34:43.189375 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 3:34:43.189399 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.13
+1 day, 3:34:43.205606 INFO: Starting candidate selection
+1 day, 3:35:03.351156 INFO: Starting candidate scoring
+1 day, 3:35:05.741954 INFO: Finished candidate processing
+1 day, 3:35:05.742136 INFO: Collecting candidate features
+1 day, 3:35:05.889034 WARNING: intensity_correlation has 34 NaNs ( 0.04 % out of 77618)
+1 day, 3:35:05.889338 WARNING: height_correlation has 4 NaNs ( 0.01 % out of 77618)
+1 day, 3:35:05.895230 INFO: Collecting fragment features
+1 day, 3:35:05.941743 INFO: Finished candidate scoring
+1 day, 3:35:05.977760 PROGRESS: === Extracted 77618 precursors and 731529 fragments ===
+1 day, 3:35:05.978184 INFO: performing precursor FDR with 47 features
+1 day, 3:35:05.978223 INFO: Decoy channel: -1
+1 day, 3:35:05.978247 INFO: Competetive: True
+1 day, 3:35:06.002802 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:35:06.018293 WARNING: dropped 21 target PSMs due to missing features
+1 day, 3:35:06.018438 WARNING: dropped 15 decoy PSMs due to missing features
+1 day, 3:35:07.260310 INFO: Test AUC: 0.546
+1 day, 3:35:07.260449 INFO: Train AUC: 0.591
+1 day, 3:35:07.260481 INFO: AUC difference: 7.55%
+1 day, 3:35:07.260503 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:35:07.345741 INFO: Resetting torch num_threads to 100
+1 day, 3:35:07.348716 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:35:07.352349 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:35:07.352504 PROGRESS: Total precursors accumulated: 20,953
+1 day, 3:35:07.352582 PROGRESS: Target precursors: 12,882 (61.48%)
+1 day, 3:35:07.352636 PROGRESS: Decoy precursors: 8,071 (38.52%)
+1 day, 3:35:07.352691 PROGRESS: 
+1 day, 3:35:07.352738 PROGRESS: Precursor Summary:
+1 day, 3:35:07.353880 PROGRESS: Channel   0:	 0.05 FDR:   425; 0.01 FDR:   309; 0.001 FDR:   276
+1 day, 3:35:07.353975 PROGRESS: 
+1 day, 3:35:07.354031 PROGRESS: Protein Summary:
+1 day, 3:35:07.355280 PROGRESS: Channel   0:	 0.05 FDR:   406; 0.01 FDR:   296; 0.001 FDR:   267
+1 day, 3:35:07.355376 PROGRESS: =========================================================================
+1 day, 3:35:07.361785 INFO: fragments_df_filtered: 3388
+1 day, 3:35:07.534142 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:35:07.578702 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:35:07.619514 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:35:07.659148 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:35:07.842419 INFO: calibration group: precursor, predicting mz
+1 day, 3:35:07.849543 INFO: calibration group: precursor, predicting rt
+1 day, 3:35:07.877943 INFO: calibration group: precursor, predicting mobility
+1 day, 3:35:07.884765 INFO: calibration group: fragment, predicting mz
+1 day, 3:35:07.934762 INFO: === checking if optimization conditions were reached ===
+1 day, 3:35:07.935081 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 3:35:07.937484 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 128.2918.
+1 day, 3:35:07.937550 INFO: ==============================================
+1 day, 3:35:07.937676 INFO: Starting optimization step 4.
+1 day, 3:35:07.937761 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:35:07.937836 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:35:07.954945 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:35:07.955081 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:35:07.955130 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 3:35:07.955158 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.08
+1 day, 3:35:07.963926 INFO: Starting candidate selection
+1 day, 3:35:22.497582 INFO: Starting candidate scoring
+1 day, 3:35:24.966613 INFO: Finished candidate processing
+1 day, 3:35:24.966722 INFO: Collecting candidate features
+1 day, 3:35:25.093137 WARNING: intensity_correlation has 47 NaNs ( 0.06 % out of 77258)
+1 day, 3:35:25.093493 WARNING: height_correlation has 6 NaNs ( 0.01 % out of 77258)
+1 day, 3:35:25.099477 INFO: Collecting fragment features
+1 day, 3:35:25.161531 INFO: Finished candidate scoring
+1 day, 3:35:25.196479 PROGRESS: === Extracted 77258 precursors and 724876 fragments ===
+1 day, 3:35:25.197160 INFO: performing precursor FDR with 47 features
+1 day, 3:35:25.197202 INFO: Decoy channel: -1
+1 day, 3:35:25.197226 INFO: Competetive: True
+1 day, 3:35:25.231813 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:35:25.248865 WARNING: dropped 25 target PSMs due to missing features
+1 day, 3:35:25.248997 WARNING: dropped 24 decoy PSMs due to missing features
+1 day, 3:35:26.560815 INFO: Test AUC: 0.548
+1 day, 3:35:26.560950 INFO: Train AUC: 0.591
+1 day, 3:35:26.560980 INFO: AUC difference: 7.22%
+1 day, 3:35:26.561002 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:35:26.656089 INFO: Resetting torch num_threads to 100
+1 day, 3:35:26.659143 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:35:26.662797 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:35:26.662955 PROGRESS: Total precursors accumulated: 20,874
+1 day, 3:35:26.663020 PROGRESS: Target precursors: 12,812 (61.38%)
+1 day, 3:35:26.663072 PROGRESS: Decoy precursors: 8,062 (38.62%)
+1 day, 3:35:26.663122 PROGRESS: 
+1 day, 3:35:26.663168 PROGRESS: Precursor Summary:
+1 day, 3:35:26.664282 PROGRESS: Channel   0:	 0.05 FDR:   446; 0.01 FDR:   336; 0.001 FDR:   326
+1 day, 3:35:26.664378 PROGRESS: 
+1 day, 3:35:26.664434 PROGRESS: Protein Summary:
+1 day, 3:35:26.665719 PROGRESS: Channel   0:	 0.05 FDR:   427; 0.01 FDR:   321; 0.001 FDR:   312
+1 day, 3:35:26.665817 PROGRESS: =========================================================================
+1 day, 3:35:26.672746 INFO: fragments_df_filtered: 3589
+1 day, 3:35:26.843423 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:35:26.880862 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:35:26.919137 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:35:26.957121 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:35:27.156203 INFO: calibration group: precursor, predicting mz
+1 day, 3:35:27.163583 INFO: calibration group: precursor, predicting rt
+1 day, 3:35:27.192280 INFO: calibration group: precursor, predicting mobility
+1 day, 3:35:27.198938 INFO: calibration group: fragment, predicting mz
+1 day, 3:35:27.250906 INFO: === checking if optimization conditions were reached ===
+1 day, 3:35:27.251243 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 3:35:27.253666 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 111.6870.
+1 day, 3:35:27.253731 INFO: ==============================================
+1 day, 3:35:27.253844 INFO: Starting optimization step 5.
+1 day, 3:35:27.253921 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:35:27.254021 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:35:27.270939 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:35:27.271065 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:35:27.272136 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:35:27.272177 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.03
+1 day, 3:35:27.281239 INFO: Starting candidate selection
+1 day, 3:35:40.232525 INFO: Starting candidate scoring
+1 day, 3:35:42.687949 INFO: Finished candidate processing
+1 day, 3:35:42.688066 INFO: Collecting candidate features
+1 day, 3:35:42.808410 WARNING: intensity_correlation has 43 NaNs ( 0.06 % out of 77229)
+1 day, 3:35:42.808795 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 77229)
+1 day, 3:35:42.818658 INFO: Collecting fragment features
+1 day, 3:35:42.862497 INFO: Finished candidate scoring
+1 day, 3:35:42.921347 PROGRESS: === Extracted 77229 precursors and 722948 fragments ===
+1 day, 3:35:42.921775 INFO: performing precursor FDR with 47 features
+1 day, 3:35:42.921814 INFO: Decoy channel: -1
+1 day, 3:35:42.921844 INFO: Competetive: True
+1 day, 3:35:42.944356 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:35:42.959618 WARNING: dropped 28 target PSMs due to missing features
+1 day, 3:35:42.959770 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 3:35:44.207454 INFO: Test AUC: 0.534
+1 day, 3:35:44.207596 INFO: Train AUC: 0.587
+1 day, 3:35:44.207631 INFO: AUC difference: 8.98%
+1 day, 3:35:44.207655 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:35:44.293792 INFO: Resetting torch num_threads to 100
+1 day, 3:35:44.328093 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:35:44.331909 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:35:44.332055 PROGRESS: Total precursors accumulated: 20,885
+1 day, 3:35:44.332126 PROGRESS: Target precursors: 12,672 (60.68%)
+1 day, 3:35:44.332186 PROGRESS: Decoy precursors: 8,213 (39.32%)
+1 day, 3:35:44.332242 PROGRESS: 
+1 day, 3:35:44.332295 PROGRESS: Precursor Summary:
+1 day, 3:35:44.333478 PROGRESS: Channel   0:	 0.05 FDR:   428; 0.01 FDR:   341; 0.001 FDR:   237
+1 day, 3:35:44.333578 PROGRESS: 
+1 day, 3:35:44.333641 PROGRESS: Protein Summary:
+1 day, 3:35:44.334903 PROGRESS: Channel   0:	 0.05 FDR:   410; 0.01 FDR:   327; 0.001 FDR:   228
+1 day, 3:35:44.334998 PROGRESS: =========================================================================
+1 day, 3:35:44.341979 INFO: fragments_df_filtered: 3611
+1 day, 3:35:44.550043 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:35:44.595238 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:35:45.693552 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:35:45.741836 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:35:46.010309 INFO: calibration group: precursor, predicting mz
+1 day, 3:35:46.018826 INFO: calibration group: precursor, predicting rt
+1 day, 3:35:46.049271 INFO: calibration group: precursor, predicting mobility
+1 day, 3:35:46.056544 INFO: calibration group: fragment, predicting mz
+1 day, 3:35:46.112041 INFO: === checking if optimization conditions were reached ===
+1 day, 3:35:46.112334 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 3:35:46.114429 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 108.5777.
+1 day, 3:35:46.114490 INFO: ==============================================
+1 day, 3:35:46.114602 INFO: Starting optimization step 6.
+1 day, 3:35:46.114687 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:35:46.114764 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:35:46.132864 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:35:46.132991 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:35:46.133054 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:35:46.133088 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.08
+1 day, 3:35:46.142994 INFO: Starting candidate selection
+1 day, 3:35:58.791351 INFO: Starting candidate scoring
+1 day, 3:36:01.289227 INFO: Finished candidate processing
+1 day, 3:36:01.289364 INFO: Collecting candidate features
+1 day, 3:36:01.414364 WARNING: intensity_correlation has 50 NaNs ( 0.06 % out of 76964)
+1 day, 3:36:01.414666 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 76964)
+1 day, 3:36:01.421417 INFO: Collecting fragment features
+1 day, 3:36:01.472060 INFO: Finished candidate scoring
+1 day, 3:36:01.508333 PROGRESS: === Extracted 76964 precursors and 721072 fragments ===
+1 day, 3:36:01.508754 INFO: performing precursor FDR with 47 features
+1 day, 3:36:01.508791 INFO: Decoy channel: -1
+1 day, 3:36:01.508819 INFO: Competetive: True
+1 day, 3:36:01.534676 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:36:01.550028 WARNING: dropped 29 target PSMs due to missing features
+1 day, 3:36:01.550178 WARNING: dropped 24 decoy PSMs due to missing features
+1 day, 3:36:02.765891 INFO: Test AUC: 0.547
+1 day, 3:36:02.766039 INFO: Train AUC: 0.586
+1 day, 3:36:02.766074 INFO: AUC difference: 6.61%
+1 day, 3:36:02.766100 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:36:02.851244 INFO: Resetting torch num_threads to 100
+1 day, 3:36:02.854304 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 3:36:02.857943 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:36:02.858123 PROGRESS: Total precursors accumulated: 20,810
+1 day, 3:36:02.858196 PROGRESS: Target precursors: 12,643 (60.75%)
+1 day, 3:36:02.858259 PROGRESS: Decoy precursors: 8,167 (39.25%)
+1 day, 3:36:02.858316 PROGRESS: 
+1 day, 3:36:02.858369 PROGRESS: Precursor Summary:
+1 day, 3:36:02.859576 PROGRESS: Channel   0:	 0.05 FDR:   421; 0.01 FDR:   351; 0.001 FDR:   324
+1 day, 3:36:02.860264 PROGRESS: 
+1 day, 3:36:02.860341 PROGRESS: Protein Summary:
+1 day, 3:36:02.861672 PROGRESS: Channel   0:	 0.05 FDR:   403; 0.01 FDR:   337; 0.001 FDR:   312
+1 day, 3:36:02.861779 PROGRESS: =========================================================================
+1 day, 3:36:02.869012 INFO: fragments_df_filtered: 3649
+1 day, 3:36:03.037331 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:36:03.074069 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:36:03.114120 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:36:03.152121 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:36:03.358338 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:03.365955 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:03.394612 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:03.401560 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:03.454770 INFO: === checking if optimization conditions were reached ===
+1 day, 3:36:03.455086 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 3:36:03.456435 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 108.5777 found after 7 searches.
+1 day, 3:36:03.456493 INFO: ==============================================
+1 day, 3:36:03.456598 PROGRESS: Optimization finished for rt_error.
+1 day, 3:36:03.623091 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:03.630770 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:03.660267 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:03.667166 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:03.746317 INFO: Starting optimization step 0.
+1 day, 3:36:03.746560 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:36:03.746634 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:36:03.758784 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:36:03.758906 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:36:03.758946 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:36:03.758970 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.00
+1 day, 3:36:03.767920 INFO: Starting candidate selection
+1 day, 3:36:16.353378 INFO: Starting candidate scoring
+1 day, 3:36:18.795371 INFO: Finished candidate processing
+1 day, 3:36:18.795559 INFO: Collecting candidate features
+1 day, 3:36:18.936878 WARNING: intensity_correlation has 53 NaNs ( 0.07 % out of 77120)
+1 day, 3:36:18.937226 WARNING: height_correlation has 9 NaNs ( 0.01 % out of 77120)
+1 day, 3:36:18.944850 INFO: Collecting fragment features
+1 day, 3:36:19.007239 INFO: Finished candidate scoring
+1 day, 3:36:19.057781 PROGRESS: === Extracted 77120 precursors and 722107 fragments ===
+1 day, 3:36:19.058189 INFO: performing precursor FDR with 47 features
+1 day, 3:36:19.058227 INFO: Decoy channel: -1
+1 day, 3:36:19.058251 INFO: Competetive: True
+1 day, 3:36:19.083263 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:36:19.098624 WARNING: dropped 30 target PSMs due to missing features
+1 day, 3:36:19.098767 WARNING: dropped 26 decoy PSMs due to missing features
+1 day, 3:36:20.381869 INFO: Test AUC: 0.560
+1 day, 3:36:20.382032 INFO: Train AUC: 0.602
+1 day, 3:36:20.382062 INFO: AUC difference: 7.01%
+1 day, 3:36:20.382084 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:36:20.477371 INFO: Resetting torch num_threads to 100
+1 day, 3:36:20.480695 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:36:20.484682 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:36:20.484845 PROGRESS: Total precursors accumulated: 20,843
+1 day, 3:36:20.484917 PROGRESS: Target precursors: 12,981 (62.28%)
+1 day, 3:36:20.484974 PROGRESS: Decoy precursors: 7,862 (37.72%)
+1 day, 3:36:20.485035 PROGRESS: 
+1 day, 3:36:20.485085 PROGRESS: Precursor Summary:
+1 day, 3:36:20.486328 PROGRESS: Channel   0:	 0.05 FDR:   461; 0.01 FDR:   357; 0.001 FDR:   336
+1 day, 3:36:20.486426 PROGRESS: 
+1 day, 3:36:20.486485 PROGRESS: Protein Summary:
+1 day, 3:36:20.487808 PROGRESS: Channel   0:	 0.05 FDR:   441; 0.01 FDR:   343; 0.001 FDR:   322
+1 day, 3:36:20.487904 PROGRESS: =========================================================================
+1 day, 3:36:20.495607 INFO: fragments_df_filtered: 3746
+1 day, 3:36:20.684521 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:36:20.730015 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:36:20.781474 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:36:20.829729 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:36:21.111460 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:21.119456 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:21.149210 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:21.156217 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:21.210830 INFO: === checking if optimization conditions were reached ===
+1 day, 3:36:21.211138 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 3:36:21.213961 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0728.
+1 day, 3:36:21.214118 INFO: ==============================================
+1 day, 3:36:21.214267 INFO: Starting optimization step 1.
+1 day, 3:36:21.214337 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:36:21.214410 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:36:21.229161 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:36:21.229279 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:36:21.229331 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 3:36:21.229358 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.95
+1 day, 3:36:21.238368 INFO: Starting candidate selection
+1 day, 3:36:30.624423 INFO: Starting candidate scoring
+1 day, 3:36:32.983388 INFO: Finished candidate processing
+1 day, 3:36:32.983563 INFO: Collecting candidate features
+1 day, 3:36:33.134370 WARNING: intensity_correlation has 55 NaNs ( 0.07 % out of 75719)
+1 day, 3:36:33.134758 WARNING: height_correlation has 8 NaNs ( 0.01 % out of 75719)
+1 day, 3:36:33.142567 INFO: Collecting fragment features
+1 day, 3:36:33.196464 INFO: Finished candidate scoring
+1 day, 3:36:33.232827 PROGRESS: === Extracted 75719 precursors and 704011 fragments ===
+1 day, 3:36:33.233324 INFO: performing precursor FDR with 47 features
+1 day, 3:36:33.233369 INFO: Decoy channel: -1
+1 day, 3:36:33.233395 INFO: Competetive: True
+1 day, 3:36:33.259926 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:36:33.275501 WARNING: dropped 23 target PSMs due to missing features
+1 day, 3:36:33.275639 WARNING: dropped 37 decoy PSMs due to missing features
+1 day, 3:36:34.483883 INFO: Test AUC: 0.563
+1 day, 3:36:34.484025 INFO: Train AUC: 0.615
+1 day, 3:36:34.484056 INFO: AUC difference: 8.38%
+1 day, 3:36:34.484079 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:36:34.571700 INFO: Resetting torch num_threads to 100
+1 day, 3:36:34.574811 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:36:34.578562 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:36:34.578737 PROGRESS: Total precursors accumulated: 20,491
+1 day, 3:36:34.578823 PROGRESS: Target precursors: 12,979 (63.34%)
+1 day, 3:36:34.578899 PROGRESS: Decoy precursors: 7,512 (36.66%)
+1 day, 3:36:34.578964 PROGRESS: 
+1 day, 3:36:34.579028 PROGRESS: Precursor Summary:
+1 day, 3:36:34.580296 PROGRESS: Channel   0:	 0.05 FDR:   523; 0.01 FDR:   325; 0.001 FDR:   314
+1 day, 3:36:34.580402 PROGRESS: 
+1 day, 3:36:34.580476 PROGRESS: Protein Summary:
+1 day, 3:36:34.581836 PROGRESS: Channel   0:	 0.05 FDR:   500; 0.01 FDR:   313; 0.001 FDR:   302
+1 day, 3:36:34.581934 PROGRESS: =========================================================================
+1 day, 3:36:34.588519 INFO: fragments_df_filtered: 3452
+1 day, 3:36:34.753047 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:36:34.789308 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:36:34.829824 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:36:34.869079 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:36:35.056117 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:35.063676 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:35.092361 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:35.099353 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:35.152509 INFO: === checking if optimization conditions were reached ===
+1 day, 3:36:35.152800 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 3:36:35.154880 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0550.
+1 day, 3:36:35.154944 INFO: ==============================================
+1 day, 3:36:35.155052 INFO: Starting optimization step 2.
+1 day, 3:36:35.155130 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:36:35.155204 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:36:35.172709 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:36:35.172848 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:36:35.172896 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:36:35.172926 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 3:36:35.181905 INFO: Starting candidate selection
+1 day, 3:36:42.921656 INFO: Starting candidate scoring
+1 day, 3:36:45.301528 INFO: Finished candidate processing
+1 day, 3:36:45.301712 INFO: Collecting candidate features
+1 day, 3:36:45.460288 WARNING: intensity_correlation has 64 NaNs ( 0.09 % out of 73886)
+1 day, 3:36:45.460676 WARNING: height_correlation has 13 NaNs ( 0.02 % out of 73886)
+1 day, 3:36:45.469417 INFO: Collecting fragment features
+1 day, 3:36:45.523584 INFO: Finished candidate scoring
+1 day, 3:36:45.592955 PROGRESS: === Extracted 73886 precursors and 682131 fragments ===
+1 day, 3:36:45.593395 INFO: performing precursor FDR with 47 features
+1 day, 3:36:45.593434 INFO: Decoy channel: -1
+1 day, 3:36:45.593458 INFO: Competetive: True
+1 day, 3:36:45.623355 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:36:45.641428 WARNING: dropped 31 target PSMs due to missing features
+1 day, 3:36:45.641575 WARNING: dropped 39 decoy PSMs due to missing features
+1 day, 3:36:47.033999 INFO: Test AUC: 0.560
+1 day, 3:36:47.034143 INFO: Train AUC: 0.600
+1 day, 3:36:47.034174 INFO: AUC difference: 6.74%
+1 day, 3:36:47.034195 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:36:47.130583 INFO: Resetting torch num_threads to 100
+1 day, 3:36:47.133800 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:36:47.138097 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:36:47.138278 PROGRESS: Total precursors accumulated: 20,063
+1 day, 3:36:47.138343 PROGRESS: Target precursors: 12,447 (62.04%)
+1 day, 3:36:47.138396 PROGRESS: Decoy precursors: 7,616 (37.96%)
+1 day, 3:36:47.138445 PROGRESS: 
+1 day, 3:36:47.138491 PROGRESS: Precursor Summary:
+1 day, 3:36:47.139673 PROGRESS: Channel   0:	 0.05 FDR:   434; 0.01 FDR:   357; 0.001 FDR:   277
+1 day, 3:36:47.139779 PROGRESS: 
+1 day, 3:36:47.139837 PROGRESS: Protein Summary:
+1 day, 3:36:47.141139 PROGRESS: Channel   0:	 0.05 FDR:   415; 0.01 FDR:   344; 0.001 FDR:   268
+1 day, 3:36:47.141235 PROGRESS: =========================================================================
+1 day, 3:36:47.148660 INFO: fragments_df_filtered: 3644
+1 day, 3:36:47.666241 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:36:47.708598 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:36:47.752370 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:36:47.791655 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:36:47.998402 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:48.006356 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:48.035260 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:48.042312 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:48.097195 INFO: === checking if optimization conditions were reached ===
+1 day, 3:36:48.097537 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 3:36:48.100055 PROGRESS: ❌ mobility_error : optimization incomplete after 3 search(es). Will search with parameter 0.0442.
+1 day, 3:36:48.100122 INFO: ==============================================
+1 day, 3:36:48.100235 INFO: Starting optimization step 3.
+1 day, 3:36:48.100316 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:36:48.100390 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:36:48.122216 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:36:48.122368 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:36:48.122424 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:36:48.122454 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.08
+1 day, 3:36:48.131424 INFO: Starting candidate selection
+1 day, 3:36:54.392955 INFO: Starting candidate scoring
+1 day, 3:36:56.787871 INFO: Finished candidate processing
+1 day, 3:36:56.788047 INFO: Collecting candidate features
+1 day, 3:36:56.931693 WARNING: intensity_correlation has 64 NaNs ( 0.09 % out of 73048)
+1 day, 3:36:56.932003 WARNING: height_correlation has 8 NaNs ( 0.01 % out of 73048)
+1 day, 3:36:56.937778 INFO: Collecting fragment features
+1 day, 3:36:56.989704 INFO: Finished candidate scoring
+1 day, 3:36:57.023230 PROGRESS: === Extracted 73048 precursors and 667746 fragments ===
+1 day, 3:36:57.023713 INFO: performing precursor FDR with 47 features
+1 day, 3:36:57.023753 INFO: Decoy channel: -1
+1 day, 3:36:57.023779 INFO: Competetive: True
+1 day, 3:36:57.047528 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:36:57.061894 WARNING: dropped 31 target PSMs due to missing features
+1 day, 3:36:57.062033 WARNING: dropped 36 decoy PSMs due to missing features
+1 day, 3:36:58.158468 INFO: Test AUC: 0.557
+1 day, 3:36:58.158608 INFO: Train AUC: 0.600
+1 day, 3:36:58.158639 INFO: AUC difference: 7.06%
+1 day, 3:36:58.158661 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:36:58.247386 INFO: Resetting torch num_threads to 100
+1 day, 3:36:58.250284 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:36:58.253583 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:36:58.253728 PROGRESS: Total precursors accumulated: 19,862
+1 day, 3:36:58.253793 PROGRESS: Target precursors: 12,381 (62.34%)
+1 day, 3:36:58.253847 PROGRESS: Decoy precursors: 7,481 (37.66%)
+1 day, 3:36:58.253896 PROGRESS: 
+1 day, 3:36:58.253942 PROGRESS: Precursor Summary:
+1 day, 3:36:58.255061 PROGRESS: Channel   0:	 0.05 FDR:   453; 0.01 FDR:   355; 0.001 FDR:   260
+1 day, 3:36:58.255157 PROGRESS: 
+1 day, 3:36:58.255213 PROGRESS: Protein Summary:
+1 day, 3:36:58.256477 PROGRESS: Channel   0:	 0.05 FDR:   434; 0.01 FDR:   342; 0.001 FDR:   250
+1 day, 3:36:58.256572 PROGRESS: =========================================================================
+1 day, 3:36:58.263573 INFO: fragments_df_filtered: 3667
+1 day, 3:36:58.448148 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 3:36:58.494950 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 3:36:58.546730 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 3:36:58.592601 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 3:36:58.869020 INFO: calibration group: precursor, predicting mz
+1 day, 3:36:58.876389 INFO: calibration group: precursor, predicting rt
+1 day, 3:36:58.904739 INFO: calibration group: precursor, predicting mobility
+1 day, 3:36:58.911485 INFO: calibration group: fragment, predicting mz
+1 day, 3:36:58.963023 INFO: === checking if optimization conditions were reached ===
+1 day, 3:36:58.963315 PROGRESS: === Optimization of mobility_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 3:36:58.965293 PROGRESS: ❌ mobility_error : optimization incomplete after 4 search(es). Will search with parameter 0.0407.
+1 day, 3:36:58.965353 INFO: ==============================================
+1 day, 3:36:58.965454 INFO: Starting optimization step 4.
+1 day, 3:36:58.965521 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 3:36:58.965588 PROGRESS: Extracting batch of 47305 precursors
+1 day, 3:36:58.977952 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:36:58.978073 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:36:58.978124 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:36:58.978147 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.01
+1 day, 3:36:58.986818 INFO: Starting candidate selection
+1 day, 3:37:04.153800 INFO: Starting candidate scoring
+1 day, 3:37:05.449723 INFO: Finished candidate processing
+1 day, 3:37:05.449842 INFO: Collecting candidate features
+1 day, 3:37:05.556163 WARNING: intensity_correlation has 455 NaNs ( 0.69 % out of 66290)
+1 day, 3:37:05.556501 WARNING: height_correlation has 9 NaNs ( 0.01 % out of 66290)
+1 day, 3:37:05.563697 INFO: Collecting fragment features
+1 day, 3:37:05.595958 INFO: Finished candidate scoring
+1 day, 3:37:05.628222 PROGRESS: === Extracted 66290 precursors and 371537 fragments ===
+1 day, 3:37:05.628630 INFO: performing precursor FDR with 47 features
+1 day, 3:37:05.628671 INFO: Decoy channel: -1
+1 day, 3:37:05.628695 INFO: Competetive: True
+1 day, 3:37:05.647437 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:37:05.660165 WARNING: dropped 238 target PSMs due to missing features
+1 day, 3:37:05.660310 WARNING: dropped 221 decoy PSMs due to missing features
+1 day, 3:37:06.647996 INFO: Test AUC: 0.528
+1 day, 3:37:06.648135 INFO: Train AUC: 0.584
+1 day, 3:37:06.648166 INFO: AUC difference: 9.68%
+1 day, 3:37:06.648189 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:37:06.734476 INFO: Resetting torch num_threads to 100
+1 day, 3:37:06.737195 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:37:06.740359 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:37:06.740509 PROGRESS: Total precursors accumulated: 18,875
+1 day, 3:37:06.740574 PROGRESS: Target precursors: 11,308 (59.91%)
+1 day, 3:37:06.740635 PROGRESS: Decoy precursors: 7,567 (40.09%)
+1 day, 3:37:06.740685 PROGRESS: 
+1 day, 3:37:06.740734 PROGRESS: Precursor Summary:
+1 day, 3:37:06.743323 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 3:37:06.743429 PROGRESS: 
+1 day, 3:37:06.743487 PROGRESS: Protein Summary:
+1 day, 3:37:06.744516 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 3:37:06.744608 PROGRESS: =========================================================================
+1 day, 3:37:07.029206 INFO: calibration group: precursor, predicting mz
+1 day, 3:37:07.038793 INFO: calibration group: precursor, predicting rt
+1 day, 3:37:07.078076 INFO: calibration group: precursor, predicting mobility
+1 day, 3:37:07.087750 INFO: calibration group: fragment, predicting mz
+1 day, 3:37:07.158586 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 3:37:07.158890 PROGRESS: === Optimization of mobility_error has been skipped 1 time(s); maximum number is 1 ===
+1 day, 3:37:07.158955 INFO: Starting optimization step 5.
+1 day, 3:37:07.159041 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 3:37:07.159117 PROGRESS: Extracting batch of 63016 precursors
+1 day, 3:37:07.175909 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:37:07.176046 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:37:07.176097 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:37:07.176126 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.01
+1 day, 3:37:07.177088 INFO: Starting candidate selection
+1 day, 3:37:13.750426 INFO: Starting candidate scoring
+1 day, 3:37:15.443235 INFO: Finished candidate processing
+1 day, 3:37:15.443345 INFO: Collecting candidate features
+1 day, 3:37:15.583160 WARNING: intensity_correlation has 606 NaNs ( 0.69 % out of 88431)
+1 day, 3:37:15.583532 WARNING: height_correlation has 21 NaNs ( 0.02 % out of 88431)
+1 day, 3:37:15.591551 INFO: Collecting fragment features
+1 day, 3:37:15.637098 INFO: Finished candidate scoring
+1 day, 3:37:15.713950 PROGRESS: === Extracted 154721 precursors and 867858 fragments ===
+1 day, 3:37:15.728372 INFO: performing precursor FDR with 47 features
+1 day, 3:37:15.728484 INFO: Decoy channel: -1
+1 day, 3:37:15.728509 INFO: Competetive: True
+1 day, 3:37:15.789018 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:37:15.819179 WARNING: dropped 551 target PSMs due to missing features
+1 day, 3:37:15.819326 WARNING: dropped 522 decoy PSMs due to missing features
+1 day, 3:37:18.521247 INFO: Test AUC: 0.534
+1 day, 3:37:18.521390 INFO: Train AUC: 0.579
+1 day, 3:37:18.521420 INFO: AUC difference: 7.78%
+1 day, 3:37:18.521441 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 3:37:18.614262 INFO: Resetting torch num_threads to 100
+1 day, 3:37:18.621595 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 3:37:18.629389 PROGRESS: ============================= Precursor FDR =============================
+1 day, 3:37:18.629676 PROGRESS: Total precursors accumulated: 44,110
+1 day, 3:37:18.629740 PROGRESS: Target precursors: 26,272 (59.56%)
+1 day, 3:37:18.629791 PROGRESS: Decoy precursors: 17,838 (40.44%)
+1 day, 3:37:18.629839 PROGRESS: 
+1 day, 3:37:18.629885 PROGRESS: Precursor Summary:
+1 day, 3:37:18.631032 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 3:37:18.631130 PROGRESS: 
+1 day, 3:37:18.631186 PROGRESS: Protein Summary:
+1 day, 3:37:18.632316 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+1 day, 3:37:18.632410 PROGRESS: =========================================================================
+1 day, 3:37:18.954072 INFO: calibration group: precursor, predicting mz
+1 day, 3:37:18.971831 INFO: calibration group: precursor, predicting rt
+1 day, 3:37:19.050257 INFO: calibration group: precursor, predicting mobility
+1 day, 3:37:19.070485 INFO: calibration group: fragment, predicting mz
+1 day, 3:37:19.227144 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 3:37:19.227435 PROGRESS: === Optimization of mobility_error has been skipped 2 time(s); maximum number is 1 ===
+1 day, 3:37:19.227784 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0442 found after 4 searches.
+1 day, 3:37:19.227857 PROGRESS: Optimization finished for mobility_error.
+1 day, 3:37:19.419647 INFO: calibration group: precursor, predicting mz
+1 day, 3:37:19.427437 INFO: calibration group: precursor, predicting rt
+1 day, 3:37:19.456136 INFO: calibration group: precursor, predicting mobility
+1 day, 3:37:19.463625 INFO: calibration group: fragment, predicting mz
+1 day, 3:37:19.542095 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 3:37:19.542334 PROGRESS: ==============================================
+1 day, 3:37:19.542428 PROGRESS: ms2_error      : 15.0000
+1 day, 3:37:19.542512 PROGRESS: ms1_error      : 10.0000
+1 day, 3:37:19.542586 PROGRESS: rt_error       : 108.5777
+1 day, 3:37:19.542659 PROGRESS: mobility_error : 0.0442
+1 day, 3:37:19.542723 PROGRESS: ==============================================
+1 day, 3:37:19.545810 INFO: calibration group: precursor, predicting mz
+1 day, 3:37:21.048802 INFO: calibration group: precursor, predicting rt
+1 day, 3:37:27.530135 INFO: calibration group: precursor, predicting mobility
+1 day, 3:37:28.995516 INFO: calibration group: fragment, predicting mz
+1 day, 3:37:41.507685 PROGRESS: Extracting batch of 10272670 precursors
+1 day, 3:37:43.982903 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 3:37:43.983043 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 3:37:43.983094 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 3:37:43.983120 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.01
+1 day, 3:37:43.987659 INFO: Starting candidate selection
+1 day, 3:55:14.038565 INFO: Applying score cutoff of 13.930057899475097
+1 day, 3:55:14.583282 INFO: Removed 2371988 precursors with score below cutoff
+1 day, 3:55:17.063764 INFO: Starting candidate scoring
+1 day, 3:59:04.117699 INFO: Finished candidate processing
+1 day, 3:59:04.118330 INFO: Collecting candidate features
+1 day, 3:59:28.296463 WARNING: intensity_correlation has 81345 NaNs ( 0.59 % out of 13820635)
+1 day, 3:59:28.310421 WARNING: height_correlation has 1557 NaNs ( 0.01 % out of 13820635)
+1 day, 3:59:28.765506 INFO: Collecting fragment features
+1 day, 3:59:36.546146 INFO: Finished candidate scoring
+1 day, 3:59:51.646327 INFO: === FDR correction performed with classifier version 15 ===
+1 day, 3:59:51.650632 INFO: performing precursor FDR with 47 features
+1 day, 3:59:51.650709 INFO: Decoy channel: -1
+1 day, 3:59:51.650744 INFO: Competetive: True
+1 day, 3:59:55.296233 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 3:59:57.549162 WARNING: dropped 41241 target PSMs due to missing features
+1 day, 3:59:57.549321 WARNING: dropped 41007 decoy PSMs due to missing features
+1 day, 4:04:08.147853 INFO: Test AUC: 0.545
+1 day, 4:04:08.148132 INFO: Train AUC: 0.557
+1 day, 4:04:08.148173 INFO: AUC difference: 2.27%
+1 day, 4:04:08.995384 INFO: Resetting torch num_threads to 100
+1 day, 4:04:09.306761 INFO: Removing fragments below FDR threshold
+1 day, 4:04:09.450331 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:04:09.450649 PROGRESS: Total precursors accumulated: 0
+1 day, 4:04:09.450724 PROGRESS: Target precursors: 0 (0.00%)
+1 day, 4:04:09.450781 PROGRESS: Decoy precursors: 0 (0.00%)
+1 day, 4:04:09.450833 PROGRESS: 
+1 day, 4:04:09.450887 PROGRESS: Precursor Summary:
+1 day, 4:04:09.451028 PROGRESS: 
+1 day, 4:04:09.451098 PROGRESS: Protein Summary:
+1 day, 4:04:09.451176 PROGRESS: =========================================================================
+1 day, 4:04:09.629513 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 4:04:10.061352 PROGRESS: Loading raw file 4/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 4:04:10.062224 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+1 day, 4:04:10.062335 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 4:04:10.063188 INFO: Initializing RawFileManager
+1 day, 4:04:10.063318 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:10.063387 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:10.063429 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:10.285106 INFO: Reading 39,128 frames with 2,751,035,867 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.201121 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d...
+1 day, 4:04:20.202393 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.205784 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.206073 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.206463 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.207638 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.224046 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:20.224288 INFO: Indexing quadrupole dimension
+1 day, 4:04:20.709221 INFO: Transposing detector events
+1 day, 4:04:30.041433 INFO: Finished transposing data
+1 day, 4:04:30.079049 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 4:04:30.080030 INFO: RT (min)            : 0.0 - 70.0
+1 day, 4:04:30.080127 INFO: RT duration (sec)   : 4199.8
+1 day, 4:04:30.080185 INFO: RT duration (min)   : 70.0
+1 day, 4:04:30.080242 INFO: Cycle len (scans)   : 9
+1 day, 4:04:30.080288 INFO: Cycle len (sec)     : 0.97
+1 day, 4:04:30.080335 INFO: Number of cycles    : 4347
+1 day, 4:04:30.080380 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 4:04:31.494115 INFO: Initializing CalibrationManager
+1 day, 4:04:31.494415 INFO: Loading calibration config
+1 day, 4:04:31.494824 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 4:04:31.494916 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 4:04:31.494983 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 4:04:31.495106 INFO: Initializing OptimizationManager
+1 day, 4:04:31.495241 INFO: initial parameter: ms1_error = 30
+1 day, 4:04:31.495293 INFO: initial parameter: ms2_error = 30
+1 day, 4:04:31.495356 INFO: initial parameter: rt_error = 2099.891532
+1 day, 4:04:31.495417 INFO: initial parameter: mobility_error = 0.1
+1 day, 4:04:31.495464 INFO: initial parameter: column_type = library
+1 day, 4:04:31.495508 INFO: initial parameter: num_candidates = 1
+1 day, 4:04:31.495553 INFO: initial parameter: classifier_version = -1
+1 day, 4:04:31.495598 INFO: initial parameter: fwhm_rt = 5
+1 day, 4:04:31.495640 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 4:04:31.495682 INFO: initial parameter: score_cutoff = 0
+1 day, 4:04:31.495736 INFO: Initializing TimingManager
+1 day, 4:04:31.495786 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 4:04:31.495860 INFO: FDRManager not loaded from disk.
+1 day, 4:04:31.495885 INFO: Initializing FDRManager
+1 day, 4:04:31.495911 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 4:04:32.783127 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+1 day, 4:04:34.642774 PROGRESS: Starting initial search for precursors.
+1 day, 4:04:34.888385 INFO: Starting optimization step 0.
+1 day, 4:04:34.888653 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 4:04:34.888724 PROGRESS: Extracting batch of 15771 precursors
+1 day, 4:04:34.892370 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:04:34.892427 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:04:34.892457 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 4:04:34.892482 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 4:04:34.893417 INFO: Starting candidate selection
+1 day, 4:05:52.383754 INFO: Starting candidate scoring
+1 day, 4:05:53.120112 INFO: Finished candidate processing
+1 day, 4:05:53.120435 INFO: Collecting candidate features
+1 day, 4:05:53.197586 WARNING: intensity_correlation has 4 NaNs ( 0.03 % out of 13802)
+1 day, 4:05:53.201350 INFO: Collecting fragment features
+1 day, 4:05:53.214498 INFO: Finished candidate scoring
+1 day, 4:05:53.230680 PROGRESS: === Extracted 13802 precursors and 138314 fragments ===
+1 day, 4:05:53.231171 INFO: performing precursor FDR with 47 features
+1 day, 4:05:53.231210 INFO: Decoy channel: -1
+1 day, 4:05:53.231238 INFO: Competetive: True
+1 day, 4:05:53.236643 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:05:53.239878 WARNING: dropped 3 target PSMs due to missing features
+1 day, 4:05:53.239937 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 4:05:53.402307 INFO: Test AUC: 0.510
+1 day, 4:05:53.402440 INFO: Train AUC: 0.516
+1 day, 4:05:53.402475 INFO: AUC difference: 0.99%
+1 day, 4:05:53.485892 INFO: Resetting torch num_threads to 100
+1 day, 4:05:53.487299 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 4:05:53.488914 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:05:53.489045 PROGRESS: Total precursors accumulated: 7,060
+1 day, 4:05:53.489126 PROGRESS: Target precursors: 3,698 (52.38%)
+1 day, 4:05:53.489195 PROGRESS: Decoy precursors: 3,362 (47.62%)
+1 day, 4:05:53.489263 PROGRESS: 
+1 day, 4:05:53.489320 PROGRESS: Precursor Summary:
+1 day, 4:05:53.490221 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 4:05:53.490319 PROGRESS: 
+1 day, 4:05:53.490386 PROGRESS: Protein Summary:
+1 day, 4:05:53.491334 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 4:05:53.491436 PROGRESS: =========================================================================
+1 day, 4:05:53.654286 INFO: Starting optimization step 1.
+1 day, 4:05:53.654592 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 4:05:53.654681 PROGRESS: Extracting batch of 31534 precursors
+1 day, 4:05:53.662746 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:05:53.662829 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:05:53.662875 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 4:05:53.662899 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 4:05:53.663937 INFO: Starting candidate selection
+1 day, 4:08:29.712946 INFO: Starting candidate scoring
+1 day, 4:08:31.154310 INFO: Finished candidate processing
+1 day, 4:08:31.154428 INFO: Collecting candidate features
+1 day, 4:08:31.212761 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 27402)
+1 day, 4:08:31.213104 WARNING: height_correlation has 2 NaNs ( 0.01 % out of 27402)
+1 day, 4:08:31.219737 INFO: Collecting fragment features
+1 day, 4:08:31.240469 INFO: Finished candidate scoring
+1 day, 4:08:31.283892 PROGRESS: === Extracted 41204 precursors and 412093 fragments ===
+1 day, 4:08:31.290364 INFO: performing precursor FDR with 47 features
+1 day, 4:08:31.290452 INFO: Decoy channel: -1
+1 day, 4:08:31.290477 INFO: Competetive: True
+1 day, 4:08:31.313692 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:08:31.323153 WARNING: dropped 5 target PSMs due to missing features
+1 day, 4:08:31.323288 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 4:08:31.997327 INFO: Test AUC: 0.554
+1 day, 4:08:31.997469 INFO: Train AUC: 0.560
+1 day, 4:08:31.997499 INFO: AUC difference: 1.08%
+1 day, 4:08:32.089072 INFO: Resetting torch num_threads to 100
+1 day, 4:08:32.107023 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 4:08:32.110433 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:08:32.110585 PROGRESS: Total precursors accumulated: 21,106
+1 day, 4:08:32.110652 PROGRESS: Target precursors: 12,436 (58.92%)
+1 day, 4:08:32.110707 PROGRESS: Decoy precursors: 8,670 (41.08%)
+1 day, 4:08:32.110757 PROGRESS: 
+1 day, 4:08:32.110804 PROGRESS: Precursor Summary:
+1 day, 4:08:32.111878 PROGRESS: Channel   0:	 0.05 FDR:    61; 0.01 FDR:    44; 0.001 FDR:    44
+1 day, 4:08:32.111972 PROGRESS: 
+1 day, 4:08:32.112030 PROGRESS: Protein Summary:
+1 day, 4:08:32.113143 PROGRESS: Channel   0:	 0.05 FDR:    60; 0.01 FDR:    43; 0.001 FDR:    43
+1 day, 4:08:32.113235 PROGRESS: =========================================================================
+1 day, 4:08:32.336965 INFO: Starting optimization step 2.
+1 day, 4:08:32.337275 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 4:08:32.337360 PROGRESS: Extracting batch of 63016 precursors
+1 day, 4:08:32.376720 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:08:32.376856 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:08:32.376894 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 4:08:32.376916 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 4:08:32.377917 INFO: Starting candidate selection
+1 day, 4:13:31.780607 INFO: Starting candidate scoring
+1 day, 4:13:34.576194 INFO: Finished candidate processing
+1 day, 4:13:34.577376 INFO: Collecting candidate features
+1 day, 4:13:34.699610 WARNING: intensity_correlation has 10 NaNs ( 0.02 % out of 54958)
+1 day, 4:13:34.699909 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 54958)
+1 day, 4:13:34.706543 INFO: Collecting fragment features
+1 day, 4:13:34.746860 INFO: Finished candidate scoring
+1 day, 4:13:34.832222 PROGRESS: === Extracted 96162 precursors and 961862 fragments ===
+1 day, 4:13:34.844600 INFO: performing precursor FDR with 47 features
+1 day, 4:13:34.844701 INFO: Decoy channel: -1
+1 day, 4:13:34.844728 INFO: Competetive: True
+1 day, 4:13:34.888402 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:13:34.910585 WARNING: dropped 12 target PSMs due to missing features
+1 day, 4:13:34.910727 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 4:13:36.642508 INFO: Test AUC: 0.560
+1 day, 4:13:36.642652 INFO: Train AUC: 0.584
+1 day, 4:13:36.642682 INFO: AUC difference: 4.07%
+1 day, 4:13:36.735847 INFO: Resetting torch num_threads to 100
+1 day, 4:13:36.741493 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 4:13:36.750948 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:13:36.751265 PROGRESS: Total precursors accumulated: 49,289
+1 day, 4:13:36.751332 PROGRESS: Target precursors: 29,985 (60.84%)
+1 day, 4:13:36.751401 PROGRESS: Decoy precursors: 19,304 (39.16%)
+1 day, 4:13:36.751450 PROGRESS: 
+1 day, 4:13:36.751497 PROGRESS: Precursor Summary:
+1 day, 4:13:36.752986 PROGRESS: Channel   0:	 0.05 FDR:   490; 0.01 FDR:   368; 0.001 FDR:   191
+1 day, 4:13:36.753097 PROGRESS: 
+1 day, 4:13:36.753160 PROGRESS: Protein Summary:
+1 day, 4:13:36.754590 PROGRESS: Channel   0:	 0.05 FDR:   454; 0.01 FDR:   340; 0.001 FDR:   185
+1 day, 4:13:36.754683 PROGRESS: =========================================================================
+1 day, 4:13:36.768941 INFO: fragments_df_filtered: 3246
+1 day, 4:13:37.000444 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:13:37.039852 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:13:37.080358 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:13:37.121238 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:13:37.289942 INFO: calibration group: precursor, predicting mz
+1 day, 4:13:37.305906 INFO: calibration group: precursor, predicting rt
+1 day, 4:13:37.371234 INFO: calibration group: precursor, predicting mobility
+1 day, 4:13:37.385948 INFO: calibration group: fragment, predicting mz
+1 day, 4:13:37.524875 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 4:13:37.525208 INFO: Starting optimization step 3.
+1 day, 4:13:37.525305 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 4:13:37.525384 PROGRESS: Extracting batch of 110321 precursors
+1 day, 4:13:37.554773 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:13:37.554912 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:13:37.554964 INFO: FWHM in RT is 3.29 seconds, sigma is 0.72
+1 day, 4:13:37.554989 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.07
+1 day, 4:13:37.563736 INFO: Starting candidate selection
+1 day, 4:22:33.620155 INFO: Starting candidate scoring
+1 day, 4:22:43.462940 INFO: Finished candidate processing
+1 day, 4:22:43.463142 INFO: Collecting candidate features
+1 day, 4:22:43.789795 WARNING: intensity_correlation has 3 NaNs ( 0.00 % out of 189298)
+1 day, 4:22:43.800116 INFO: Collecting fragment features
+1 day, 4:22:43.928700 INFO: Finished candidate scoring
+1 day, 4:22:44.027528 PROGRESS: === Extracted 189298 precursors and 1924909 fragments ===
+1 day, 4:22:44.028042 INFO: performing precursor FDR with 47 features
+1 day, 4:22:44.028083 INFO: Decoy channel: -1
+1 day, 4:22:44.028112 INFO: Competetive: True
+1 day, 4:22:44.093043 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:22:44.130131 WARNING: dropped 2 target PSMs due to missing features
+1 day, 4:22:44.130277 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 4:22:47.779152 INFO: Test AUC: 0.573
+1 day, 4:22:47.779293 INFO: Train AUC: 0.592
+1 day, 4:22:47.779331 INFO: AUC difference: 3.34%
+1 day, 4:22:47.878297 INFO: Resetting torch num_threads to 100
+1 day, 4:22:47.884372 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 4:22:47.893698 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:22:47.894020 PROGRESS: Total precursors accumulated: 50,272
+1 day, 4:22:47.894096 PROGRESS: Target precursors: 31,807 (63.27%)
+1 day, 4:22:47.894171 PROGRESS: Decoy precursors: 18,465 (36.73%)
+1 day, 4:22:47.894235 PROGRESS: 
+1 day, 4:22:47.894298 PROGRESS: Precursor Summary:
+1 day, 4:22:47.895753 PROGRESS: Channel   0:	 0.05 FDR:   606; 0.01 FDR:   404; 0.001 FDR:   211
+1 day, 4:22:47.895864 PROGRESS: 
+1 day, 4:22:47.895934 PROGRESS: Protein Summary:
+1 day, 4:22:47.897418 PROGRESS: Channel   0:	 0.05 FDR:   564; 0.01 FDR:   377; 0.001 FDR:   202
+1 day, 4:22:47.897524 PROGRESS: =========================================================================
+1 day, 4:22:47.908848 INFO: fragments_df_filtered: 4736
+1 day, 4:22:48.131573 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:22:48.181299 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:22:48.235159 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:22:48.277343 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:22:48.593965 INFO: calibration group: precursor, predicting mz
+1 day, 4:22:48.609274 INFO: calibration group: precursor, predicting rt
+1 day, 4:22:48.678761 INFO: calibration group: precursor, predicting mobility
+1 day, 4:22:48.695543 INFO: calibration group: fragment, predicting mz
+1 day, 4:22:48.841416 INFO: === checking if optimization conditions were reached ===
+1 day, 4:22:48.844018 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 4:22:48.845196 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 4:22:48.845252 INFO: ==============================================
+1 day, 4:22:48.845365 INFO: Starting optimization step 4.
+1 day, 4:22:48.845442 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 4:22:48.845522 PROGRESS: Extracting batch of 110321 precursors
+1 day, 4:22:48.887152 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:22:48.887301 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:22:48.887363 INFO: FWHM in RT is 3.27 seconds, sigma is 0.72
+1 day, 4:22:48.887393 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.09
+1 day, 4:22:48.890849 INFO: Starting candidate selection
+1 day, 4:30:45.595671 INFO: Starting candidate scoring
+1 day, 4:30:51.125854 INFO: Finished candidate processing
+1 day, 4:30:51.126046 INFO: Collecting candidate features
+1 day, 4:30:51.487588 WARNING: intensity_correlation has 6 NaNs ( 0.00 % out of 188990)
+1 day, 4:30:51.488092 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 188990)
+1 day, 4:30:51.501045 INFO: Collecting fragment features
+1 day, 4:30:51.626128 INFO: Finished candidate scoring
+1 day, 4:30:51.740306 PROGRESS: === Extracted 188990 precursors and 1853558 fragments ===
+1 day, 4:30:51.740801 INFO: performing precursor FDR with 47 features
+1 day, 4:30:51.740842 INFO: Decoy channel: -1
+1 day, 4:30:51.740867 INFO: Competetive: True
+1 day, 4:30:51.812799 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:30:51.855789 WARNING: dropped 4 target PSMs due to missing features
+1 day, 4:30:51.855950 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 4:30:55.603076 INFO: Test AUC: 0.561
+1 day, 4:30:55.603220 INFO: Train AUC: 0.593
+1 day, 4:30:55.603252 INFO: AUC difference: 5.43%
+1 day, 4:30:55.603275 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:30:55.701716 INFO: Resetting torch num_threads to 100
+1 day, 4:30:55.709138 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 4:30:55.720448 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:30:55.720772 PROGRESS: Total precursors accumulated: 50,200
+1 day, 4:30:55.720839 PROGRESS: Target precursors: 31,261 (62.27%)
+1 day, 4:30:55.720892 PROGRESS: Decoy precursors: 18,939 (37.73%)
+1 day, 4:30:55.720942 PROGRESS: 
+1 day, 4:30:55.720990 PROGRESS: Precursor Summary:
+1 day, 4:30:55.722606 PROGRESS: Channel   0:	 0.05 FDR:   856; 0.01 FDR:   623; 0.001 FDR:   380
+1 day, 4:30:55.722707 PROGRESS: 
+1 day, 4:30:55.722766 PROGRESS: Protein Summary:
+1 day, 4:30:55.724380 PROGRESS: Channel   0:	 0.05 FDR:   780; 0.01 FDR:   563; 0.001 FDR:   347
+1 day, 4:30:55.724478 PROGRESS: =========================================================================
+1 day, 4:30:55.740648 INFO: fragments_df_filtered: 5000
+1 day, 4:30:55.931506 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:30:55.985672 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:30:56.040953 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:30:56.093825 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:30:56.513629 INFO: calibration group: precursor, predicting mz
+1 day, 4:30:56.521525 INFO: calibration group: precursor, predicting rt
+1 day, 4:30:56.549796 INFO: calibration group: precursor, predicting mobility
+1 day, 4:30:56.556335 INFO: calibration group: fragment, predicting mz
+1 day, 4:30:56.609565 INFO: === checking if optimization conditions were reached ===
+1 day, 4:30:56.611771 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 4:30:56.612774 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 4:30:56.612828 INFO: ==============================================
+1 day, 4:30:56.612930 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 4:30:56.782667 INFO: calibration group: precursor, predicting mz
+1 day, 4:30:56.790482 INFO: calibration group: precursor, predicting rt
+1 day, 4:30:56.818752 INFO: calibration group: precursor, predicting mobility
+1 day, 4:30:56.825211 INFO: calibration group: fragment, predicting mz
+1 day, 4:30:56.877812 INFO: Starting optimization step 0.
+1 day, 4:30:56.878099 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:30:56.878185 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:30:56.893579 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:30:56.893710 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:30:56.893763 INFO: FWHM in RT is 2.93 seconds, sigma is 0.64
+1 day, 4:30:56.893787 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 4:30:56.905252 INFO: Starting candidate selection
+1 day, 4:34:22.894164 INFO: Starting candidate scoring
+1 day, 4:34:25.378247 INFO: Finished candidate processing
+1 day, 4:34:25.378372 INFO: Collecting candidate features
+1 day, 4:34:25.520619 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 81108)
+1 day, 4:34:25.529571 INFO: Collecting fragment features
+1 day, 4:34:25.583163 INFO: Finished candidate scoring
+1 day, 4:34:25.623681 PROGRESS: === Extracted 81108 precursors and 793934 fragments ===
+1 day, 4:34:25.624191 INFO: performing precursor FDR with 47 features
+1 day, 4:34:25.624233 INFO: Decoy channel: -1
+1 day, 4:34:25.624261 INFO: Competetive: True
+1 day, 4:34:25.656072 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:34:25.676376 WARNING: dropped 1 target PSMs due to missing features
+1 day, 4:34:26.999712 INFO: Test AUC: 0.559
+1 day, 4:34:26.999859 INFO: Train AUC: 0.617
+1 day, 4:34:26.999890 INFO: AUC difference: 9.41%
+1 day, 4:34:26.999912 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:34:27.089878 INFO: Resetting torch num_threads to 100
+1 day, 4:34:27.093655 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:34:27.097626 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:34:27.097774 PROGRESS: Total precursors accumulated: 21,521
+1 day, 4:34:27.097838 PROGRESS: Target precursors: 13,690 (63.61%)
+1 day, 4:34:27.097893 PROGRESS: Decoy precursors: 7,831 (36.39%)
+1 day, 4:34:27.097943 PROGRESS: 
+1 day, 4:34:27.097990 PROGRESS: Precursor Summary:
+1 day, 4:34:27.099124 PROGRESS: Channel   0:	 0.05 FDR:   386; 0.01 FDR:   245; 0.001 FDR:   196
+1 day, 4:34:27.099224 PROGRESS: 
+1 day, 4:34:27.099285 PROGRESS: Protein Summary:
+1 day, 4:34:27.100529 PROGRESS: Channel   0:	 0.05 FDR:   372; 0.01 FDR:   239; 0.001 FDR:   190
+1 day, 4:34:27.100626 PROGRESS: =========================================================================
+1 day, 4:34:27.132518 INFO: fragments_df_filtered: 2750
+1 day, 4:34:27.317519 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:34:27.363418 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:34:27.414558 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:34:27.464722 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:34:27.630617 INFO: calibration group: precursor, predicting mz
+1 day, 4:34:27.638109 INFO: calibration group: precursor, predicting rt
+1 day, 4:34:27.666725 INFO: calibration group: precursor, predicting mobility
+1 day, 4:34:27.673389 INFO: calibration group: fragment, predicting mz
+1 day, 4:34:27.725447 INFO: === checking if optimization conditions were reached ===
+1 day, 4:34:27.725804 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 4:34:27.727962 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 363.0382.
+1 day, 4:34:27.728048 INFO: ==============================================
+1 day, 4:34:27.728162 INFO: Starting optimization step 1.
+1 day, 4:34:27.728245 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:34:27.728330 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:34:27.749980 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:34:27.750112 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:34:27.750172 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 4:34:27.750220 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.21
+1 day, 4:34:27.759354 INFO: Starting candidate selection
+1 day, 4:35:07.362859 INFO: Starting candidate scoring
+1 day, 4:35:09.723699 INFO: Finished candidate processing
+1 day, 4:35:09.723875 INFO: Collecting candidate features
+1 day, 4:35:09.888788 WARNING: intensity_correlation has 39 NaNs ( 0.05 % out of 77944)
+1 day, 4:35:09.889588 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 77944)
+1 day, 4:35:09.898966 INFO: Collecting fragment features
+1 day, 4:35:09.954815 INFO: Finished candidate scoring
+1 day, 4:35:10.001761 PROGRESS: === Extracted 77944 precursors and 743017 fragments ===
+1 day, 4:35:10.002231 INFO: performing precursor FDR with 47 features
+1 day, 4:35:10.002269 INFO: Decoy channel: -1
+1 day, 4:35:10.002293 INFO: Competetive: True
+1 day, 4:35:10.032414 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:35:10.047951 WARNING: dropped 22 target PSMs due to missing features
+1 day, 4:35:10.048093 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 4:35:11.333784 INFO: Test AUC: 0.511
+1 day, 4:35:11.334009 INFO: Train AUC: 0.599
+1 day, 4:35:11.334041 INFO: AUC difference: 14.68%
+1 day, 4:35:11.334064 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:35:11.425162 INFO: Resetting torch num_threads to 100
+1 day, 4:35:11.429133 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:35:11.432997 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:35:11.433163 PROGRESS: Total precursors accumulated: 20,983
+1 day, 4:35:11.433230 PROGRESS: Target precursors: 12,961 (61.77%)
+1 day, 4:35:11.433281 PROGRESS: Decoy precursors: 8,022 (38.23%)
+1 day, 4:35:11.433336 PROGRESS: 
+1 day, 4:35:11.433382 PROGRESS: Precursor Summary:
+1 day, 4:35:11.434549 PROGRESS: Channel   0:	 0.05 FDR:   407; 0.01 FDR:   322; 0.001 FDR:   282
+1 day, 4:35:11.434648 PROGRESS: 
+1 day, 4:35:11.434706 PROGRESS: Protein Summary:
+1 day, 4:35:11.435956 PROGRESS: Channel   0:	 0.05 FDR:   391; 0.01 FDR:   311; 0.001 FDR:   273
+1 day, 4:35:11.436050 PROGRESS: =========================================================================
+1 day, 4:35:11.445255 INFO: fragments_df_filtered: 3444
+1 day, 4:35:11.646101 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:35:11.696069 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:35:11.748792 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:35:11.797349 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:35:12.050128 INFO: calibration group: precursor, predicting mz
+1 day, 4:35:12.057560 INFO: calibration group: precursor, predicting rt
+1 day, 4:35:12.086435 INFO: calibration group: precursor, predicting mobility
+1 day, 4:35:12.093011 INFO: calibration group: fragment, predicting mz
+1 day, 4:35:12.146224 INFO: === checking if optimization conditions were reached ===
+1 day, 4:35:12.146514 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 4:35:12.148476 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 335.0451.
+1 day, 4:35:12.148540 INFO: ==============================================
+1 day, 4:35:12.148642 INFO: Starting optimization step 2.
+1 day, 4:35:12.148717 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:35:12.148796 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:35:12.160954 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:35:12.161072 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:35:12.161131 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 4:35:12.161159 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.09
+1 day, 4:35:12.170097 INFO: Starting candidate selection
+1 day, 4:35:47.938976 INFO: Starting candidate scoring
+1 day, 4:35:50.269687 INFO: Finished candidate processing
+1 day, 4:35:50.269856 INFO: Collecting candidate features
+1 day, 4:35:50.424368 WARNING: intensity_correlation has 34 NaNs ( 0.04 % out of 77847)
+1 day, 4:35:50.424723 WARNING: height_correlation has 3 NaNs ( 0.00 % out of 77847)
+1 day, 4:35:50.432954 INFO: Collecting fragment features
+1 day, 4:35:50.481861 INFO: Finished candidate scoring
+1 day, 4:35:50.518704 PROGRESS: === Extracted 77847 precursors and 741047 fragments ===
+1 day, 4:35:50.519174 INFO: performing precursor FDR with 47 features
+1 day, 4:35:50.519212 INFO: Decoy channel: -1
+1 day, 4:35:50.519236 INFO: Competetive: True
+1 day, 4:35:50.544517 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:35:50.559686 WARNING: dropped 18 target PSMs due to missing features
+1 day, 4:35:50.559826 WARNING: dropped 17 decoy PSMs due to missing features
+1 day, 4:35:51.771723 INFO: Test AUC: 0.512
+1 day, 4:35:51.771863 INFO: Train AUC: 0.600
+1 day, 4:35:51.771892 INFO: AUC difference: 14.62%
+1 day, 4:35:51.771917 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:35:51.859090 INFO: Resetting torch num_threads to 100
+1 day, 4:35:51.862103 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:35:51.865679 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:35:51.865837 PROGRESS: Total precursors accumulated: 20,957
+1 day, 4:35:51.865901 PROGRESS: Target precursors: 12,970 (61.89%)
+1 day, 4:35:51.865952 PROGRESS: Decoy precursors: 7,987 (38.11%)
+1 day, 4:35:51.866001 PROGRESS: 
+1 day, 4:35:51.866047 PROGRESS: Precursor Summary:
+1 day, 4:35:51.867155 PROGRESS: Channel   0:	 0.05 FDR:   430; 0.01 FDR:   339; 0.001 FDR:   292
+1 day, 4:35:51.867249 PROGRESS: 
+1 day, 4:35:51.867306 PROGRESS: Protein Summary:
+1 day, 4:35:51.868575 PROGRESS: Channel   0:	 0.05 FDR:   414; 0.01 FDR:   327; 0.001 FDR:   282
+1 day, 4:35:51.868678 PROGRESS: =========================================================================
+1 day, 4:35:51.875773 INFO: fragments_df_filtered: 3564
+1 day, 4:35:52.052202 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:35:52.091577 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:35:52.132786 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:35:52.171638 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:35:52.368040 INFO: calibration group: precursor, predicting mz
+1 day, 4:35:52.375291 INFO: calibration group: precursor, predicting rt
+1 day, 4:35:52.403415 INFO: calibration group: precursor, predicting mobility
+1 day, 4:35:52.410025 INFO: calibration group: fragment, predicting mz
+1 day, 4:35:52.461591 INFO: === checking if optimization conditions were reached ===
+1 day, 4:35:52.461908 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 4:35:52.464436 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 265.3358.
+1 day, 4:35:52.464501 INFO: ==============================================
+1 day, 4:35:52.464610 INFO: Starting optimization step 3.
+1 day, 4:35:52.464689 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:35:52.464767 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:35:52.481933 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:35:52.482058 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:35:52.482113 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:35:52.482141 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.09
+1 day, 4:35:52.490994 INFO: Starting candidate selection
+1 day, 4:36:21.142754 INFO: Starting candidate scoring
+1 day, 4:36:23.485472 INFO: Finished candidate processing
+1 day, 4:36:23.485579 INFO: Collecting candidate features
+1 day, 4:36:23.622277 WARNING: intensity_correlation has 33 NaNs ( 0.04 % out of 77966)
+1 day, 4:36:23.622597 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 77966)
+1 day, 4:36:23.628621 INFO: Collecting fragment features
+1 day, 4:36:23.682459 INFO: Finished candidate scoring
+1 day, 4:36:23.721174 PROGRESS: === Extracted 77966 precursors and 738470 fragments ===
+1 day, 4:36:23.721644 INFO: performing precursor FDR with 47 features
+1 day, 4:36:23.721683 INFO: Decoy channel: -1
+1 day, 4:36:23.721709 INFO: Competetive: True
+1 day, 4:36:23.747034 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:36:23.762226 WARNING: dropped 24 target PSMs due to missing features
+1 day, 4:36:23.762368 WARNING: dropped 12 decoy PSMs due to missing features
+1 day, 4:36:25.013774 INFO: Test AUC: 0.553
+1 day, 4:36:25.013914 INFO: Train AUC: 0.600
+1 day, 4:36:25.013944 INFO: AUC difference: 7.80%
+1 day, 4:36:25.013965 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:36:25.101829 INFO: Resetting torch num_threads to 100
+1 day, 4:36:25.104886 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:36:25.108519 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:36:25.108682 PROGRESS: Total precursors accumulated: 21,030
+1 day, 4:36:25.108765 PROGRESS: Target precursors: 12,955 (61.60%)
+1 day, 4:36:25.108820 PROGRESS: Decoy precursors: 8,075 (38.40%)
+1 day, 4:36:25.108871 PROGRESS: 
+1 day, 4:36:25.108917 PROGRESS: Precursor Summary:
+1 day, 4:36:25.110058 PROGRESS: Channel   0:	 0.05 FDR:   444; 0.01 FDR:   340; 0.001 FDR:   205
+1 day, 4:36:25.110179 PROGRESS: 
+1 day, 4:36:25.110235 PROGRESS: Protein Summary:
+1 day, 4:36:25.111480 PROGRESS: Channel   0:	 0.05 FDR:   424; 0.01 FDR:   327; 0.001 FDR:   199
+1 day, 4:36:25.111576 PROGRESS: =========================================================================
+1 day, 4:36:25.118487 INFO: fragments_df_filtered: 3566
+1 day, 4:36:25.295277 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:36:25.343396 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:36:26.544850 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:36:26.595147 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:36:26.856891 INFO: calibration group: precursor, predicting mz
+1 day, 4:36:26.864409 INFO: calibration group: precursor, predicting rt
+1 day, 4:36:26.893022 INFO: calibration group: precursor, predicting mobility
+1 day, 4:36:26.899841 INFO: calibration group: fragment, predicting mz
+1 day, 4:36:26.953701 INFO: === checking if optimization conditions were reached ===
+1 day, 4:36:26.954015 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 4:36:26.958753 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 179.9808.
+1 day, 4:36:26.958824 INFO: ==============================================
+1 day, 4:36:26.958940 INFO: Starting optimization step 4.
+1 day, 4:36:26.959035 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:36:26.959107 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:36:26.976042 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:36:26.976160 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:36:26.976213 INFO: FWHM in RT is 3.00 seconds, sigma is 0.66
+1 day, 4:36:26.976241 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.07
+1 day, 4:36:26.985206 INFO: Starting candidate selection
+1 day, 4:36:46.279330 INFO: Starting candidate scoring
+1 day, 4:36:48.630839 INFO: Finished candidate processing
+1 day, 4:36:48.631014 INFO: Collecting candidate features
+1 day, 4:36:48.782800 WARNING: intensity_correlation has 35 NaNs ( 0.05 % out of 77354)
+1 day, 4:36:48.783126 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 77354)
+1 day, 4:36:48.789058 INFO: Collecting fragment features
+1 day, 4:36:48.835550 INFO: Finished candidate scoring
+1 day, 4:36:48.877570 PROGRESS: === Extracted 77354 precursors and 728037 fragments ===
+1 day, 4:36:48.877992 INFO: performing precursor FDR with 47 features
+1 day, 4:36:48.878030 INFO: Decoy channel: -1
+1 day, 4:36:48.878054 INFO: Competetive: True
+1 day, 4:36:48.903600 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:36:48.919691 WARNING: dropped 24 target PSMs due to missing features
+1 day, 4:36:48.919829 WARNING: dropped 13 decoy PSMs due to missing features
+1 day, 4:36:50.173316 INFO: Test AUC: 0.550
+1 day, 4:36:50.173459 INFO: Train AUC: 0.590
+1 day, 4:36:50.173491 INFO: AUC difference: 6.89%
+1 day, 4:36:50.173514 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:36:50.260738 INFO: Resetting torch num_threads to 100
+1 day, 4:36:50.263738 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:36:50.267473 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:36:50.267644 PROGRESS: Total precursors accumulated: 20,896
+1 day, 4:36:50.267708 PROGRESS: Target precursors: 12,653 (60.55%)
+1 day, 4:36:50.267760 PROGRESS: Decoy precursors: 8,243 (39.45%)
+1 day, 4:36:50.267811 PROGRESS: 
+1 day, 4:36:50.267857 PROGRESS: Precursor Summary:
+1 day, 4:36:50.269009 PROGRESS: Channel   0:	 0.05 FDR:   446; 0.01 FDR:   339; 0.001 FDR:   157
+1 day, 4:36:50.269120 PROGRESS: 
+1 day, 4:36:50.269179 PROGRESS: Protein Summary:
+1 day, 4:36:50.270427 PROGRESS: Channel   0:	 0.05 FDR:   426; 0.01 FDR:   325; 0.001 FDR:   152
+1 day, 4:36:50.270521 PROGRESS: =========================================================================
+1 day, 4:36:50.277245 INFO: fragments_df_filtered: 3509
+1 day, 4:36:50.454510 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:36:50.503402 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:36:50.553998 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:36:50.604641 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:36:50.863887 INFO: calibration group: precursor, predicting mz
+1 day, 4:36:50.871492 INFO: calibration group: precursor, predicting rt
+1 day, 4:36:50.899934 INFO: calibration group: precursor, predicting mobility
+1 day, 4:36:50.906704 INFO: calibration group: fragment, predicting mz
+1 day, 4:36:50.959639 INFO: === checking if optimization conditions were reached ===
+1 day, 4:36:50.959954 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 4:36:50.962315 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 156.6826.
+1 day, 4:36:50.962383 INFO: ==============================================
+1 day, 4:36:50.962498 INFO: Starting optimization step 5.
+1 day, 4:36:50.962573 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:36:50.962640 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:36:50.979077 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:36:50.979202 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:36:50.979248 INFO: FWHM in RT is 3.03 seconds, sigma is 0.67
+1 day, 4:36:50.979276 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.06
+1 day, 4:36:50.988221 INFO: Starting candidate selection
+1 day, 4:37:08.310198 INFO: Starting candidate scoring
+1 day, 4:37:10.665717 INFO: Finished candidate processing
+1 day, 4:37:10.665883 INFO: Collecting candidate features
+1 day, 4:37:10.816468 WARNING: intensity_correlation has 40 NaNs ( 0.05 % out of 77188)
+1 day, 4:37:10.816771 WARNING: height_correlation has 8 NaNs ( 0.01 % out of 77188)
+1 day, 4:37:10.822733 INFO: Collecting fragment features
+1 day, 4:37:10.872656 INFO: Finished candidate scoring
+1 day, 4:37:10.911640 PROGRESS: === Extracted 77188 precursors and 725307 fragments ===
+1 day, 4:37:10.912135 INFO: performing precursor FDR with 47 features
+1 day, 4:37:10.912184 INFO: Decoy channel: -1
+1 day, 4:37:10.912211 INFO: Competetive: True
+1 day, 4:37:10.940051 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:37:10.955892 WARNING: dropped 26 target PSMs due to missing features
+1 day, 4:37:10.956033 WARNING: dropped 16 decoy PSMs due to missing features
+1 day, 4:37:12.190437 INFO: Test AUC: 0.506
+1 day, 4:37:12.190568 INFO: Train AUC: 0.592
+1 day, 4:37:12.190597 INFO: AUC difference: 14.52%
+1 day, 4:37:12.190617 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:37:12.278734 INFO: Resetting torch num_threads to 100
+1 day, 4:37:12.281950 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:37:12.285750 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:37:12.285926 PROGRESS: Total precursors accumulated: 20,882
+1 day, 4:37:12.285989 PROGRESS: Target precursors: 12,643 (60.54%)
+1 day, 4:37:12.286041 PROGRESS: Decoy precursors: 8,239 (39.46%)
+1 day, 4:37:12.286092 PROGRESS: 
+1 day, 4:37:12.286139 PROGRESS: Precursor Summary:
+1 day, 4:37:12.287313 PROGRESS: Channel   0:	 0.05 FDR:   429; 0.01 FDR:   324; 0.001 FDR:   272
+1 day, 4:37:12.287408 PROGRESS: 
+1 day, 4:37:12.287462 PROGRESS: Protein Summary:
+1 day, 4:37:12.288727 PROGRESS: Channel   0:	 0.05 FDR:   412; 0.01 FDR:   311; 0.001 FDR:   262
+1 day, 4:37:12.288818 PROGRESS: =========================================================================
+1 day, 4:37:12.295406 INFO: fragments_df_filtered: 3391
+1 day, 4:37:12.461777 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:37:12.510777 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:37:12.551335 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:37:12.592882 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:37:12.777397 INFO: calibration group: precursor, predicting mz
+1 day, 4:37:12.785011 INFO: calibration group: precursor, predicting rt
+1 day, 4:37:12.813735 INFO: calibration group: precursor, predicting mobility
+1 day, 4:37:12.820576 INFO: calibration group: fragment, predicting mz
+1 day, 4:37:12.874811 INFO: === checking if optimization conditions were reached ===
+1 day, 4:37:12.875128 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 4:37:12.877501 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 129.0891.
+1 day, 4:37:12.877564 INFO: ==============================================
+1 day, 4:37:12.877676 INFO: Starting optimization step 6.
+1 day, 4:37:12.877752 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:37:12.877831 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:37:12.894706 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:37:12.894828 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:37:12.894885 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:37:12.894916 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.11
+1 day, 4:37:12.903921 INFO: Starting candidate selection
+1 day, 4:37:27.565516 INFO: Starting candidate scoring
+1 day, 4:37:29.879757 INFO: Finished candidate processing
+1 day, 4:37:29.879877 INFO: Collecting candidate features
+1 day, 4:37:30.005459 WARNING: intensity_correlation has 46 NaNs ( 0.06 % out of 77010)
+1 day, 4:37:30.005860 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 77010)
+1 day, 4:37:30.015350 INFO: Collecting fragment features
+1 day, 4:37:30.058959 INFO: Finished candidate scoring
+1 day, 4:37:30.107368 PROGRESS: === Extracted 77010 precursors and 721073 fragments ===
+1 day, 4:37:30.107772 INFO: performing precursor FDR with 47 features
+1 day, 4:37:30.107811 INFO: Decoy channel: -1
+1 day, 4:37:30.107835 INFO: Competetive: True
+1 day, 4:37:30.130642 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:37:30.145880 WARNING: dropped 21 target PSMs due to missing features
+1 day, 4:37:30.146019 WARNING: dropped 26 decoy PSMs due to missing features
+1 day, 4:37:31.355726 INFO: Test AUC: 0.546
+1 day, 4:37:31.355870 INFO: Train AUC: 0.598
+1 day, 4:37:31.355900 INFO: AUC difference: 8.55%
+1 day, 4:37:31.355921 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:37:31.445679 INFO: Resetting torch num_threads to 100
+1 day, 4:37:31.448751 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:37:31.452466 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:37:31.452650 PROGRESS: Total precursors accumulated: 20,843
+1 day, 4:37:31.452717 PROGRESS: Target precursors: 12,753 (61.19%)
+1 day, 4:37:31.452769 PROGRESS: Decoy precursors: 8,090 (38.81%)
+1 day, 4:37:31.452819 PROGRESS: 
+1 day, 4:37:31.452863 PROGRESS: Precursor Summary:
+1 day, 4:37:31.454035 PROGRESS: Channel   0:	 0.05 FDR:   463; 0.01 FDR:   337; 0.001 FDR:   283
+1 day, 4:37:31.454151 PROGRESS: 
+1 day, 4:37:31.454211 PROGRESS: Protein Summary:
+1 day, 4:37:31.455491 PROGRESS: Channel   0:	 0.05 FDR:   444; 0.01 FDR:   323; 0.001 FDR:   272
+1 day, 4:37:31.455587 PROGRESS: =========================================================================
+1 day, 4:37:31.462259 INFO: fragments_df_filtered: 3451
+1 day, 4:37:31.640205 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:37:31.685173 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:37:31.723482 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:37:31.764190 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:37:31.951048 INFO: calibration group: precursor, predicting mz
+1 day, 4:37:31.958686 INFO: calibration group: precursor, predicting rt
+1 day, 4:37:31.987612 INFO: calibration group: precursor, predicting mobility
+1 day, 4:37:31.994385 INFO: calibration group: fragment, predicting mz
+1 day, 4:37:32.047363 INFO: === checking if optimization conditions were reached ===
+1 day, 4:37:32.047663 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 4:37:32.049720 PROGRESS: ❌ rt_error       : optimization incomplete after 7 search(es). Will search with parameter 114.0027.
+1 day, 4:37:32.049786 INFO: ==============================================
+1 day, 4:37:32.049891 INFO: Starting optimization step 7.
+1 day, 4:37:32.049970 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:37:32.050039 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:37:32.062141 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:37:32.062258 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:37:32.062305 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:37:32.062332 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.05
+1 day, 4:37:32.071250 INFO: Starting candidate selection
+1 day, 4:37:44.893738 INFO: Starting candidate scoring
+1 day, 4:37:47.274486 INFO: Finished candidate processing
+1 day, 4:37:47.274670 INFO: Collecting candidate features
+1 day, 4:37:47.442320 WARNING: intensity_correlation has 48 NaNs ( 0.06 % out of 76867)
+1 day, 4:37:47.442707 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 76867)
+1 day, 4:37:47.451426 INFO: Collecting fragment features
+1 day, 4:37:47.509899 INFO: Finished candidate scoring
+1 day, 4:37:47.554749 PROGRESS: === Extracted 76867 precursors and 718263 fragments ===
+1 day, 4:37:47.555290 INFO: performing precursor FDR with 47 features
+1 day, 4:37:47.555330 INFO: Decoy channel: -1
+1 day, 4:37:47.555354 INFO: Competetive: True
+1 day, 4:37:47.591342 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:37:47.610829 WARNING: dropped 24 target PSMs due to missing features
+1 day, 4:37:47.610972 WARNING: dropped 25 decoy PSMs due to missing features
+1 day, 4:37:49.140729 INFO: Test AUC: 0.540
+1 day, 4:37:49.140875 INFO: Train AUC: 0.600
+1 day, 4:37:49.140905 INFO: AUC difference: 10.02%
+1 day, 4:37:49.140927 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:37:49.239569 INFO: Resetting torch num_threads to 100
+1 day, 4:37:49.242933 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:37:49.247404 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:37:49.247575 PROGRESS: Total precursors accumulated: 20,796
+1 day, 4:37:49.247638 PROGRESS: Target precursors: 12,735 (61.24%)
+1 day, 4:37:49.247691 PROGRESS: Decoy precursors: 8,061 (38.76%)
+1 day, 4:37:49.247737 PROGRESS: 
+1 day, 4:37:49.247782 PROGRESS: Precursor Summary:
+1 day, 4:37:49.248977 PROGRESS: Channel   0:	 0.05 FDR:   417; 0.01 FDR:   331; 0.001 FDR:   297
+1 day, 4:37:49.249079 PROGRESS: 
+1 day, 4:37:49.249138 PROGRESS: Protein Summary:
+1 day, 4:37:49.250428 PROGRESS: Channel   0:	 0.05 FDR:   401; 0.01 FDR:   318; 0.001 FDR:   284
+1 day, 4:37:49.250522 PROGRESS: =========================================================================
+1 day, 4:37:49.257899 INFO: fragments_df_filtered: 3452
+1 day, 4:37:49.452842 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:37:49.498648 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:37:49.542123 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:37:49.584507 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:37:49.773618 INFO: calibration group: precursor, predicting mz
+1 day, 4:37:49.781497 INFO: calibration group: precursor, predicting rt
+1 day, 4:37:49.810452 INFO: calibration group: precursor, predicting mobility
+1 day, 4:37:49.817480 INFO: calibration group: fragment, predicting mz
+1 day, 4:37:49.872015 INFO: === checking if optimization conditions were reached ===
+1 day, 4:37:49.872367 PROGRESS: === Optimization of rt_error has been performed 8 time(s); minimum number is 2 ===
+1 day, 4:37:49.875185 PROGRESS: ❌ rt_error       : optimization incomplete after 8 search(es). Will search with parameter 109.7940.
+1 day, 4:37:49.875248 INFO: ==============================================
+1 day, 4:37:49.875371 INFO: Starting optimization step 8.
+1 day, 4:37:49.875449 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:37:49.875526 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:37:49.894051 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:37:49.894167 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:37:49.894243 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:37:49.894274 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.05
+1 day, 4:37:49.901625 INFO: Starting candidate selection
+1 day, 4:38:02.621637 INFO: Starting candidate scoring
+1 day, 4:38:04.985353 INFO: Finished candidate processing
+1 day, 4:38:04.985530 INFO: Collecting candidate features
+1 day, 4:38:05.148310 WARNING: intensity_correlation has 51 NaNs ( 0.07 % out of 76918)
+1 day, 4:38:05.148699 WARNING: height_correlation has 9 NaNs ( 0.01 % out of 76918)
+1 day, 4:38:05.157507 INFO: Collecting fragment features
+1 day, 4:38:05.209746 INFO: Finished candidate scoring
+1 day, 4:38:05.254352 PROGRESS: === Extracted 76918 precursors and 718658 fragments ===
+1 day, 4:38:05.254781 INFO: performing precursor FDR with 47 features
+1 day, 4:38:05.254820 INFO: Decoy channel: -1
+1 day, 4:38:05.254843 INFO: Competetive: True
+1 day, 4:38:05.285499 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:38:05.304174 WARNING: dropped 24 target PSMs due to missing features
+1 day, 4:38:05.304324 WARNING: dropped 29 decoy PSMs due to missing features
+1 day, 4:38:06.798994 INFO: Test AUC: 0.549
+1 day, 4:38:06.799143 INFO: Train AUC: 0.599
+1 day, 4:38:06.799173 INFO: AUC difference: 8.32%
+1 day, 4:38:06.799197 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:38:06.892242 INFO: Resetting torch num_threads to 100
+1 day, 4:38:06.895524 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 4:38:06.899794 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:38:06.899971 PROGRESS: Total precursors accumulated: 20,814
+1 day, 4:38:06.900037 PROGRESS: Target precursors: 12,752 (61.27%)
+1 day, 4:38:06.900101 PROGRESS: Decoy precursors: 8,062 (38.73%)
+1 day, 4:38:06.900158 PROGRESS: 
+1 day, 4:38:06.900204 PROGRESS: Precursor Summary:
+1 day, 4:38:06.901403 PROGRESS: Channel   0:	 0.05 FDR:   429; 0.01 FDR:   306; 0.001 FDR:   247
+1 day, 4:38:06.901501 PROGRESS: 
+1 day, 4:38:06.901558 PROGRESS: Protein Summary:
+1 day, 4:38:06.902823 PROGRESS: Channel   0:	 0.05 FDR:   412; 0.01 FDR:   293; 0.001 FDR:   239
+1 day, 4:38:06.902916 PROGRESS: =========================================================================
+1 day, 4:38:06.909595 INFO: fragments_df_filtered: 3205
+1 day, 4:38:07.135614 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:38:07.179408 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:38:07.220927 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:38:07.263103 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:38:07.431053 INFO: calibration group: precursor, predicting mz
+1 day, 4:38:07.438938 INFO: calibration group: precursor, predicting rt
+1 day, 4:38:07.467856 INFO: calibration group: precursor, predicting mobility
+1 day, 4:38:07.474806 INFO: calibration group: fragment, predicting mz
+1 day, 4:38:07.530119 INFO: === checking if optimization conditions were reached ===
+1 day, 4:38:07.530465 PROGRESS: === Optimization of rt_error has been performed 9 time(s); minimum number is 2 ===
+1 day, 4:38:07.532104 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 109.7940 found after 9 searches.
+1 day, 4:38:07.532163 INFO: ==============================================
+1 day, 4:38:07.532275 PROGRESS: Optimization finished for rt_error.
+1 day, 4:38:07.733203 INFO: calibration group: precursor, predicting mz
+1 day, 4:38:07.741343 INFO: calibration group: precursor, predicting rt
+1 day, 4:38:07.770436 INFO: calibration group: precursor, predicting mobility
+1 day, 4:38:07.777406 INFO: calibration group: fragment, predicting mz
+1 day, 4:38:07.870199 INFO: Starting optimization step 0.
+1 day, 4:38:07.870474 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:38:07.870559 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:38:07.891878 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:38:07.892020 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:38:07.892075 INFO: FWHM in RT is 3.02 seconds, sigma is 0.66
+1 day, 4:38:07.892104 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.10
+1 day, 4:38:07.893157 INFO: Starting candidate selection
+1 day, 4:38:19.984383 INFO: Starting candidate scoring
+1 day, 4:38:22.362898 INFO: Finished candidate processing
+1 day, 4:38:22.363089 INFO: Collecting candidate features
+1 day, 4:38:22.518187 WARNING: intensity_correlation has 42 NaNs ( 0.05 % out of 76888)
+1 day, 4:38:22.518497 WARNING: height_correlation has 6 NaNs ( 0.01 % out of 76888)
+1 day, 4:38:22.524446 INFO: Collecting fragment features
+1 day, 4:38:22.573827 INFO: Finished candidate scoring
+1 day, 4:38:22.610667 PROGRESS: === Extracted 76888 precursors and 718726 fragments ===
+1 day, 4:38:22.611162 INFO: performing precursor FDR with 47 features
+1 day, 4:38:22.611201 INFO: Decoy channel: -1
+1 day, 4:38:22.611226 INFO: Competetive: True
+1 day, 4:38:22.638353 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:38:22.654192 WARNING: dropped 24 target PSMs due to missing features
+1 day, 4:38:22.654331 WARNING: dropped 19 decoy PSMs due to missing features
+1 day, 4:38:23.826991 INFO: Test AUC: 0.569
+1 day, 4:38:23.827130 INFO: Train AUC: 0.622
+1 day, 4:38:23.827163 INFO: AUC difference: 8.56%
+1 day, 4:38:23.827188 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:38:23.915677 INFO: Resetting torch num_threads to 100
+1 day, 4:38:23.918719 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 4:38:23.922412 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:38:23.922575 PROGRESS: Total precursors accumulated: 20,806
+1 day, 4:38:23.922641 PROGRESS: Target precursors: 13,227 (63.57%)
+1 day, 4:38:23.922705 PROGRESS: Decoy precursors: 7,579 (36.43%)
+1 day, 4:38:23.922774 PROGRESS: 
+1 day, 4:38:23.922824 PROGRESS: Precursor Summary:
+1 day, 4:38:23.923988 PROGRESS: Channel   0:	 0.05 FDR:   473; 0.01 FDR:   302; 0.001 FDR:   241
+1 day, 4:38:23.924093 PROGRESS: 
+1 day, 4:38:23.924149 PROGRESS: Protein Summary:
+1 day, 4:38:23.925419 PROGRESS: Channel   0:	 0.05 FDR:   454; 0.01 FDR:   291; 0.001 FDR:   233
+1 day, 4:38:23.925515 PROGRESS: =========================================================================
+1 day, 4:38:23.931774 INFO: fragments_df_filtered: 3175
+1 day, 4:38:24.109950 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:38:24.161211 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:38:24.206294 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:38:24.244833 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:38:24.407386 INFO: calibration group: precursor, predicting mz
+1 day, 4:38:24.414945 INFO: calibration group: precursor, predicting rt
+1 day, 4:38:24.443213 INFO: calibration group: precursor, predicting mobility
+1 day, 4:38:24.450084 INFO: calibration group: fragment, predicting mz
+1 day, 4:38:24.503247 INFO: === checking if optimization conditions were reached ===
+1 day, 4:38:24.503579 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 4:38:24.505538 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0522.
+1 day, 4:38:24.505605 INFO: ==============================================
+1 day, 4:38:24.505725 INFO: Starting optimization step 1.
+1 day, 4:38:24.505812 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:38:24.505901 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:38:24.523196 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:38:24.523325 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:38:24.523387 INFO: FWHM in RT is 3.04 seconds, sigma is 0.67
+1 day, 4:38:24.523417 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.10
+1 day, 4:38:24.532145 INFO: Starting candidate selection
+1 day, 4:38:32.082567 INFO: Starting candidate scoring
+1 day, 4:38:34.373250 INFO: Finished candidate processing
+1 day, 4:38:34.373426 INFO: Collecting candidate features
+1 day, 4:38:34.490898 WARNING: intensity_correlation has 58 NaNs ( 0.08 % out of 73646)
+1 day, 4:38:34.491207 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 73646)
+1 day, 4:38:34.498047 INFO: Collecting fragment features
+1 day, 4:38:34.549583 INFO: Finished candidate scoring
+1 day, 4:38:34.586055 PROGRESS: === Extracted 73646 precursors and 677746 fragments ===
+1 day, 4:38:34.586458 INFO: performing precursor FDR with 47 features
+1 day, 4:38:34.586496 INFO: Decoy channel: -1
+1 day, 4:38:34.586520 INFO: Competetive: True
+1 day, 4:38:34.610570 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:38:34.625133 WARNING: dropped 31 target PSMs due to missing features
+1 day, 4:38:34.625270 WARNING: dropped 29 decoy PSMs due to missing features
+1 day, 4:38:35.737775 INFO: Test AUC: 0.567
+1 day, 4:38:35.737911 INFO: Train AUC: 0.603
+1 day, 4:38:35.737941 INFO: AUC difference: 6.07%
+1 day, 4:38:35.737961 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:38:35.825420 INFO: Resetting torch num_threads to 100
+1 day, 4:38:35.828336 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 4:38:35.831776 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:38:35.831947 PROGRESS: Total precursors accumulated: 19,996
+1 day, 4:38:35.832013 PROGRESS: Target precursors: 12,497 (62.50%)
+1 day, 4:38:35.832067 PROGRESS: Decoy precursors: 7,499 (37.50%)
+1 day, 4:38:35.832119 PROGRESS: 
+1 day, 4:38:35.832167 PROGRESS: Precursor Summary:
+1 day, 4:38:35.834527 PROGRESS: Channel   0:	 0.05 FDR:   472; 0.01 FDR:   328; 0.001 FDR:   298
+1 day, 4:38:35.834628 PROGRESS: 
+1 day, 4:38:35.834687 PROGRESS: Protein Summary:
+1 day, 4:38:35.835950 PROGRESS: Channel   0:	 0.05 FDR:   454; 0.01 FDR:   317; 0.001 FDR:   289
+1 day, 4:38:35.836064 PROGRESS: =========================================================================
+1 day, 4:38:35.842447 INFO: fragments_df_filtered: 3410
+1 day, 4:38:36.008550 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:38:36.058214 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:38:36.095852 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:38:36.132401 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:38:36.317584 INFO: calibration group: precursor, predicting mz
+1 day, 4:38:36.324785 INFO: calibration group: precursor, predicting rt
+1 day, 4:38:36.352940 INFO: calibration group: precursor, predicting mobility
+1 day, 4:38:36.359353 INFO: calibration group: fragment, predicting mz
+1 day, 4:38:36.409858 INFO: === checking if optimization conditions were reached ===
+1 day, 4:38:36.410171 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 4:38:36.412185 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0497.
+1 day, 4:38:36.412250 INFO: ==============================================
+1 day, 4:38:36.412374 INFO: Starting optimization step 2.
+1 day, 4:38:36.412453 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:38:36.412526 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:38:36.429041 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:38:36.429169 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:38:36.429220 INFO: FWHM in RT is 3.00 seconds, sigma is 0.66
+1 day, 4:38:36.429251 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.10
+1 day, 4:38:36.438072 INFO: Starting candidate selection
+1 day, 4:38:43.146973 INFO: Starting candidate scoring
+1 day, 4:38:45.457990 INFO: Finished candidate processing
+1 day, 4:38:45.458107 INFO: Collecting candidate features
+1 day, 4:38:45.614879 WARNING: intensity_correlation has 60 NaNs ( 0.08 % out of 72956)
+1 day, 4:38:45.615228 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 72956)
+1 day, 4:38:45.621266 INFO: Collecting fragment features
+1 day, 4:38:45.691592 INFO: Finished candidate scoring
+1 day, 4:38:45.737185 PROGRESS: === Extracted 72956 precursors and 668555 fragments ===
+1 day, 4:38:45.737844 INFO: performing precursor FDR with 47 features
+1 day, 4:38:45.737886 INFO: Decoy channel: -1
+1 day, 4:38:45.737911 INFO: Competetive: True
+1 day, 4:38:45.776632 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:38:45.793955 WARNING: dropped 35 target PSMs due to missing features
+1 day, 4:38:45.794095 WARNING: dropped 29 decoy PSMs due to missing features
+1 day, 4:38:47.221699 INFO: Test AUC: 0.557
+1 day, 4:38:47.221840 INFO: Train AUC: 0.608
+1 day, 4:38:47.221871 INFO: AUC difference: 8.39%
+1 day, 4:38:47.221895 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:38:47.316336 INFO: Resetting torch num_threads to 100
+1 day, 4:38:47.319637 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 4:38:47.323592 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:38:47.323766 PROGRESS: Total precursors accumulated: 19,830
+1 day, 4:38:47.323829 PROGRESS: Target precursors: 12,368 (62.37%)
+1 day, 4:38:47.323892 PROGRESS: Decoy precursors: 7,462 (37.63%)
+1 day, 4:38:47.323943 PROGRESS: 
+1 day, 4:38:47.323988 PROGRESS: Precursor Summary:
+1 day, 4:38:47.325187 PROGRESS: Channel   0:	 0.05 FDR:   444; 0.01 FDR:   321; 0.001 FDR:   299
+1 day, 4:38:47.325290 PROGRESS: 
+1 day, 4:38:47.325345 PROGRESS: Protein Summary:
+1 day, 4:38:47.326627 PROGRESS: Channel   0:	 0.05 FDR:   426; 0.01 FDR:   310; 0.001 FDR:   289
+1 day, 4:38:47.326723 PROGRESS: =========================================================================
+1 day, 4:38:47.333710 INFO: fragments_df_filtered: 3327
+1 day, 4:38:47.527363 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:38:47.573175 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:38:47.612643 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:38:47.651086 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:38:47.829768 INFO: calibration group: precursor, predicting mz
+1 day, 4:38:47.837620 INFO: calibration group: precursor, predicting rt
+1 day, 4:38:47.866634 INFO: calibration group: precursor, predicting mobility
+1 day, 4:38:47.873504 INFO: calibration group: fragment, predicting mz
+1 day, 4:38:47.930044 INFO: === checking if optimization conditions were reached ===
+1 day, 4:38:47.930402 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 4:38:47.932888 PROGRESS: ❌ mobility_error : optimization incomplete after 3 search(es). Will search with parameter 0.0420.
+1 day, 4:38:47.932950 INFO: ==============================================
+1 day, 4:38:47.933082 INFO: Starting optimization step 3.
+1 day, 4:38:47.933165 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:38:47.933270 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:38:47.955202 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:38:47.955335 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:38:47.955408 INFO: FWHM in RT is 3.01 seconds, sigma is 0.66
+1 day, 4:38:47.955442 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.13
+1 day, 4:38:47.956508 INFO: Starting candidate selection
+1 day, 4:38:53.800843 INFO: Starting candidate scoring
+1 day, 4:38:56.635248 INFO: Finished candidate processing
+1 day, 4:38:56.635426 INFO: Collecting candidate features
+1 day, 4:38:56.772563 WARNING: intensity_correlation has 58 NaNs ( 0.08 % out of 72008)
+1 day, 4:38:56.772864 WARNING: height_correlation has 6 NaNs ( 0.01 % out of 72008)
+1 day, 4:38:56.778658 INFO: Collecting fragment features
+1 day, 4:38:56.823675 INFO: Finished candidate scoring
+1 day, 4:38:56.857490 PROGRESS: === Extracted 72008 precursors and 654450 fragments ===
+1 day, 4:38:56.857903 INFO: performing precursor FDR with 47 features
+1 day, 4:38:56.857943 INFO: Decoy channel: -1
+1 day, 4:38:56.857967 INFO: Competetive: True
+1 day, 4:38:56.880257 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:38:56.898257 WARNING: dropped 35 target PSMs due to missing features
+1 day, 4:38:56.898403 WARNING: dropped 26 decoy PSMs due to missing features
+1 day, 4:38:58.120070 INFO: Test AUC: 0.554
+1 day, 4:38:58.120208 INFO: Train AUC: 0.617
+1 day, 4:38:58.120238 INFO: AUC difference: 10.28%
+1 day, 4:38:58.120259 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:38:59.412881 INFO: Resetting torch num_threads to 100
+1 day, 4:38:59.415785 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 4:38:59.419991 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:38:59.420141 PROGRESS: Total precursors accumulated: 19,629
+1 day, 4:38:59.420206 PROGRESS: Target precursors: 12,412 (63.23%)
+1 day, 4:38:59.420257 PROGRESS: Decoy precursors: 7,217 (36.77%)
+1 day, 4:38:59.420307 PROGRESS: 
+1 day, 4:38:59.420353 PROGRESS: Precursor Summary:
+1 day, 4:38:59.421598 PROGRESS: Channel   0:	 0.05 FDR:   463; 0.01 FDR:   363; 0.001 FDR:   285
+1 day, 4:38:59.421700 PROGRESS: 
+1 day, 4:38:59.421755 PROGRESS: Protein Summary:
+1 day, 4:38:59.423077 PROGRESS: Channel   0:	 0.05 FDR:   447; 0.01 FDR:   350; 0.001 FDR:   276
+1 day, 4:38:59.423177 PROGRESS: =========================================================================
+1 day, 4:38:59.430209 INFO: fragments_df_filtered: 3586
+1 day, 4:38:59.609401 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:38:59.654315 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:38:59.706298 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:38:59.755334 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:39:00.024478 INFO: calibration group: precursor, predicting mz
+1 day, 4:39:00.032000 INFO: calibration group: precursor, predicting rt
+1 day, 4:39:00.060702 INFO: calibration group: precursor, predicting mobility
+1 day, 4:39:00.067511 INFO: calibration group: fragment, predicting mz
+1 day, 4:39:00.121666 INFO: === checking if optimization conditions were reached ===
+1 day, 4:39:00.121983 PROGRESS: === Optimization of mobility_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 4:39:00.124170 PROGRESS: ❌ mobility_error : optimization incomplete after 4 search(es). Will search with parameter 0.0350.
+1 day, 4:39:00.124232 INFO: ==============================================
+1 day, 4:39:00.124364 INFO: Starting optimization step 4.
+1 day, 4:39:00.124439 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 4:39:00.124508 PROGRESS: Extracting batch of 47305 precursors
+1 day, 4:39:00.142010 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:39:00.142146 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:39:00.142194 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:39:00.142222 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 4:39:00.145536 INFO: Starting candidate selection
+1 day, 4:39:05.351594 INFO: Starting candidate scoring
+1 day, 4:39:07.581901 INFO: Finished candidate processing
+1 day, 4:39:07.582603 INFO: Collecting candidate features
+1 day, 4:39:07.706367 WARNING: intensity_correlation has 70 NaNs ( 0.10 % out of 71218)
+1 day, 4:39:07.706681 WARNING: height_correlation has 3 NaNs ( 0.00 % out of 71218)
+1 day, 4:39:07.712714 INFO: Collecting fragment features
+1 day, 4:39:07.758135 INFO: Finished candidate scoring
+1 day, 4:39:07.801774 PROGRESS: === Extracted 71218 precursors and 639726 fragments ===
+1 day, 4:39:07.802199 INFO: performing precursor FDR with 47 features
+1 day, 4:39:07.802238 INFO: Decoy channel: -1
+1 day, 4:39:07.802263 INFO: Competetive: True
+1 day, 4:39:07.829563 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 4:39:07.846157 WARNING: dropped 30 target PSMs due to missing features
+1 day, 4:39:07.846307 WARNING: dropped 41 decoy PSMs due to missing features
+1 day, 4:39:09.256490 INFO: Test AUC: 0.499
+1 day, 4:39:09.256636 INFO: Train AUC: 0.610
+1 day, 4:39:09.256670 INFO: AUC difference: 18.13%
+1 day, 4:39:09.256693 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 4:39:09.344787 INFO: Resetting torch num_threads to 100
+1 day, 4:39:09.347933 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 4:39:09.351979 PROGRESS: ============================= Precursor FDR =============================
+1 day, 4:39:09.352133 PROGRESS: Total precursors accumulated: 19,456
+1 day, 4:39:09.352197 PROGRESS: Target precursors: 12,241 (62.92%)
+1 day, 4:39:09.352248 PROGRESS: Decoy precursors: 7,215 (37.08%)
+1 day, 4:39:09.352296 PROGRESS: 
+1 day, 4:39:09.352341 PROGRESS: Precursor Summary:
+1 day, 4:39:09.353537 PROGRESS: Channel   0:	 0.05 FDR:   443; 0.01 FDR:   340; 0.001 FDR:   289
+1 day, 4:39:09.353640 PROGRESS: 
+1 day, 4:39:09.353698 PROGRESS: Protein Summary:
+1 day, 4:39:09.354991 PROGRESS: Channel   0:	 0.05 FDR:   426; 0.01 FDR:   327; 0.001 FDR:   279
+1 day, 4:39:09.355086 PROGRESS: =========================================================================
+1 day, 4:39:09.362186 INFO: fragments_df_filtered: 3353
+1 day, 4:39:09.558646 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 4:39:09.610215 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 4:39:09.662239 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 4:39:09.710740 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 4:39:09.923728 INFO: calibration group: precursor, predicting mz
+1 day, 4:39:09.931770 INFO: calibration group: precursor, predicting rt
+1 day, 4:39:09.960814 INFO: calibration group: precursor, predicting mobility
+1 day, 4:39:09.967737 INFO: calibration group: fragment, predicting mz
+1 day, 4:39:10.022268 INFO: === checking if optimization conditions were reached ===
+1 day, 4:39:10.022554 PROGRESS: === Optimization of mobility_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 4:39:10.023592 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0420 found after 5 searches.
+1 day, 4:39:10.023644 INFO: ==============================================
+1 day, 4:39:10.023737 PROGRESS: Optimization finished for mobility_error.
+1 day, 4:39:10.212636 INFO: calibration group: precursor, predicting mz
+1 day, 4:39:10.220623 INFO: calibration group: precursor, predicting rt
+1 day, 4:39:10.249774 INFO: calibration group: precursor, predicting mobility
+1 day, 4:39:10.256759 INFO: calibration group: fragment, predicting mz
+1 day, 4:39:10.338002 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 4:39:10.338245 PROGRESS: ==============================================
+1 day, 4:39:10.338322 PROGRESS: ms2_error      : 15.0000
+1 day, 4:39:10.338380 PROGRESS: ms1_error      : 10.0000
+1 day, 4:39:10.338433 PROGRESS: rt_error       : 109.7940
+1 day, 4:39:10.338483 PROGRESS: mobility_error : 0.0420
+1 day, 4:39:10.338529 PROGRESS: ==============================================
+1 day, 4:39:10.341399 INFO: calibration group: precursor, predicting mz
+1 day, 4:39:11.863498 INFO: calibration group: precursor, predicting rt
+1 day, 4:39:18.431416 INFO: calibration group: precursor, predicting mobility
+1 day, 4:39:19.889100 INFO: calibration group: fragment, predicting mz
+1 day, 4:39:32.551238 PROGRESS: Extracting batch of 10272670 precursors
+1 day, 4:39:34.879099 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 4:39:34.879247 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 4:39:34.879306 INFO: FWHM in RT is 2.99 seconds, sigma is 0.66
+1 day, 4:39:34.879335 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 4:39:34.880902 INFO: Starting candidate selection
+1 day, 4:57:32.514129 INFO: Applying score cutoff of 32.54461517715454
+1 day, 4:57:32.883866 INFO: Removed 6775189 precursors with score below cutoff
+1 day, 4:57:36.041108 INFO: Starting candidate scoring
+1 day, 5:02:39.083597 INFO: Finished candidate processing
+1 day, 5:02:39.085609 INFO: Collecting candidate features
+1 day, 5:02:58.054180 WARNING: intensity_correlation has 19 NaNs ( 0.00 % out of 10179236)
+1 day, 5:02:58.405169 INFO: Collecting fragment features
+1 day, 5:03:05.884300 INFO: Finished candidate scoring
+1 day, 5:03:18.542470 INFO: === FDR correction performed with classifier version 17 ===
+1 day, 5:03:18.557811 INFO: performing precursor FDR with 47 features
+1 day, 5:03:18.557903 INFO: Decoy channel: -1
+1 day, 5:03:18.557934 INFO: Competetive: True
+1 day, 5:03:21.268260 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:03:22.969702 WARNING: dropped 9 target PSMs due to missing features
+1 day, 5:03:22.969862 WARNING: dropped 10 decoy PSMs due to missing features
+1 day, 5:06:43.082188 INFO: Test AUC: 0.536
+1 day, 5:06:43.082472 INFO: Train AUC: 0.577
+1 day, 5:06:43.082533 INFO: AUC difference: 7.11%
+1 day, 5:06:43.082560 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:06:43.832031 INFO: Resetting torch num_threads to 100
+1 day, 5:06:44.247534 INFO: Removing fragments below FDR threshold
+1 day, 5:06:44.994672 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:06:44.995279 PROGRESS: Total precursors accumulated: 71,677
+1 day, 5:06:44.995354 PROGRESS: Target precursors: 70,968 (99.01%)
+1 day, 5:06:44.995410 PROGRESS: Decoy precursors: 709 (0.99%)
+1 day, 5:06:44.995461 PROGRESS: 
+1 day, 5:06:44.995507 PROGRESS: Precursor Summary:
+1 day, 5:06:45.023085 PROGRESS: Channel   0:	 0.05 FDR: 70,968; 0.01 FDR: 70,968; 0.001 FDR: 52,858
+1 day, 5:06:45.023355 PROGRESS: 
+1 day, 5:06:45.023431 PROGRESS: Protein Summary:
+1 day, 5:06:45.063654 PROGRESS: Channel   0:	 0.05 FDR: 11,368; 0.01 FDR: 11,368; 0.001 FDR: 8,952
+1 day, 5:06:45.063910 PROGRESS: =========================================================================
+1 day, 5:06:45.848576 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 5:06:46.281337 PROGRESS: Loading raw file 5/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 5:06:46.281524 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+1 day, 5:06:46.281606 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 5:06:46.282345 INFO: Initializing RawFileManager
+1 day, 5:06:46.282475 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:46.282540 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:46.282586 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:46.506040 INFO: Reading 39,128 frames with 2,766,418,119 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.642844 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d...
+1 day, 5:06:55.646131 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.648928 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.649221 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.649652 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.651430 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.667433 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:06:55.667733 INFO: Indexing quadrupole dimension
+1 day, 5:06:56.163804 INFO: Transposing detector events
+1 day, 5:07:05.651960 INFO: Finished transposing data
+1 day, 5:07:05.689175 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 5:07:05.690246 INFO: RT (min)            : 0.0 - 70.0
+1 day, 5:07:05.690337 INFO: RT duration (sec)   : 4199.9
+1 day, 5:07:05.690396 INFO: RT duration (min)   : 70.0
+1 day, 5:07:05.690449 INFO: Cycle len (scans)   : 9
+1 day, 5:07:05.690494 INFO: Cycle len (sec)     : 0.97
+1 day, 5:07:05.690536 INFO: Number of cycles    : 4347
+1 day, 5:07:05.690579 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 5:07:07.038748 INFO: Initializing CalibrationManager
+1 day, 5:07:07.039040 INFO: Loading calibration config
+1 day, 5:07:07.039684 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 5:07:07.039774 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 5:07:07.039878 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 5:07:07.040067 INFO: Initializing OptimizationManager
+1 day, 5:07:07.040170 INFO: initial parameter: ms1_error = 30
+1 day, 5:07:07.040220 INFO: initial parameter: ms2_error = 30
+1 day, 5:07:07.040280 INFO: initial parameter: rt_error = 2099.9331315
+1 day, 5:07:07.040332 INFO: initial parameter: mobility_error = 0.1
+1 day, 5:07:07.040377 INFO: initial parameter: column_type = library
+1 day, 5:07:07.040418 INFO: initial parameter: num_candidates = 1
+1 day, 5:07:07.040459 INFO: initial parameter: classifier_version = -1
+1 day, 5:07:07.040499 INFO: initial parameter: fwhm_rt = 5
+1 day, 5:07:07.040541 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 5:07:07.040582 INFO: initial parameter: score_cutoff = 0
+1 day, 5:07:07.040648 INFO: Initializing TimingManager
+1 day, 5:07:07.040710 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 5:07:07.040831 INFO: FDRManager not loaded from disk.
+1 day, 5:07:07.040855 INFO: Initializing FDRManager
+1 day, 5:07:07.040904 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 5:07:08.343185 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+1 day, 5:07:10.190801 PROGRESS: Starting initial search for precursors.
+1 day, 5:07:10.444234 INFO: Starting optimization step 0.
+1 day, 5:07:10.444473 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 5:07:10.444559 PROGRESS: Extracting batch of 15771 precursors
+1 day, 5:07:10.448040 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:07:10.448095 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:07:10.448128 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 5:07:10.448150 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 5:07:10.449255 INFO: Starting candidate selection
+1 day, 5:08:30.989736 INFO: Starting candidate scoring
+1 day, 5:08:31.750243 INFO: Finished candidate processing
+1 day, 5:08:31.750398 INFO: Collecting candidate features
+1 day, 5:08:31.811239 WARNING: intensity_correlation has 1 NaNs ( 0.01 % out of 13769)
+1 day, 5:08:31.817322 INFO: Collecting fragment features
+1 day, 5:08:31.830137 INFO: Finished candidate scoring
+1 day, 5:08:31.838317 PROGRESS: === Extracted 13769 precursors and 138111 fragments ===
+1 day, 5:08:31.840005 INFO: performing precursor FDR with 47 features
+1 day, 5:08:31.840053 INFO: Decoy channel: -1
+1 day, 5:08:31.840077 INFO: Competetive: True
+1 day, 5:08:31.844987 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:08:31.847817 WARNING: dropped 1 target PSMs due to missing features
+1 day, 5:08:31.964303 INFO: Test AUC: 0.520
+1 day, 5:08:31.964422 INFO: Train AUC: 0.526
+1 day, 5:08:31.964458 INFO: AUC difference: 1.08%
+1 day, 5:08:32.054943 INFO: Resetting torch num_threads to 100
+1 day, 5:08:32.056781 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 5:08:32.058587 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:08:32.058722 PROGRESS: Total precursors accumulated: 7,051
+1 day, 5:08:32.058786 PROGRESS: Target precursors: 3,754 (53.24%)
+1 day, 5:08:32.058838 PROGRESS: Decoy precursors: 3,297 (46.76%)
+1 day, 5:08:32.058886 PROGRESS: 
+1 day, 5:08:32.058933 PROGRESS: Precursor Summary:
+1 day, 5:08:32.059836 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:08:32.059927 PROGRESS: 
+1 day, 5:08:32.059985 PROGRESS: Protein Summary:
+1 day, 5:08:32.060923 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:08:32.061016 PROGRESS: =========================================================================
+1 day, 5:08:32.562142 INFO: Starting optimization step 1.
+1 day, 5:08:32.562484 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 5:08:32.562569 PROGRESS: Extracting batch of 31534 precursors
+1 day, 5:08:32.572921 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:08:32.573017 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:08:32.573075 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 5:08:32.573102 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 5:08:32.574152 INFO: Starting candidate selection
+1 day, 5:11:05.686722 INFO: Starting candidate scoring
+1 day, 5:11:07.107514 INFO: Finished candidate processing
+1 day, 5:11:07.107649 INFO: Collecting candidate features
+1 day, 5:11:07.202116 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 27356)
+1 day, 5:11:07.206388 INFO: Collecting fragment features
+1 day, 5:11:07.226676 INFO: Finished candidate scoring
+1 day, 5:11:07.276261 PROGRESS: === Extracted 41125 precursors and 411700 fragments ===
+1 day, 5:11:07.281582 INFO: performing precursor FDR with 47 features
+1 day, 5:11:07.281674 INFO: Decoy channel: -1
+1 day, 5:11:07.281702 INFO: Competetive: True
+1 day, 5:11:07.301575 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:11:07.310666 WARNING: dropped 5 target PSMs due to missing features
+1 day, 5:11:07.310788 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 5:11:07.839553 INFO: Test AUC: 0.556
+1 day, 5:11:07.839747 INFO: Train AUC: 0.571
+1 day, 5:11:07.839781 INFO: AUC difference: 2.51%
+1 day, 5:11:07.932074 INFO: Resetting torch num_threads to 100
+1 day, 5:11:07.935115 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 5:11:07.941110 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:11:07.941292 PROGRESS: Total precursors accumulated: 21,081
+1 day, 5:11:07.941356 PROGRESS: Target precursors: 12,488 (59.24%)
+1 day, 5:11:07.941411 PROGRESS: Decoy precursors: 8,593 (40.76%)
+1 day, 5:11:07.941462 PROGRESS: 
+1 day, 5:11:07.941511 PROGRESS: Precursor Summary:
+1 day, 5:11:07.942638 PROGRESS: Channel   0:	 0.05 FDR:   217; 0.01 FDR:   108; 0.001 FDR:    74
+1 day, 5:11:07.942737 PROGRESS: 
+1 day, 5:11:07.942795 PROGRESS: Protein Summary:
+1 day, 5:11:07.943928 PROGRESS: Channel   0:	 0.05 FDR:   210; 0.01 FDR:   105; 0.001 FDR:    72
+1 day, 5:11:07.944021 PROGRESS: =========================================================================
+1 day, 5:11:08.185118 INFO: Starting optimization step 2.
+1 day, 5:11:08.185405 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 5:11:08.185486 PROGRESS: Extracting batch of 63016 precursors
+1 day, 5:11:08.201520 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:11:08.201653 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:11:08.201700 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 5:11:08.201724 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 5:11:08.202642 INFO: Starting candidate selection
+1 day, 5:16:07.057094 INFO: Starting candidate scoring
+1 day, 5:16:09.888317 INFO: Finished candidate processing
+1 day, 5:16:09.889342 INFO: Collecting candidate features
+1 day, 5:16:09.997535 WARNING: intensity_correlation has 8 NaNs ( 0.01 % out of 54891)
+1 day, 5:16:10.002839 INFO: Collecting fragment features
+1 day, 5:16:10.044607 INFO: Finished candidate scoring
+1 day, 5:16:10.183056 PROGRESS: === Extracted 96016 precursors and 961064 fragments ===
+1 day, 5:16:10.197403 INFO: performing precursor FDR with 47 features
+1 day, 5:16:10.197504 INFO: Decoy channel: -1
+1 day, 5:16:10.197531 INFO: Competetive: True
+1 day, 5:16:10.250833 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:16:10.276185 WARNING: dropped 10 target PSMs due to missing features
+1 day, 5:16:10.276334 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 5:16:12.038979 INFO: Test AUC: 0.560
+1 day, 5:16:12.039157 INFO: Train AUC: 0.586
+1 day, 5:16:12.039197 INFO: AUC difference: 4.39%
+1 day, 5:16:12.138009 INFO: Resetting torch num_threads to 100
+1 day, 5:16:12.144972 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 5:16:12.155491 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:16:12.155824 PROGRESS: Total precursors accumulated: 49,256
+1 day, 5:16:12.155896 PROGRESS: Target precursors: 30,048 (61.00%)
+1 day, 5:16:12.155959 PROGRESS: Decoy precursors: 19,208 (39.00%)
+1 day, 5:16:12.156018 PROGRESS: 
+1 day, 5:16:12.156075 PROGRESS: Precursor Summary:
+1 day, 5:16:12.157614 PROGRESS: Channel   0:	 0.05 FDR:   517; 0.01 FDR:   264; 0.001 FDR:   164
+1 day, 5:16:12.157734 PROGRESS: 
+1 day, 5:16:12.157801 PROGRESS: Protein Summary:
+1 day, 5:16:12.159216 PROGRESS: Channel   0:	 0.05 FDR:   480; 0.01 FDR:   247; 0.001 FDR:   157
+1 day, 5:16:12.159316 PROGRESS: =========================================================================
+1 day, 5:16:12.173011 INFO: fragments_df_filtered: 2515
+1 day, 5:16:12.441787 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 5:16:12.485053 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 5:16:12.528258 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 5:16:12.570090 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 5:16:12.688953 INFO: calibration group: precursor, predicting mz
+1 day, 5:16:12.705223 INFO: calibration group: precursor, predicting rt
+1 day, 5:16:12.776463 INFO: calibration group: precursor, predicting mobility
+1 day, 5:16:12.794895 INFO: calibration group: fragment, predicting mz
+1 day, 5:16:12.940912 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 5:16:12.941349 INFO: Starting optimization step 3.
+1 day, 5:16:12.941440 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 5:16:12.941542 PROGRESS: Extracting batch of 110321 precursors
+1 day, 5:16:12.991878 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:16:12.992020 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:16:12.992085 INFO: FWHM in RT is 3.34 seconds, sigma is 0.73
+1 day, 5:16:12.992115 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.25
+1 day, 5:16:12.992983 INFO: Starting candidate selection
+1 day, 5:24:59.334754 INFO: Starting candidate scoring
+1 day, 5:25:09.131341 INFO: Finished candidate processing
+1 day, 5:25:09.131655 INFO: Collecting candidate features
+1 day, 5:25:09.480867 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 189444)
+1 day, 5:25:09.481313 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 189444)
+1 day, 5:25:09.491078 INFO: Collecting fragment features
+1 day, 5:25:09.627432 INFO: Finished candidate scoring
+1 day, 5:25:09.810677 PROGRESS: === Extracted 189444 precursors and 1928124 fragments ===
+1 day, 5:25:09.811186 INFO: performing precursor FDR with 47 features
+1 day, 5:25:09.811227 INFO: Decoy channel: -1
+1 day, 5:25:09.811252 INFO: Competetive: True
+1 day, 5:25:09.889267 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:25:09.933546 WARNING: dropped 1 target PSMs due to missing features
+1 day, 5:25:09.933701 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 5:25:13.881278 INFO: Test AUC: 0.565
+1 day, 5:25:13.881422 INFO: Train AUC: 0.594
+1 day, 5:25:13.881455 INFO: AUC difference: 4.85%
+1 day, 5:25:13.981011 INFO: Resetting torch num_threads to 100
+1 day, 5:25:13.988259 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 5:25:13.999363 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:25:13.999669 PROGRESS: Total precursors accumulated: 50,280
+1 day, 5:25:13.999733 PROGRESS: Target precursors: 31,765 (63.18%)
+1 day, 5:25:13.999785 PROGRESS: Decoy precursors: 18,515 (36.82%)
+1 day, 5:25:13.999833 PROGRESS: 
+1 day, 5:25:13.999878 PROGRESS: Precursor Summary:
+1 day, 5:25:14.001418 PROGRESS: Channel   0:	 0.05 FDR:   531; 0.01 FDR:   354; 0.001 FDR:   236
+1 day, 5:25:14.001516 PROGRESS: 
+1 day, 5:25:14.001572 PROGRESS: Protein Summary:
+1 day, 5:25:14.003019 PROGRESS: Channel   0:	 0.05 FDR:   493; 0.01 FDR:   327; 0.001 FDR:   221
+1 day, 5:25:14.003119 PROGRESS: =========================================================================
+1 day, 5:25:14.018618 INFO: fragments_df_filtered: 4487
+1 day, 5:25:14.555186 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 5:25:14.609693 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 5:25:14.658135 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 5:25:14.706894 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 5:25:15.063892 INFO: calibration group: precursor, predicting mz
+1 day, 5:25:15.079678 INFO: calibration group: precursor, predicting rt
+1 day, 5:25:15.146362 INFO: calibration group: precursor, predicting mobility
+1 day, 5:25:15.161728 INFO: calibration group: fragment, predicting mz
+1 day, 5:25:15.300652 INFO: === checking if optimization conditions were reached ===
+1 day, 5:25:15.303001 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 5:25:15.303959 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 5:25:15.304006 INFO: ==============================================
+1 day, 5:25:15.304117 INFO: Starting optimization step 4.
+1 day, 5:25:15.304188 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 5:25:15.304253 PROGRESS: Extracting batch of 110321 precursors
+1 day, 5:25:15.338933 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:25:15.339070 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:25:15.339135 INFO: FWHM in RT is 3.18 seconds, sigma is 0.70
+1 day, 5:25:15.339163 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.05
+1 day, 5:25:15.348121 INFO: Starting candidate selection
+1 day, 5:33:20.589612 INFO: Starting candidate scoring
+1 day, 5:33:25.952936 INFO: Finished candidate processing
+1 day, 5:33:25.953130 INFO: Collecting candidate features
+1 day, 5:33:26.336351 WARNING: intensity_correlation has 8 NaNs ( 0.00 % out of 189371)
+1 day, 5:33:26.346713 INFO: Collecting fragment features
+1 day, 5:33:26.478556 INFO: Finished candidate scoring
+1 day, 5:33:26.598025 PROGRESS: === Extracted 189371 precursors and 1858213 fragments ===
+1 day, 5:33:26.598656 INFO: performing precursor FDR with 47 features
+1 day, 5:33:26.598697 INFO: Decoy channel: -1
+1 day, 5:33:26.598722 INFO: Competetive: True
+1 day, 5:33:26.677485 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:33:26.722183 WARNING: dropped 2 target PSMs due to missing features
+1 day, 5:33:26.722324 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 5:33:30.444743 INFO: Test AUC: 0.559
+1 day, 5:33:30.444906 INFO: Train AUC: 0.591
+1 day, 5:33:30.444941 INFO: AUC difference: 5.50%
+1 day, 5:33:30.444963 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:33:30.544967 INFO: Resetting torch num_threads to 100
+1 day, 5:33:30.579670 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 5:33:30.592024 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:33:30.592302 PROGRESS: Total precursors accumulated: 50,235
+1 day, 5:33:30.592367 PROGRESS: Target precursors: 31,145 (62.00%)
+1 day, 5:33:30.592419 PROGRESS: Decoy precursors: 19,090 (38.00%)
+1 day, 5:33:30.592466 PROGRESS: 
+1 day, 5:33:30.592512 PROGRESS: Precursor Summary:
+1 day, 5:33:30.594095 PROGRESS: Channel   0:	 0.05 FDR:   898; 0.01 FDR:   602; 0.001 FDR:   338
+1 day, 5:33:30.594197 PROGRESS: 
+1 day, 5:33:30.594255 PROGRESS: Protein Summary:
+1 day, 5:33:30.595907 PROGRESS: Channel   0:	 0.05 FDR:   814; 0.01 FDR:   547; 0.001 FDR:   303
+1 day, 5:33:30.596003 PROGRESS: =========================================================================
+1 day, 5:33:30.612421 INFO: fragments_df_filtered: 5000
+1 day, 5:33:30.810227 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 5:33:30.855377 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 5:33:30.899462 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 5:33:30.942007 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 5:33:31.293937 INFO: calibration group: precursor, predicting mz
+1 day, 5:33:31.301193 INFO: calibration group: precursor, predicting rt
+1 day, 5:33:31.329450 INFO: calibration group: precursor, predicting mobility
+1 day, 5:33:31.335705 INFO: calibration group: fragment, predicting mz
+1 day, 5:33:31.388494 INFO: === checking if optimization conditions were reached ===
+1 day, 5:33:31.391182 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 5:33:31.392399 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 5:33:31.392475 INFO: ==============================================
+1 day, 5:33:31.392924 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 5:33:31.571186 INFO: calibration group: precursor, predicting mz
+1 day, 5:33:31.578630 INFO: calibration group: precursor, predicting rt
+1 day, 5:33:31.606909 INFO: calibration group: precursor, predicting mobility
+1 day, 5:33:31.613185 INFO: calibration group: fragment, predicting mz
+1 day, 5:33:31.666611 INFO: Starting optimization step 0.
+1 day, 5:33:31.666909 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 5:33:31.667019 PROGRESS: Extracting batch of 47305 precursors
+1 day, 5:33:31.736874 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:33:31.737037 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:33:31.737162 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:33:31.737194 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.19
+1 day, 5:33:31.738283 INFO: Starting candidate selection
+1 day, 5:37:06.778624 INFO: Starting candidate scoring
+1 day, 5:37:09.249389 INFO: Finished candidate processing
+1 day, 5:37:09.250580 INFO: Collecting candidate features
+1 day, 5:37:09.388578 WARNING: intensity_correlation has 5 NaNs ( 0.01 % out of 81104)
+1 day, 5:37:09.395422 INFO: Collecting fragment features
+1 day, 5:37:09.462985 INFO: Finished candidate scoring
+1 day, 5:37:09.499344 PROGRESS: === Extracted 81104 precursors and 793603 fragments ===
+1 day, 5:37:09.499827 INFO: performing precursor FDR with 47 features
+1 day, 5:37:09.499867 INFO: Decoy channel: -1
+1 day, 5:37:09.499892 INFO: Competetive: True
+1 day, 5:37:09.527957 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:37:09.544535 WARNING: dropped 3 target PSMs due to missing features
+1 day, 5:37:09.544677 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 5:37:11.088528 INFO: Test AUC: 0.567
+1 day, 5:37:11.088668 INFO: Train AUC: 0.615
+1 day, 5:37:11.088703 INFO: AUC difference: 7.92%
+1 day, 5:37:11.088727 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:37:11.181306 INFO: Resetting torch num_threads to 100
+1 day, 5:37:11.184149 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 5:37:11.187893 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:37:11.188053 PROGRESS: Total precursors accumulated: 21,515
+1 day, 5:37:11.188117 PROGRESS: Target precursors: 13,823 (64.25%)
+1 day, 5:37:11.188169 PROGRESS: Decoy precursors: 7,692 (35.75%)
+1 day, 5:37:11.188219 PROGRESS: 
+1 day, 5:37:11.188264 PROGRESS: Precursor Summary:
+1 day, 5:37:11.189465 PROGRESS: Channel   0:	 0.05 FDR:   468; 0.01 FDR:   335; 0.001 FDR:   201
+1 day, 5:37:11.189564 PROGRESS: 
+1 day, 5:37:11.189620 PROGRESS: Protein Summary:
+1 day, 5:37:11.190890 PROGRESS: Channel   0:	 0.05 FDR:   451; 0.01 FDR:   321; 0.001 FDR:   195
+1 day, 5:37:11.190982 PROGRESS: =========================================================================
+1 day, 5:37:11.265763 INFO: fragments_df_filtered: 3599
+1 day, 5:37:11.438265 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 5:37:11.488243 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 5:37:11.539074 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 5:37:11.587950 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 5:37:11.857865 INFO: calibration group: precursor, predicting mz
+1 day, 5:37:11.865277 INFO: calibration group: precursor, predicting rt
+1 day, 5:37:11.893752 INFO: calibration group: precursor, predicting mobility
+1 day, 5:37:11.900294 INFO: calibration group: fragment, predicting mz
+1 day, 5:37:11.954262 INFO: === checking if optimization conditions were reached ===
+1 day, 5:37:11.954539 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 5:37:11.956562 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 928.1790.
+1 day, 5:37:11.956614 INFO: ==============================================
+1 day, 5:37:11.956726 INFO: Starting optimization step 1.
+1 day, 5:37:11.956795 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 5:37:11.956861 PROGRESS: Extracting batch of 47305 precursors
+1 day, 5:37:11.968986 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:37:11.969117 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:37:11.969169 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:37:11.969193 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.95
+1 day, 5:37:11.994045 INFO: Starting candidate selection
+1 day, 5:38:48.530950 INFO: Starting candidate scoring
+1 day, 5:38:50.758500 INFO: Finished candidate processing
+1 day, 5:38:50.758858 INFO: Collecting candidate features
+1 day, 5:38:50.970067 WARNING: intensity_correlation has 19 NaNs ( 0.02 % out of 80352)
+1 day, 5:38:50.978398 INFO: Collecting fragment features
+1 day, 5:38:51.037493 INFO: Finished candidate scoring
+1 day, 5:38:51.086477 PROGRESS: === Extracted 80352 precursors and 779952 fragments ===
+1 day, 5:38:51.087107 INFO: performing precursor FDR with 47 features
+1 day, 5:38:51.087146 INFO: Decoy channel: -1
+1 day, 5:38:51.087171 INFO: Competetive: True
+1 day, 5:38:51.114974 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:38:51.130098 WARNING: dropped 11 target PSMs due to missing features
+1 day, 5:38:51.130225 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 5:38:52.695459 INFO: Test AUC: 0.562
+1 day, 5:38:52.695585 INFO: Train AUC: 0.598
+1 day, 5:38:52.695614 INFO: AUC difference: 6.15%
+1 day, 5:38:52.695635 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:38:52.786844 INFO: Resetting torch num_threads to 100
+1 day, 5:38:52.789377 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 5:38:52.792989 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:38:52.793150 PROGRESS: Total precursors accumulated: 21,408
+1 day, 5:38:52.793215 PROGRESS: Target precursors: 13,446 (62.81%)
+1 day, 5:38:52.793267 PROGRESS: Decoy precursors: 7,962 (37.19%)
+1 day, 5:38:52.793315 PROGRESS: 
+1 day, 5:38:52.793360 PROGRESS: Precursor Summary:
+1 day, 5:38:52.794764 PROGRESS: Channel   0:	 0.05 FDR:   442; 0.01 FDR:   310; 0.001 FDR:   224
+1 day, 5:38:52.794863 PROGRESS: 
+1 day, 5:38:52.794917 PROGRESS: Protein Summary:
+1 day, 5:38:52.796174 PROGRESS: Channel   0:	 0.05 FDR:   425; 0.01 FDR:   296; 0.001 FDR:   217
+1 day, 5:38:52.796265 PROGRESS: =========================================================================
+1 day, 5:38:52.802947 INFO: fragments_df_filtered: 3333
+1 day, 5:38:52.973228 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 5:38:53.014513 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 5:38:53.052604 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 5:38:53.090311 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 5:38:53.269702 INFO: calibration group: precursor, predicting mz
+1 day, 5:38:53.276796 INFO: calibration group: precursor, predicting rt
+1 day, 5:38:53.305066 INFO: calibration group: precursor, predicting mobility
+1 day, 5:38:53.311482 INFO: calibration group: fragment, predicting mz
+1 day, 5:38:53.363619 INFO: === checking if optimization conditions were reached ===
+1 day, 5:38:53.363904 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 5:38:53.365974 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 647.3889.
+1 day, 5:38:53.366031 INFO: ==============================================
+1 day, 5:38:53.366132 INFO: Starting optimization step 2.
+1 day, 5:38:53.366211 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 5:38:53.366287 PROGRESS: Extracting batch of 47305 precursors
+1 day, 5:38:53.378042 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:38:53.378159 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:38:53.378214 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:38:53.378257 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:38:53.379335 INFO: Starting candidate selection
+1 day, 5:39:58.406611 INFO: Starting candidate scoring
+1 day, 5:39:59.869277 INFO: Finished candidate processing
+1 day, 5:39:59.870418 INFO: Collecting candidate features
+1 day, 5:40:00.037895 WARNING: intensity_correlation has 308 NaNs ( 0.41 % out of 74798)
+1 day, 5:40:00.038260 WARNING: height_correlation has 11 NaNs ( 0.01 % out of 74798)
+1 day, 5:40:00.044555 INFO: Collecting fragment features
+1 day, 5:40:00.093980 INFO: Finished candidate scoring
+1 day, 5:40:00.142174 PROGRESS: === Extracted 74798 precursors and 452989 fragments ===
+1 day, 5:40:00.142768 INFO: performing precursor FDR with 47 features
+1 day, 5:40:00.142815 INFO: Decoy channel: -1
+1 day, 5:40:00.142842 INFO: Competetive: True
+1 day, 5:40:00.182683 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:40:00.202167 WARNING: dropped 160 target PSMs due to missing features
+1 day, 5:40:00.202326 WARNING: dropped 153 decoy PSMs due to missing features
+1 day, 5:40:01.636956 INFO: Test AUC: 0.531
+1 day, 5:40:01.637125 INFO: Train AUC: 0.576
+1 day, 5:40:01.637156 INFO: AUC difference: 7.74%
+1 day, 5:40:01.637178 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:40:01.732624 INFO: Resetting torch num_threads to 100
+1 day, 5:40:01.736364 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 5:40:01.740930 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:40:01.741115 PROGRESS: Total precursors accumulated: 20,619
+1 day, 5:40:01.741183 PROGRESS: Target precursors: 12,049 (58.44%)
+1 day, 5:40:01.741235 PROGRESS: Decoy precursors: 8,570 (41.56%)
+1 day, 5:40:01.741288 PROGRESS: 
+1 day, 5:40:01.741337 PROGRESS: Precursor Summary:
+1 day, 5:40:01.742339 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:40:01.742434 PROGRESS: 
+1 day, 5:40:01.742492 PROGRESS: Protein Summary:
+1 day, 5:40:01.743497 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:40:01.743590 PROGRESS: =========================================================================
+1 day, 5:40:01.992794 INFO: calibration group: precursor, predicting mz
+1 day, 5:40:02.002942 INFO: calibration group: precursor, predicting rt
+1 day, 5:40:02.043308 INFO: calibration group: precursor, predicting mobility
+1 day, 5:40:02.056288 INFO: calibration group: fragment, predicting mz
+1 day, 5:40:02.127924 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:40:02.128212 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+1 day, 5:40:02.128280 INFO: Starting optimization step 3.
+1 day, 5:40:02.128349 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 5:40:02.128416 PROGRESS: Extracting batch of 63016 precursors
+1 day, 5:40:02.144896 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:40:02.145016 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:40:02.145076 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:40:02.145100 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:40:02.146115 INFO: Starting candidate selection
+1 day, 5:41:27.484736 INFO: Starting candidate scoring
+1 day, 5:41:29.248475 INFO: Finished candidate processing
+1 day, 5:41:29.248677 INFO: Collecting candidate features
+1 day, 5:41:29.509855 WARNING: intensity_correlation has 463 NaNs ( 0.47 % out of 99516)
+1 day, 5:41:29.510178 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 99516)
+1 day, 5:41:29.517235 INFO: Collecting fragment features
+1 day, 5:41:29.583170 INFO: Finished candidate scoring
+1 day, 5:41:29.718041 PROGRESS: === Extracted 174314 precursors and 1055981 fragments ===
+1 day, 5:41:29.735101 INFO: performing precursor FDR with 47 features
+1 day, 5:41:29.735219 INFO: Decoy channel: -1
+1 day, 5:41:29.735247 INFO: Competetive: True
+1 day, 5:41:29.807325 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:41:29.840042 WARNING: dropped 420 target PSMs due to missing features
+1 day, 5:41:29.840171 WARNING: dropped 359 decoy PSMs due to missing features
+1 day, 5:41:33.445148 INFO: Test AUC: 0.530
+1 day, 5:41:33.445272 INFO: Train AUC: 0.574
+1 day, 5:41:33.445308 INFO: AUC difference: 7.57%
+1 day, 5:41:33.445336 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:41:33.541953 INFO: Resetting torch num_threads to 100
+1 day, 5:41:33.549569 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 5:41:33.558201 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:41:33.558480 PROGRESS: Total precursors accumulated: 48,116
+1 day, 5:41:33.558544 PROGRESS: Target precursors: 28,107 (58.42%)
+1 day, 5:41:33.558595 PROGRESS: Decoy precursors: 20,009 (41.58%)
+1 day, 5:41:33.558643 PROGRESS: 
+1 day, 5:41:33.558690 PROGRESS: Precursor Summary:
+1 day, 5:41:33.559908 PROGRESS: Channel   0:	 0.05 FDR:    11; 0.01 FDR:    11; 0.001 FDR:    11
+1 day, 5:41:33.560000 PROGRESS: 
+1 day, 5:41:33.560055 PROGRESS: Protein Summary:
+1 day, 5:41:33.561271 PROGRESS: Channel   0:	 0.05 FDR:    11; 0.01 FDR:    11; 0.001 FDR:    11
+1 day, 5:41:33.561365 PROGRESS: =========================================================================
+1 day, 5:41:33.840167 INFO: calibration group: precursor, predicting mz
+1 day, 5:41:33.857457 INFO: calibration group: precursor, predicting rt
+1 day, 5:41:33.933183 INFO: calibration group: precursor, predicting mobility
+1 day, 5:41:33.950620 INFO: calibration group: fragment, predicting mz
+1 day, 5:41:34.107496 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:41:34.107787 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+1 day, 5:41:34.108499 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 928.1790 found after 2 searches.
+1 day, 5:41:34.108569 PROGRESS: Optimization finished for rt_error.
+1 day, 5:41:34.281830 INFO: calibration group: precursor, predicting mz
+1 day, 5:41:34.289231 INFO: calibration group: precursor, predicting rt
+1 day, 5:41:34.317988 INFO: calibration group: precursor, predicting mobility
+1 day, 5:41:34.324592 INFO: calibration group: fragment, predicting mz
+1 day, 5:41:34.404343 INFO: Starting optimization step 0.
+1 day, 5:41:34.404544 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 5:41:34.404621 PROGRESS: Extracting batch of 47305 precursors
+1 day, 5:41:34.415971 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:41:34.416085 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:41:34.416135 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:41:34.416160 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:41:34.417172 INFO: Starting candidate selection
+1 day, 5:43:10.220728 INFO: Starting candidate scoring
+1 day, 5:43:11.722082 INFO: Finished candidate processing
+1 day, 5:43:11.722193 INFO: Collecting candidate features
+1 day, 5:43:11.847225 WARNING: intensity_correlation has 290 NaNs ( 0.38 % out of 75669)
+1 day, 5:43:11.847545 WARNING: height_correlation has 7 NaNs ( 0.01 % out of 75669)
+1 day, 5:43:11.853446 INFO: Collecting fragment features
+1 day, 5:43:11.896521 INFO: Finished candidate scoring
+1 day, 5:43:11.938788 PROGRESS: === Extracted 75669 precursors and 461330 fragments ===
+1 day, 5:43:11.939307 INFO: performing precursor FDR with 47 features
+1 day, 5:43:11.939347 INFO: Decoy channel: -1
+1 day, 5:43:11.939371 INFO: Competetive: True
+1 day, 5:43:11.968514 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:43:11.983033 WARNING: dropped 151 target PSMs due to missing features
+1 day, 5:43:11.983167 WARNING: dropped 144 decoy PSMs due to missing features
+1 day, 5:43:13.516596 INFO: Test AUC: 0.533
+1 day, 5:43:13.516725 INFO: Train AUC: 0.589
+1 day, 5:43:13.516756 INFO: AUC difference: 9.55%
+1 day, 5:43:13.516781 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:43:13.618341 INFO: Resetting torch num_threads to 100
+1 day, 5:43:13.620868 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 5:43:13.624396 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:43:13.624571 PROGRESS: Total precursors accumulated: 20,819
+1 day, 5:43:13.624638 PROGRESS: Target precursors: 12,454 (59.82%)
+1 day, 5:43:13.624692 PROGRESS: Decoy precursors: 8,365 (40.18%)
+1 day, 5:43:13.624741 PROGRESS: 
+1 day, 5:43:13.624788 PROGRESS: Precursor Summary:
+1 day, 5:43:13.625812 PROGRESS: Channel   0:	 0.05 FDR:    29; 0.01 FDR:     8; 0.001 FDR:     8
+1 day, 5:43:13.625912 PROGRESS: 
+1 day, 5:43:13.625969 PROGRESS: Protein Summary:
+1 day, 5:43:13.627030 PROGRESS: Channel   0:	 0.05 FDR:    29; 0.01 FDR:     8; 0.001 FDR:     8
+1 day, 5:43:13.627126 PROGRESS: =========================================================================
+1 day, 5:43:13.835821 INFO: calibration group: precursor, predicting mz
+1 day, 5:43:13.845471 INFO: calibration group: precursor, predicting rt
+1 day, 5:43:13.884601 INFO: calibration group: precursor, predicting mobility
+1 day, 5:43:13.895193 INFO: calibration group: fragment, predicting mz
+1 day, 5:43:13.974809 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:43:13.975145 PROGRESS: === Optimization of mobility_error has been skipped 1 time(s); maximum number is 1 ===
+1 day, 5:43:13.975222 INFO: Starting optimization step 1.
+1 day, 5:43:13.975302 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 5:43:13.975397 PROGRESS: Extracting batch of 63016 precursors
+1 day, 5:43:13.998371 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:43:13.998524 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:43:13.998584 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:43:13.998616 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:43:14.005848 INFO: Starting candidate selection
+1 day, 5:45:21.771278 INFO: Starting candidate scoring
+1 day, 5:45:23.683760 INFO: Finished candidate processing
+1 day, 5:45:23.683867 INFO: Collecting candidate features
+1 day, 5:45:23.843070 WARNING: intensity_correlation has 457 NaNs ( 0.45 % out of 100695)
+1 day, 5:45:23.843399 WARNING: height_correlation has 4 NaNs ( 0.00 % out of 100695)
+1 day, 5:45:23.850243 INFO: Collecting fragment features
+1 day, 5:45:23.914073 INFO: Finished candidate scoring
+1 day, 5:45:24.047620 PROGRESS: === Extracted 176364 precursors and 1075771 fragments ===
+1 day, 5:45:24.064608 INFO: performing precursor FDR with 47 features
+1 day, 5:45:24.064744 INFO: Decoy channel: -1
+1 day, 5:45:24.064772 INFO: Competetive: True
+1 day, 5:45:24.141315 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:45:24.187221 WARNING: dropped 406 target PSMs due to missing features
+1 day, 5:45:24.187351 WARNING: dropped 348 decoy PSMs due to missing features
+1 day, 5:45:28.210539 INFO: Test AUC: 0.534
+1 day, 5:45:28.210665 INFO: Train AUC: 0.578
+1 day, 5:45:28.210696 INFO: AUC difference: 7.67%
+1 day, 5:45:28.210720 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 5:45:28.306795 INFO: Resetting torch num_threads to 100
+1 day, 5:45:28.314691 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 5:45:28.323644 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:45:28.323929 PROGRESS: Total precursors accumulated: 48,525
+1 day, 5:45:28.323995 PROGRESS: Target precursors: 28,233 (58.18%)
+1 day, 5:45:28.324049 PROGRESS: Decoy precursors: 20,292 (41.82%)
+1 day, 5:45:28.324099 PROGRESS: 
+1 day, 5:45:28.324146 PROGRESS: Precursor Summary:
+1 day, 5:45:28.325307 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:45:28.325404 PROGRESS: 
+1 day, 5:45:28.325459 PROGRESS: Protein Summary:
+1 day, 5:45:28.326568 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 5:45:28.326658 PROGRESS: =========================================================================
+1 day, 5:45:28.597790 INFO: calibration group: precursor, predicting mz
+1 day, 5:45:28.615463 INFO: calibration group: precursor, predicting rt
+1 day, 5:45:28.694064 INFO: calibration group: precursor, predicting mobility
+1 day, 5:45:28.713520 INFO: calibration group: fragment, predicting mz
+1 day, 5:45:28.883613 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:45:28.883954 PROGRESS: === Optimization of mobility_error has been skipped 2 time(s); maximum number is 1 ===
+1 day, 5:45:28.884029 INFO: Starting optimization step 2.
+1 day, 5:45:28.884111 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+1 day, 5:45:28.884192 PROGRESS: Extracting batch of 126066 precursors
+1 day, 5:45:28.932334 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:45:28.932466 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:45:28.932518 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:45:28.932542 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:45:28.933495 INFO: Starting candidate selection
+1 day, 5:49:39.153967 INFO: Starting candidate scoring
+1 day, 5:49:42.779376 INFO: Finished candidate processing
+1 day, 5:49:42.779931 INFO: Collecting candidate features
+1 day, 5:49:43.248710 WARNING: intensity_correlation has 825 NaNs ( 0.41 % out of 201454)
+1 day, 5:49:43.249135 WARNING: height_correlation has 20 NaNs ( 0.01 % out of 201454)
+1 day, 5:49:43.260936 INFO: Collecting fragment features
+1 day, 5:49:43.374297 INFO: Finished candidate scoring
+1 day, 5:49:43.629806 PROGRESS: === Extracted 377818 precursors and 2304509 fragments ===
+1 day, 5:49:43.667153 INFO: performing precursor FDR with 47 features
+1 day, 5:49:43.667293 INFO: Decoy channel: -1
+1 day, 5:49:43.667324 INFO: Competetive: True
+1 day, 5:49:43.833697 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:49:43.906306 WARNING: dropped 860 target PSMs due to missing features
+1 day, 5:49:43.906452 WARNING: dropped 730 decoy PSMs due to missing features
+1 day, 5:49:51.771276 INFO: Test AUC: 0.539
+1 day, 5:49:51.771411 INFO: Train AUC: 0.562
+1 day, 5:49:51.771442 INFO: AUC difference: 4.14%
+1 day, 5:49:51.885738 INFO: Resetting torch num_threads to 100
+1 day, 5:49:51.903959 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 5:49:51.924565 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:49:51.924897 PROGRESS: Total precursors accumulated: 103,965
+1 day, 5:49:51.924973 PROGRESS: Target precursors: 59,778 (57.50%)
+1 day, 5:49:51.925034 PROGRESS: Decoy precursors: 44,187 (42.50%)
+1 day, 5:49:51.925086 PROGRESS: 
+1 day, 5:49:51.925132 PROGRESS: Precursor Summary:
+1 day, 5:49:51.926708 PROGRESS: Channel   0:	 0.05 FDR:    10; 0.01 FDR:    10; 0.001 FDR:    10
+1 day, 5:49:51.926806 PROGRESS: 
+1 day, 5:49:51.926864 PROGRESS: Protein Summary:
+1 day, 5:49:51.928308 PROGRESS: Channel   0:	 0.05 FDR:    10; 0.01 FDR:    10; 0.001 FDR:    10
+1 day, 5:49:51.928408 PROGRESS: =========================================================================
+1 day, 5:49:52.338324 INFO: calibration group: precursor, predicting mz
+1 day, 5:49:52.372378 INFO: calibration group: precursor, predicting rt
+1 day, 5:49:52.526228 INFO: calibration group: precursor, predicting mobility
+1 day, 5:49:52.560570 INFO: calibration group: fragment, predicting mz
+1 day, 5:49:52.862743 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:49:52.863108 PROGRESS: === Optimization of mobility_error has been skipped 3 time(s); maximum number is 1 ===
+1 day, 5:49:52.863196 INFO: Starting optimization step 3.
+1 day, 5:49:52.863290 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+1 day, 5:49:52.863373 PROGRESS: Extracting batch of 252186 precursors
+1 day, 5:49:52.929407 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:49:52.929542 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:49:52.929595 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:49:52.929632 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:49:52.930501 INFO: Starting candidate selection
+1 day, 5:58:18.836363 INFO: Starting candidate scoring
+1 day, 5:58:25.854419 INFO: Finished candidate processing
+1 day, 5:58:25.855713 INFO: Collecting candidate features
+1 day, 5:58:26.595680 WARNING: intensity_correlation has 1682 NaNs ( 0.42 % out of 402483)
+1 day, 5:58:26.596313 WARNING: height_correlation has 32 NaNs ( 0.01 % out of 402483)
+1 day, 5:58:26.614506 INFO: Collecting fragment features
+1 day, 5:58:26.830599 INFO: Finished candidate scoring
+1 day, 5:58:27.274586 PROGRESS: === Extracted 780301 precursors and 4758413 fragments ===
+1 day, 5:58:27.346816 INFO: performing precursor FDR with 47 features
+1 day, 5:58:27.346953 INFO: Decoy channel: -1
+1 day, 5:58:27.346979 INFO: Competetive: True
+1 day, 5:58:27.700319 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 5:58:27.856907 WARNING: dropped 1771 target PSMs due to missing features
+1 day, 5:58:27.857061 WARNING: dropped 1521 decoy PSMs due to missing features
+1 day, 5:58:44.707110 INFO: Test AUC: 0.538
+1 day, 5:58:44.707250 INFO: Train AUC: 0.560
+1 day, 5:58:44.707281 INFO: AUC difference: 3.79%
+1 day, 5:58:44.849686 INFO: Resetting torch num_threads to 100
+1 day, 5:58:44.887431 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 5:58:44.926096 PROGRESS: ============================= Precursor FDR =============================
+1 day, 5:58:44.926393 PROGRESS: Total precursors accumulated: 214,670
+1 day, 5:58:44.926461 PROGRESS: Target precursors: 122,628 (57.12%)
+1 day, 5:58:44.926512 PROGRESS: Decoy precursors: 92,042 (42.88%)
+1 day, 5:58:44.926561 PROGRESS: 
+1 day, 5:58:44.926607 PROGRESS: Precursor Summary:
+1 day, 5:58:44.928795 PROGRESS: Channel   0:	 0.05 FDR:    12; 0.01 FDR:    12; 0.001 FDR:    12
+1 day, 5:58:44.928913 PROGRESS: 
+1 day, 5:58:44.928971 PROGRESS: Protein Summary:
+1 day, 5:58:44.930946 PROGRESS: Channel   0:	 0.05 FDR:    12; 0.01 FDR:    12; 0.001 FDR:    12
+1 day, 5:58:44.931043 PROGRESS: =========================================================================
+1 day, 5:58:45.561255 INFO: calibration group: precursor, predicting mz
+1 day, 5:58:45.626595 INFO: calibration group: precursor, predicting rt
+1 day, 5:58:45.939986 INFO: calibration group: precursor, predicting mobility
+1 day, 5:58:46.008703 INFO: calibration group: fragment, predicting mz
+1 day, 5:58:46.607587 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 5:58:46.607900 PROGRESS: === Optimization of mobility_error has been skipped 4 time(s); maximum number is 1 ===
+1 day, 5:58:46.607976 INFO: Starting optimization step 4.
+1 day, 5:58:46.608047 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+1 day, 5:58:46.608114 PROGRESS: Extracting batch of 504181 precursors
+1 day, 5:58:46.730517 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 5:58:46.730647 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 5:58:46.730697 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 5:58:46.730721 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 5:58:46.731654 INFO: Starting candidate selection
+1 day, 6:15:25.816559 INFO: Starting candidate scoring
+1 day, 6:15:39.397619 INFO: Finished candidate processing
+1 day, 6:15:39.398015 INFO: Collecting candidate features
+1 day, 6:15:41.347618 WARNING: intensity_correlation has 3391 NaNs ( 0.42 % out of 806192)
+1 day, 6:15:41.348589 WARNING: height_correlation has 87 NaNs ( 0.01 % out of 806192)
+1 day, 6:15:41.379760 INFO: Collecting fragment features
+1 day, 6:15:41.824660 INFO: Finished candidate scoring
+1 day, 6:15:42.819839 PROGRESS: === Extracted 1586493 precursors and 9669491 fragments ===
+1 day, 6:15:42.991578 INFO: performing precursor FDR with 47 features
+1 day, 6:15:42.991748 INFO: Decoy channel: -1
+1 day, 6:15:42.991777 INFO: Competetive: True
+1 day, 6:15:43.850148 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 6:15:44.222489 WARNING: dropped 3681 target PSMs due to missing features
+1 day, 6:15:44.222664 WARNING: dropped 3053 decoy PSMs due to missing features
+1 day, 6:16:16.208036 INFO: Test AUC: 0.543
+1 day, 6:16:16.208494 INFO: Train AUC: 0.552
+1 day, 6:16:16.208549 INFO: AUC difference: 1.56%
+1 day, 6:16:16.424190 INFO: Resetting torch num_threads to 100
+1 day, 6:16:16.609385 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 6:16:16.697370 PROGRESS: ============================= Precursor FDR =============================
+1 day, 6:16:16.697690 PROGRESS: Total precursors accumulated: 436,463
+1 day, 6:16:16.697758 PROGRESS: Target precursors: 247,942 (56.81%)
+1 day, 6:16:16.697811 PROGRESS: Decoy precursors: 188,521 (43.19%)
+1 day, 6:16:16.697862 PROGRESS: 
+1 day, 6:16:16.697910 PROGRESS: Precursor Summary:
+1 day, 6:16:16.701218 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 6:16:16.701328 PROGRESS: 
+1 day, 6:16:16.701386 PROGRESS: Protein Summary:
+1 day, 6:16:16.704253 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 6:16:16.704353 PROGRESS: =========================================================================
+1 day, 6:16:17.777621 INFO: calibration group: precursor, predicting mz
+1 day, 6:16:17.913176 INFO: calibration group: precursor, predicting rt
+1 day, 6:16:18.531006 INFO: calibration group: precursor, predicting mobility
+1 day, 6:16:18.662752 INFO: calibration group: fragment, predicting mz
+1 day, 6:16:19.893827 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 6:16:19.894135 PROGRESS: === Optimization of mobility_error has been skipped 5 time(s); maximum number is 1 ===
+1 day, 6:16:19.894228 INFO: Starting optimization step 5.
+1 day, 6:16:19.894304 PROGRESS: === Extracting elution groups 504000 to 1016000 ===
+1 day, 6:16:19.894378 PROGRESS: Extracting batch of 1008477 precursors
+1 day, 6:16:20.142713 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 6:16:20.142840 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 6:16:20.142890 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 6:16:20.142915 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 6:16:20.144304 INFO: Starting candidate selection
+1 day, 6:49:50.718674 INFO: Starting candidate scoring
+1 day, 6:50:18.587351 INFO: Finished candidate processing
+1 day, 6:50:18.587566 INFO: Collecting candidate features
+1 day, 6:50:21.791298 WARNING: intensity_correlation has 6797 NaNs ( 0.42 % out of 1611068)
+1 day, 6:50:21.792906 WARNING: height_correlation has 143 NaNs ( 0.01 % out of 1611068)
+1 day, 6:50:21.848133 INFO: Collecting fragment features
+1 day, 6:50:22.760270 INFO: Finished candidate scoring
+1 day, 6:50:25.549104 PROGRESS: === Extracted 3197561 precursors and 19486926 fragments ===
+1 day, 6:50:25.860974 INFO: performing precursor FDR with 47 features
+1 day, 6:50:25.861143 INFO: Decoy channel: -1
+1 day, 6:50:25.861171 INFO: Competetive: True
+1 day, 6:50:27.250880 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 6:50:27.859649 WARNING: dropped 7430 target PSMs due to missing features
+1 day, 6:50:27.859800 WARNING: dropped 6194 decoy PSMs due to missing features
+1 day, 6:51:25.729953 INFO: Test AUC: 0.546
+1 day, 6:51:25.730195 INFO: Train AUC: 0.553
+1 day, 6:51:25.730233 INFO: AUC difference: 1.23%
+1 day, 6:51:26.039066 INFO: Resetting torch num_threads to 100
+1 day, 6:51:26.201311 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 6:51:26.366532 PROGRESS: ============================= Precursor FDR =============================
+1 day, 6:51:26.366887 PROGRESS: Total precursors accumulated: 879,771
+1 day, 6:51:26.366958 PROGRESS: Target precursors: 502,623 (57.13%)
+1 day, 6:51:26.367013 PROGRESS: Decoy precursors: 377,148 (42.87%)
+1 day, 6:51:26.367065 PROGRESS: 
+1 day, 6:51:26.367115 PROGRESS: Precursor Summary:
+1 day, 6:51:26.372566 PROGRESS: Channel   0:	 0.05 FDR:    12; 0.01 FDR:    12; 0.001 FDR:    12
+1 day, 6:51:26.372679 PROGRESS: 
+1 day, 6:51:26.372762 PROGRESS: Protein Summary:
+1 day, 6:51:26.377503 PROGRESS: Channel   0:	 0.05 FDR:    12; 0.01 FDR:    12; 0.001 FDR:    12
+1 day, 6:51:26.377611 PROGRESS: =========================================================================
+1 day, 6:51:28.072426 INFO: calibration group: precursor, predicting mz
+1 day, 6:51:28.347723 INFO: calibration group: precursor, predicting rt
+1 day, 6:51:29.613642 INFO: calibration group: precursor, predicting mobility
+1 day, 6:51:29.882163 INFO: calibration group: fragment, predicting mz
+1 day, 6:51:32.315285 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 6:51:32.315553 PROGRESS: === Optimization of mobility_error has been skipped 6 time(s); maximum number is 1 ===
+1 day, 6:51:32.315634 INFO: Starting optimization step 6.
+1 day, 6:51:32.315706 PROGRESS: === Extracting elution groups 1016000 to 2040000 ===
+1 day, 6:51:32.315776 PROGRESS: Extracting batch of 2017059 precursors
+1 day, 6:51:32.791675 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 6:51:32.791805 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 6:51:32.791855 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 6:51:32.791879 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 6:51:32.818864 INFO: Starting candidate selection
+1 day, 7:57:16.828232 INFO: Starting candidate scoring
+1 day, 7:58:10.015085 INFO: Finished candidate processing
+1 day, 7:58:10.015771 INFO: Collecting candidate features
+1 day, 7:58:16.382296 WARNING: intensity_correlation has 13596 NaNs ( 0.42 % out of 3222947)
+1 day, 7:58:16.385277 WARNING: height_correlation has 310 NaNs ( 0.01 % out of 3222947)
+1 day, 7:58:16.491967 INFO: Collecting fragment features
+1 day, 7:58:18.358294 INFO: Finished candidate scoring
+1 day, 7:58:23.103320 PROGRESS: === Extracted 6420508 precursors and 39130648 fragments ===
+1 day, 7:58:23.775283 INFO: performing precursor FDR with 47 features
+1 day, 7:58:23.775416 INFO: Decoy channel: -1
+1 day, 7:58:23.775444 INFO: Competetive: True
+1 day, 7:58:26.497588 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 7:58:27.740328 WARNING: dropped 15012 target PSMs due to missing features
+1 day, 7:58:27.740470 WARNING: dropped 12384 decoy PSMs due to missing features
+1 day, 8:00:24.617821 INFO: Test AUC: 0.549
+1 day, 8:00:24.618064 INFO: Train AUC: 0.553
+1 day, 8:00:24.618102 INFO: AUC difference: 0.66%
+1 day, 8:00:25.125573 INFO: Resetting torch num_threads to 100
+1 day, 8:00:25.479246 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 8:00:25.803565 PROGRESS: ============================= Precursor FDR =============================
+1 day, 8:00:25.803899 PROGRESS: Total precursors accumulated: 1,766,169
+1 day, 8:00:25.803979 PROGRESS: Target precursors: 1,012,938 (57.35%)
+1 day, 8:00:25.804034 PROGRESS: Decoy precursors: 753,231 (42.65%)
+1 day, 8:00:25.804082 PROGRESS: 
+1 day, 8:00:25.804127 PROGRESS: Precursor Summary:
+1 day, 8:00:25.813108 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 8:00:25.813269 PROGRESS: 
+1 day, 8:00:25.813328 PROGRESS: Protein Summary:
+1 day, 8:00:25.821530 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 8:00:25.821666 PROGRESS: =========================================================================
+1 day, 8:00:28.971327 INFO: calibration group: precursor, predicting mz
+1 day, 8:00:29.510397 INFO: calibration group: precursor, predicting rt
+1 day, 8:00:32.038786 INFO: calibration group: precursor, predicting mobility
+1 day, 8:00:32.553765 INFO: calibration group: fragment, predicting mz
+1 day, 8:00:37.395103 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 8:00:37.395380 PROGRESS: === Optimization of mobility_error has been skipped 7 time(s); maximum number is 1 ===
+1 day, 8:00:37.395460 INFO: Starting optimization step 7.
+1 day, 8:00:37.395530 PROGRESS: === Extracting elution groups 2040000 to 4088000 ===
+1 day, 8:00:37.395601 PROGRESS: Extracting batch of 4034279 precursors
+1 day, 8:00:38.318393 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 8:00:38.318525 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 8:00:38.318575 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 8:00:38.318602 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 8:00:38.322493 INFO: Starting candidate selection
+1 day, 10:09:55.408623 INFO: Starting candidate scoring
+1 day, 10:11:46.649007 INFO: Finished candidate processing
+1 day, 10:11:46.649559 INFO: Collecting candidate features
+1 day, 10:11:59.914125 WARNING: intensity_correlation has 27573 NaNs ( 0.43 % out of 6445452)
+1 day, 10:11:59.919864 WARNING: height_correlation has 596 NaNs ( 0.01 % out of 6445452)
+1 day, 10:12:00.134508 INFO: Collecting fragment features
+1 day, 10:12:04.170379 INFO: Finished candidate scoring
+1 day, 10:12:17.455229 PROGRESS: === Extracted 12865960 precursors and 78416882 fragments ===
+1 day, 10:12:18.821954 INFO: performing precursor FDR with 47 features
+1 day, 10:12:18.822089 INFO: Decoy channel: -1
+1 day, 10:12:18.822120 INFO: Competetive: True
+1 day, 10:12:24.568510 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 10:12:27.135487 WARNING: dropped 30138 target PSMs due to missing features
+1 day, 10:12:27.135651 WARNING: dropped 25171 decoy PSMs due to missing features
+1 day, 10:16:37.331042 INFO: Test AUC: 0.553
+1 day, 10:16:37.331308 INFO: Train AUC: 0.555
+1 day, 10:16:37.331351 INFO: AUC difference: 0.44%
+1 day, 10:16:38.130588 INFO: Resetting torch num_threads to 100
+1 day, 10:16:38.945898 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 10:16:39.597938 PROGRESS: ============================= Precursor FDR =============================
+1 day, 10:16:39.598265 PROGRESS: Total precursors accumulated: 3,539,232
+1 day, 10:16:39.598332 PROGRESS: Target precursors: 2,029,808 (57.35%)
+1 day, 10:16:39.598387 PROGRESS: Decoy precursors: 1,509,424 (42.65%)
+1 day, 10:16:39.598439 PROGRESS: 
+1 day, 10:16:39.598487 PROGRESS: Precursor Summary:
+1 day, 10:16:39.616879 PROGRESS: Channel   0:	 0.05 FDR:   984; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 10:16:39.617146 PROGRESS: 
+1 day, 10:16:39.617213 PROGRESS: Protein Summary:
+1 day, 10:16:39.635117 PROGRESS: Channel   0:	 0.05 FDR:   798; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 10:16:39.635354 PROGRESS: =========================================================================
+1 day, 10:16:41.634058 INFO: calibration group: precursor, predicting mz
+1 day, 10:16:41.943379 INFO: calibration group: precursor, predicting rt
+1 day, 10:16:43.348363 INFO: calibration group: precursor, predicting mobility
+1 day, 10:16:43.646237 INFO: calibration group: fragment, predicting mz
+1 day, 10:16:46.370483 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 10:16:46.370787 PROGRESS: === Optimization of mobility_error has been skipped 8 time(s); maximum number is 1 ===
+1 day, 10:16:46.370886 INFO: Starting optimization step 8.
+1 day, 10:16:46.370969 PROGRESS: === Extracting elution groups 4088000 to 5215079 ===
+1 day, 10:16:46.371046 PROGRESS: Extracting batch of 2220101 precursors
+1 day, 10:16:46.896145 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 10:16:46.896278 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 10:16:46.896328 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 10:16:46.896353 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 10:16:46.897605 INFO: Starting candidate selection
+1 day, 11:28:13.935907 INFO: Starting candidate scoring
+1 day, 11:29:15.345610 INFO: Finished candidate processing
+1 day, 11:29:15.346430 INFO: Collecting candidate features
+1 day, 11:29:22.772211 WARNING: intensity_correlation has 15033 NaNs ( 0.42 % out of 3548711)
+1 day, 11:29:22.775837 WARNING: height_correlation has 313 NaNs ( 0.01 % out of 3548711)
+1 day, 11:29:22.895730 INFO: Collecting fragment features
+1 day, 11:29:25.006925 INFO: Finished candidate scoring
+1 day, 11:29:34.921156 PROGRESS: === Extracted 16414671 precursors and 100023572 fragments ===
+1 day, 11:29:36.624189 INFO: performing precursor FDR with 47 features
+1 day, 11:29:36.624343 INFO: Decoy channel: -1
+1 day, 11:29:36.624378 INFO: Competetive: True
+1 day, 11:29:43.237189 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 11:29:46.254328 WARNING: dropped 38306 target PSMs due to missing features
+1 day, 11:29:46.254509 WARNING: dropped 32200 decoy PSMs due to missing features
+1 day, 11:35:38.091527 INFO: Test AUC: 0.550
+1 day, 11:35:38.091811 INFO: Train AUC: 0.556
+1 day, 11:35:38.091858 INFO: AUC difference: 1.00%
+1 day, 11:35:39.063962 INFO: Resetting torch num_threads to 100
+1 day, 11:35:40.071739 INFO: === FDR correction performed with classifier version 6 ===
+1 day, 11:35:40.894245 PROGRESS: ============================= Precursor FDR =============================
+1 day, 11:35:40.894596 PROGRESS: Total precursors accumulated: 4,515,476
+1 day, 11:35:40.894661 PROGRESS: Target precursors: 2,582,159 (57.18%)
+1 day, 11:35:40.894715 PROGRESS: Decoy precursors: 1,933,317 (42.82%)
+1 day, 11:35:40.894764 PROGRESS: 
+1 day, 11:35:40.894812 PROGRESS: Precursor Summary:
+1 day, 11:35:40.918636 PROGRESS: Channel   0:	 0.05 FDR: 1,625; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 11:35:40.918936 PROGRESS: 
+1 day, 11:35:40.919004 PROGRESS: Protein Summary:
+1 day, 11:35:40.942572 PROGRESS: Channel   0:	 0.05 FDR: 1,221; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 11:35:40.942858 PROGRESS: =========================================================================
+1 day, 11:35:41.061763 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 11:35:41.062109 PROGRESS: ==============================================
+1 day, 11:35:41.677580 INFO: fragments_df_filtered: 0
+1 day, 11:35:42.221453 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 11:35:42.221750 WARNING: Using current optimal value for ms2_error: 15.00.
+1 day, 11:35:42.764882 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 11:35:42.765196 WARNING: Using current optimal value for ms1_error: 10.00.
+1 day, 11:35:43.324761 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 11:35:43.326779 WARNING: Using current optimal value for rt_error: 928.18.
+1 day, 11:35:43.886334 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 11:35:43.887595 WARNING: Using current optimal value for mobility_error: 0.10.
+1 day, 11:35:43.895610 PROGRESS: ms2_error      : 15.0000
+1 day, 11:35:43.895882 PROGRESS: ms1_error      : 10.0000
+1 day, 11:35:43.895949 PROGRESS: rt_error       : 928.1790
+1 day, 11:35:43.896000 PROGRESS: mobility_error : 0.1000
+1 day, 11:35:43.896052 PROGRESS: ==============================================
+1 day, 11:35:44.187120 INFO: calibration group: precursor, predicting mz
+1 day, 11:35:45.630433 INFO: calibration group: precursor, predicting rt
+1 day, 11:35:52.014192 INFO: calibration group: precursor, predicting mobility
+1 day, 11:35:53.442992 INFO: calibration group: fragment, predicting mz
+1 day, 11:36:05.765460 PROGRESS: Extracting batch of 10272670 precursors
+1 day, 11:36:08.235186 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 11:36:08.235334 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 11:36:08.235389 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 11:36:08.235420 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.99
+1 day, 11:36:08.236684 INFO: Starting candidate selection
+1 day, 17:03:24.175734 INFO: Applying score cutoff of 16.388819221496583
+1 day, 17:03:24.761183 INFO: Removed 756755 precursors with score below cutoff
+1 day, 17:03:27.548187 INFO: Starting candidate scoring
+1 day, 17:08:09.152647 INFO: Finished candidate processing
+1 day, 17:08:09.154537 INFO: Collecting candidate features
+1 day, 17:08:38.125089 WARNING: intensity_correlation has 63896 NaNs ( 0.40 % out of 16085008)
+1 day, 17:08:38.139236 WARNING: height_correlation has 1153 NaNs ( 0.01 % out of 16085008)
+1 day, 17:08:38.670293 INFO: Collecting fragment features
+1 day, 17:08:47.720867 INFO: Finished candidate scoring
+1 day, 17:09:09.410645 INFO: === FDR correction performed with classifier version 17 ===
+1 day, 17:09:09.414616 INFO: performing precursor FDR with 47 features
+1 day, 17:09:09.414698 INFO: Decoy channel: -1
+1 day, 17:09:09.414726 INFO: Competetive: True
+1 day, 17:09:13.653986 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:09:16.260779 WARNING: dropped 35212 target PSMs due to missing features
+1 day, 17:09:16.260954 WARNING: dropped 29359 decoy PSMs due to missing features
+1 day, 17:14:59.713294 INFO: Test AUC: 0.551
+1 day, 17:14:59.713689 INFO: Train AUC: 0.557
+1 day, 17:14:59.713736 INFO: AUC difference: 1.09%
+1 day, 17:15:00.682325 INFO: Resetting torch num_threads to 100
+1 day, 17:15:01.180504 INFO: Removing fragments below FDR threshold
+1 day, 17:15:01.937288 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:15:01.937597 PROGRESS: Total precursors accumulated: 715
+1 day, 17:15:01.937670 PROGRESS: Target precursors: 708 (99.02%)
+1 day, 17:15:01.937724 PROGRESS: Decoy precursors: 7 (0.98%)
+1 day, 17:15:01.937776 PROGRESS: 
+1 day, 17:15:01.937823 PROGRESS: Precursor Summary:
+1 day, 17:15:01.939094 PROGRESS: Channel   0:	 0.05 FDR:   708; 0.01 FDR:   708; 0.001 FDR:     1
+1 day, 17:15:01.939214 PROGRESS: 
+1 day, 17:15:01.939272 PROGRESS: Protein Summary:
+1 day, 17:15:01.940656 PROGRESS: Channel   0:	 0.05 FDR:   584; 0.01 FDR:   584; 0.001 FDR:     1
+1 day, 17:15:01.940757 PROGRESS: =========================================================================
+1 day, 17:15:02.158285 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 17:15:03.005822 PROGRESS: Loading raw file 6/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 17:15:03.005992 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/library/quant
+1 day, 17:15:03.006079 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508 at run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 17:15:03.006932 INFO: Initializing RawFileManager
+1 day, 17:15:03.007060 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:03.007116 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:03.007159 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:03.228743 INFO: Reading 39,129 frames with 2,804,178,635 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.568964 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d...
+1 day, 17:15:13.570095 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.574828 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.575064 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.575429 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.577392 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.592142 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:13.592327 INFO: Indexing quadrupole dimension
+1 day, 17:15:14.079050 INFO: Transposing detector events
+1 day, 17:15:22.229283 INFO: Finished transposing data
+1 day, 17:15:22.266391 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 17:15:22.269588 INFO: RT (min)            : 0.0 - 70.0
+1 day, 17:15:22.269689 INFO: RT duration (sec)   : 4199.8
+1 day, 17:15:22.269749 INFO: RT duration (min)   : 70.0
+1 day, 17:15:22.269802 INFO: Cycle len (scans)   : 9
+1 day, 17:15:22.269849 INFO: Cycle len (sec)     : 0.97
+1 day, 17:15:22.269894 INFO: Number of cycles    : 4347
+1 day, 17:15:22.269941 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 17:15:23.892949 INFO: Initializing CalibrationManager
+1 day, 17:15:23.893250 INFO: Loading calibration config
+1 day, 17:15:23.893918 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 17:15:23.894022 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 17:15:23.894131 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 17:15:23.894331 INFO: Initializing OptimizationManager
+1 day, 17:15:23.894457 INFO: initial parameter: ms1_error = 30
+1 day, 17:15:23.894513 INFO: initial parameter: ms2_error = 30
+1 day, 17:15:23.894578 INFO: initial parameter: rt_error = 2099.9231665
+1 day, 17:15:23.894630 INFO: initial parameter: mobility_error = 0.1
+1 day, 17:15:23.894679 INFO: initial parameter: column_type = library
+1 day, 17:15:23.894727 INFO: initial parameter: num_candidates = 1
+1 day, 17:15:23.894774 INFO: initial parameter: classifier_version = -1
+1 day, 17:15:23.894818 INFO: initial parameter: fwhm_rt = 5
+1 day, 17:15:23.894863 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 17:15:23.894906 INFO: initial parameter: score_cutoff = 0
+1 day, 17:15:23.894972 INFO: Initializing TimingManager
+1 day, 17:15:23.895038 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 17:15:23.895168 INFO: FDRManager not loaded from disk.
+1 day, 17:15:23.895195 INFO: Initializing FDRManager
+1 day, 17:15:23.895233 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 17:15:25.187639 PROGRESS: 5,215,079 target precursors potentially observable (0 removed)
+1 day, 17:15:27.035182 PROGRESS: Starting initial search for precursors.
+1 day, 17:15:27.315537 INFO: Starting optimization step 0.
+1 day, 17:15:27.315780 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 17:15:27.315871 PROGRESS: Extracting batch of 15771 precursors
+1 day, 17:15:27.319844 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:15:27.319901 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:15:27.319936 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 17:15:27.319959 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 17:15:27.320981 INFO: Starting candidate selection
+1 day, 17:16:47.828307 INFO: Starting candidate scoring
+1 day, 17:16:48.703660 INFO: Finished candidate processing
+1 day, 17:16:48.703764 INFO: Collecting candidate features
+1 day, 17:16:48.736517 WARNING: intensity_correlation has 3 NaNs ( 0.02 % out of 13756)
+1 day, 17:16:48.736741 WARNING: height_correlation has 1 NaNs ( 0.01 % out of 13756)
+1 day, 17:16:48.740366 INFO: Collecting fragment features
+1 day, 17:16:48.755947 INFO: Finished candidate scoring
+1 day, 17:16:48.763677 PROGRESS: === Extracted 13756 precursors and 138137 fragments ===
+1 day, 17:16:48.764089 INFO: performing precursor FDR with 47 features
+1 day, 17:16:48.764138 INFO: Decoy channel: -1
+1 day, 17:16:48.764164 INFO: Competetive: True
+1 day, 17:16:48.770182 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:16:48.773329 WARNING: dropped 2 target PSMs due to missing features
+1 day, 17:16:48.773388 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 17:16:48.960999 INFO: Test AUC: 0.537
+1 day, 17:16:48.961123 INFO: Train AUC: 0.538
+1 day, 17:16:48.961153 INFO: AUC difference: 0.20%
+1 day, 17:16:49.047330 INFO: Resetting torch num_threads to 100
+1 day, 17:16:49.048491 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 17:16:49.049972 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:16:49.050086 PROGRESS: Total precursors accumulated: 7,046
+1 day, 17:16:49.050149 PROGRESS: Target precursors: 3,908 (55.46%)
+1 day, 17:16:49.050202 PROGRESS: Decoy precursors: 3,138 (44.54%)
+1 day, 17:16:49.050249 PROGRESS: 
+1 day, 17:16:49.050298 PROGRESS: Precursor Summary:
+1 day, 17:16:49.051173 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:16:49.051269 PROGRESS: 
+1 day, 17:16:49.051327 PROGRESS: Protein Summary:
+1 day, 17:16:49.052260 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:16:49.052348 PROGRESS: =========================================================================
+1 day, 17:16:49.205114 INFO: Starting optimization step 1.
+1 day, 17:16:49.205377 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 17:16:49.205457 PROGRESS: Extracting batch of 31534 precursors
+1 day, 17:16:49.212803 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:16:49.212886 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:16:49.212928 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 17:16:49.212953 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 17:16:49.214103 INFO: Starting candidate selection
+1 day, 17:19:25.148763 INFO: Starting candidate scoring
+1 day, 17:19:26.536917 INFO: Finished candidate processing
+1 day, 17:19:26.537126 INFO: Collecting candidate features
+1 day, 17:19:26.640828 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 27371)
+1 day, 17:19:26.641090 WARNING: height_correlation has 2 NaNs ( 0.01 % out of 27371)
+1 day, 17:19:26.645157 INFO: Collecting fragment features
+1 day, 17:19:26.669731 INFO: Finished candidate scoring
+1 day, 17:19:26.718667 PROGRESS: === Extracted 41127 precursors and 411965 fragments ===
+1 day, 17:19:26.724046 INFO: performing precursor FDR with 47 features
+1 day, 17:19:26.724118 INFO: Decoy channel: -1
+1 day, 17:19:26.724145 INFO: Competetive: True
+1 day, 17:19:26.746186 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:19:26.755142 WARNING: dropped 7 target PSMs due to missing features
+1 day, 17:19:26.755261 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 17:19:27.333236 INFO: Test AUC: 0.548
+1 day, 17:19:27.333364 INFO: Train AUC: 0.577
+1 day, 17:19:27.333394 INFO: AUC difference: 4.94%
+1 day, 17:19:27.429164 INFO: Resetting torch num_threads to 100
+1 day, 17:19:27.431579 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 17:19:27.435446 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:19:27.435609 PROGRESS: Total precursors accumulated: 21,077
+1 day, 17:19:27.435675 PROGRESS: Target precursors: 12,701 (60.26%)
+1 day, 17:19:27.435728 PROGRESS: Decoy precursors: 8,376 (39.74%)
+1 day, 17:19:27.435780 PROGRESS: 
+1 day, 17:19:27.435827 PROGRESS: Precursor Summary:
+1 day, 17:19:27.436919 PROGRESS: Channel   0:	 0.05 FDR:   180; 0.01 FDR:   141; 0.001 FDR:    95
+1 day, 17:19:27.437015 PROGRESS: 
+1 day, 17:19:27.437087 PROGRESS: Protein Summary:
+1 day, 17:19:27.438252 PROGRESS: Channel   0:	 0.05 FDR:   173; 0.01 FDR:   136; 0.001 FDR:    93
+1 day, 17:19:27.438356 PROGRESS: =========================================================================
+1 day, 17:19:27.634003 INFO: Starting optimization step 2.
+1 day, 17:19:27.634270 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 17:19:27.634349 PROGRESS: Extracting batch of 63016 precursors
+1 day, 17:19:27.650582 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:19:27.650702 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:19:27.650741 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 17:19:27.650766 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 17:19:27.651739 INFO: Starting candidate selection
+1 day, 17:24:26.433604 INFO: Starting candidate scoring
+1 day, 17:24:29.065175 INFO: Finished candidate processing
+1 day, 17:24:29.065363 INFO: Collecting candidate features
+1 day, 17:24:29.240582 WARNING: intensity_correlation has 16 NaNs ( 0.03 % out of 54858)
+1 day, 17:24:29.240880 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 54858)
+1 day, 17:24:29.247082 INFO: Collecting fragment features
+1 day, 17:24:29.292861 INFO: Finished candidate scoring
+1 day, 17:24:29.387219 PROGRESS: === Extracted 95985 precursors and 961483 fragments ===
+1 day, 17:24:29.399437 INFO: performing precursor FDR with 47 features
+1 day, 17:24:29.399564 INFO: Decoy channel: -1
+1 day, 17:24:29.399589 INFO: Competetive: True
+1 day, 17:24:30.924586 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:24:30.945270 WARNING: dropped 17 target PSMs due to missing features
+1 day, 17:24:30.945400 WARNING: dropped 14 decoy PSMs due to missing features
+1 day, 17:24:32.553128 INFO: Test AUC: 0.557
+1 day, 17:24:32.553252 INFO: Train AUC: 0.591
+1 day, 17:24:32.553282 INFO: AUC difference: 5.73%
+1 day, 17:24:32.553304 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:24:32.644626 INFO: Resetting torch num_threads to 100
+1 day, 17:24:32.649524 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 17:24:32.658435 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:24:32.658761 PROGRESS: Total precursors accumulated: 49,224
+1 day, 17:24:32.658831 PROGRESS: Target precursors: 30,058 (61.06%)
+1 day, 17:24:32.658886 PROGRESS: Decoy precursors: 19,166 (38.94%)
+1 day, 17:24:32.658935 PROGRESS: 
+1 day, 17:24:32.658981 PROGRESS: Precursor Summary:
+1 day, 17:24:32.660494 PROGRESS: Channel   0:	 0.05 FDR:   563; 0.01 FDR:   364; 0.001 FDR:   108
+1 day, 17:24:32.660597 PROGRESS: 
+1 day, 17:24:32.660656 PROGRESS: Protein Summary:
+1 day, 17:24:32.662103 PROGRESS: Channel   0:	 0.05 FDR:   520; 0.01 FDR:   335; 0.001 FDR:   106
+1 day, 17:24:32.662201 PROGRESS: =========================================================================
+1 day, 17:24:32.683760 INFO: fragments_df_filtered: 3296
+1 day, 17:24:32.894634 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:24:32.932322 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:24:32.974832 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:24:33.016139 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:24:33.188246 INFO: calibration group: precursor, predicting mz
+1 day, 17:24:33.207930 INFO: calibration group: precursor, predicting rt
+1 day, 17:24:33.275254 INFO: calibration group: precursor, predicting mobility
+1 day, 17:24:33.291304 INFO: calibration group: fragment, predicting mz
+1 day, 17:24:33.429991 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 17:24:33.430274 INFO: Starting optimization step 3.
+1 day, 17:24:33.430346 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 17:24:33.430407 PROGRESS: Extracting batch of 110321 precursors
+1 day, 17:24:33.461444 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:24:33.461568 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:24:33.461615 INFO: FWHM in RT is 3.23 seconds, sigma is 0.71
+1 day, 17:24:33.461654 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.18
+1 day, 17:24:33.482102 INFO: Starting candidate selection
+1 day, 17:33:21.873135 INFO: Starting candidate scoring
+1 day, 17:33:31.755424 INFO: Finished candidate processing
+1 day, 17:33:31.755626 INFO: Collecting candidate features
+1 day, 17:33:32.145597 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 189429)
+1 day, 17:33:32.146041 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 189429)
+1 day, 17:33:32.156858 INFO: Collecting fragment features
+1 day, 17:33:32.294318 INFO: Finished candidate scoring
+1 day, 17:33:32.402869 PROGRESS: === Extracted 189429 precursors and 1928841 fragments ===
+1 day, 17:33:32.403458 INFO: performing precursor FDR with 47 features
+1 day, 17:33:32.403501 INFO: Decoy channel: -1
+1 day, 17:33:32.403531 INFO: Competetive: True
+1 day, 17:33:32.479460 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:33:32.518522 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 17:33:36.513353 INFO: Test AUC: 0.564
+1 day, 17:33:36.513482 INFO: Train AUC: 0.591
+1 day, 17:33:36.513513 INFO: AUC difference: 4.46%
+1 day, 17:33:36.612872 INFO: Resetting torch num_threads to 100
+1 day, 17:33:36.618128 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 17:33:36.627058 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:33:36.627372 PROGRESS: Total precursors accumulated: 50,272
+1 day, 17:33:36.627440 PROGRESS: Target precursors: 31,372 (62.40%)
+1 day, 17:33:36.627493 PROGRESS: Decoy precursors: 18,900 (37.60%)
+1 day, 17:33:36.627545 PROGRESS: 
+1 day, 17:33:36.627592 PROGRESS: Precursor Summary:
+1 day, 17:33:36.629068 PROGRESS: Channel   0:	 0.05 FDR:   611; 0.01 FDR:   449; 0.001 FDR:   149
+1 day, 17:33:36.629180 PROGRESS: 
+1 day, 17:33:36.629238 PROGRESS: Protein Summary:
+1 day, 17:33:36.630736 PROGRESS: Channel   0:	 0.05 FDR:   568; 0.01 FDR:   417; 0.001 FDR:   143
+1 day, 17:33:36.630835 PROGRESS: =========================================================================
+1 day, 17:33:36.643028 INFO: fragments_df_filtered: 5000
+1 day, 17:33:36.852103 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:33:36.893065 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:33:36.933890 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:33:36.974207 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:33:37.322549 INFO: calibration group: precursor, predicting mz
+1 day, 17:33:37.337848 INFO: calibration group: precursor, predicting rt
+1 day, 17:33:37.404536 INFO: calibration group: precursor, predicting mobility
+1 day, 17:33:37.421411 INFO: calibration group: fragment, predicting mz
+1 day, 17:33:37.563873 INFO: === checking if optimization conditions were reached ===
+1 day, 17:33:37.566150 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 17:33:37.567121 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 17:33:37.567171 INFO: ==============================================
+1 day, 17:33:37.567270 INFO: Starting optimization step 4.
+1 day, 17:33:37.567338 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1 day, 17:33:37.567406 PROGRESS: Extracting batch of 110321 precursors
+1 day, 17:33:37.594867 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:33:37.595000 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:33:37.595052 INFO: FWHM in RT is 3.27 seconds, sigma is 0.72
+1 day, 17:33:37.595077 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.08
+1 day, 17:33:37.604041 INFO: Starting candidate selection
+1 day, 17:41:42.265914 INFO: Starting candidate scoring
+1 day, 17:41:47.746869 INFO: Finished candidate processing
+1 day, 17:41:47.746980 INFO: Collecting candidate features
+1 day, 17:41:48.050362 WARNING: intensity_correlation has 10 NaNs ( 0.01 % out of 189378)
+1 day, 17:41:48.060739 INFO: Collecting fragment features
+1 day, 17:41:48.177791 INFO: Finished candidate scoring
+1 day, 17:41:48.261485 PROGRESS: === Extracted 189378 precursors and 1859279 fragments ===
+1 day, 17:41:48.261936 INFO: performing precursor FDR with 47 features
+1 day, 17:41:48.261975 INFO: Decoy channel: -1
+1 day, 17:41:48.261999 INFO: Competetive: True
+1 day, 17:41:48.329883 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:41:48.365051 WARNING: dropped 4 target PSMs due to missing features
+1 day, 17:41:48.365184 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 17:41:52.411575 INFO: Test AUC: 0.559
+1 day, 17:41:52.411703 INFO: Train AUC: 0.585
+1 day, 17:41:52.411732 INFO: AUC difference: 4.42%
+1 day, 17:41:52.509423 INFO: Resetting torch num_threads to 100
+1 day, 17:41:52.514584 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 17:41:52.523688 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:41:52.523989 PROGRESS: Total precursors accumulated: 50,234
+1 day, 17:41:52.524056 PROGRESS: Target precursors: 30,636 (60.99%)
+1 day, 17:41:52.524112 PROGRESS: Decoy precursors: 19,598 (39.01%)
+1 day, 17:41:52.524164 PROGRESS: 
+1 day, 17:41:52.524213 PROGRESS: Precursor Summary:
+1 day, 17:41:52.525721 PROGRESS: Channel   0:	 0.05 FDR:   777; 0.01 FDR:   529; 0.001 FDR:   317
+1 day, 17:41:52.525831 PROGRESS: 
+1 day, 17:41:52.525892 PROGRESS: Protein Summary:
+1 day, 17:41:52.527470 PROGRESS: Channel   0:	 0.05 FDR:   709; 0.01 FDR:   481; 0.001 FDR:   294
+1 day, 17:41:52.527568 PROGRESS: =========================================================================
+1 day, 17:41:52.540041 INFO: fragments_df_filtered: 5000
+1 day, 17:41:52.713592 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:41:52.756531 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:41:52.798551 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:41:52.839592 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:41:53.188684 INFO: calibration group: precursor, predicting mz
+1 day, 17:41:53.196136 INFO: calibration group: precursor, predicting rt
+1 day, 17:41:53.224385 INFO: calibration group: precursor, predicting mobility
+1 day, 17:41:53.231383 INFO: calibration group: fragment, predicting mz
+1 day, 17:41:53.284384 INFO: === checking if optimization conditions were reached ===
+1 day, 17:41:53.286534 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 17:41:53.287506 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 17:41:53.287554 INFO: ==============================================
+1 day, 17:41:53.287654 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 17:41:53.449152 INFO: calibration group: precursor, predicting mz
+1 day, 17:41:53.456764 INFO: calibration group: precursor, predicting rt
+1 day, 17:41:53.485070 INFO: calibration group: precursor, predicting mobility
+1 day, 17:41:53.492051 INFO: calibration group: fragment, predicting mz
+1 day, 17:41:53.543705 INFO: Starting optimization step 0.
+1 day, 17:41:53.543933 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:41:53.544009 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:41:53.560102 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:41:53.560235 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:41:53.560298 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 17:41:53.560332 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.20
+1 day, 17:41:53.569619 INFO: Starting candidate selection
+1 day, 17:45:28.505224 INFO: Starting candidate scoring
+1 day, 17:45:30.960099 INFO: Finished candidate processing
+1 day, 17:45:30.961115 INFO: Collecting candidate features
+1 day, 17:45:31.088927 WARNING: intensity_correlation has 5 NaNs ( 0.01 % out of 81016)
+1 day, 17:45:31.096488 INFO: Collecting fragment features
+1 day, 17:45:31.155047 INFO: Finished candidate scoring
+1 day, 17:45:31.191908 PROGRESS: === Extracted 81016 precursors and 792525 fragments ===
+1 day, 17:45:31.192385 INFO: performing precursor FDR with 47 features
+1 day, 17:45:31.192436 INFO: Decoy channel: -1
+1 day, 17:45:31.192460 INFO: Competetive: True
+1 day, 17:45:31.220767 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:45:31.236843 WARNING: dropped 2 target PSMs due to missing features
+1 day, 17:45:31.236968 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 17:45:32.819080 INFO: Test AUC: 0.572
+1 day, 17:45:32.819202 INFO: Train AUC: 0.614
+1 day, 17:45:32.819232 INFO: AUC difference: 6.78%
+1 day, 17:45:32.819254 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:45:32.909280 INFO: Resetting torch num_threads to 100
+1 day, 17:45:32.911849 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:45:32.915532 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:45:32.915695 PROGRESS: Total precursors accumulated: 21,499
+1 day, 17:45:32.915761 PROGRESS: Target precursors: 13,740 (63.91%)
+1 day, 17:45:32.915830 PROGRESS: Decoy precursors: 7,759 (36.09%)
+1 day, 17:45:32.915878 PROGRESS: 
+1 day, 17:45:32.915927 PROGRESS: Precursor Summary:
+1 day, 17:45:32.917042 PROGRESS: Channel   0:	 0.05 FDR:   441; 0.01 FDR:   223; 0.001 FDR:   135
+1 day, 17:45:32.917140 PROGRESS: 
+1 day, 17:45:32.917198 PROGRESS: Protein Summary:
+1 day, 17:45:32.918432 PROGRESS: Channel   0:	 0.05 FDR:   422; 0.01 FDR:   215; 0.001 FDR:   131
+1 day, 17:45:32.918525 PROGRESS: =========================================================================
+1 day, 17:45:32.947092 INFO: fragments_df_filtered: 2695
+1 day, 17:45:33.115001 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:45:33.155575 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:45:33.192651 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:45:33.230270 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:45:33.357792 INFO: calibration group: precursor, predicting mz
+1 day, 17:45:33.365352 INFO: calibration group: precursor, predicting rt
+1 day, 17:45:33.393607 INFO: calibration group: precursor, predicting mobility
+1 day, 17:45:33.401155 INFO: calibration group: fragment, predicting mz
+1 day, 17:45:33.455735 INFO: === checking if optimization conditions were reached ===
+1 day, 17:45:33.456035 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 17:45:33.458158 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 359.4032.
+1 day, 17:45:33.458220 INFO: ==============================================
+1 day, 17:45:33.458325 INFO: Starting optimization step 1.
+1 day, 17:45:33.458398 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:45:33.458470 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:45:33.475363 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:45:33.475484 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:45:33.475540 INFO: FWHM in RT is 2.96 seconds, sigma is 0.65
+1 day, 17:45:33.475567 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.17
+1 day, 17:45:33.484679 INFO: Starting candidate selection
+1 day, 17:46:13.789119 INFO: Starting candidate scoring
+1 day, 17:46:15.931985 INFO: Finished candidate processing
+1 day, 17:46:15.932186 INFO: Collecting candidate features
+1 day, 17:46:16.124385 WARNING: intensity_correlation has 32 NaNs ( 0.04 % out of 77585)
+1 day, 17:46:16.124693 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 77585)
+1 day, 17:46:16.130842 INFO: Collecting fragment features
+1 day, 17:46:16.193779 INFO: Finished candidate scoring
+1 day, 17:46:16.247418 PROGRESS: === Extracted 77585 precursors and 740863 fragments ===
+1 day, 17:46:16.247929 INFO: performing precursor FDR with 47 features
+1 day, 17:46:16.247967 INFO: Decoy channel: -1
+1 day, 17:46:16.247992 INFO: Competetive: True
+1 day, 17:46:16.277950 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:46:16.295212 WARNING: dropped 15 target PSMs due to missing features
+1 day, 17:46:16.295339 WARNING: dropped 18 decoy PSMs due to missing features
+1 day, 17:46:17.845334 INFO: Test AUC: 0.540
+1 day, 17:46:17.845454 INFO: Train AUC: 0.587
+1 day, 17:46:17.845483 INFO: AUC difference: 7.86%
+1 day, 17:46:17.845504 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:46:17.935736 INFO: Resetting torch num_threads to 100
+1 day, 17:46:17.938236 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:46:17.941785 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:46:17.941943 PROGRESS: Total precursors accumulated: 20,919
+1 day, 17:46:17.942008 PROGRESS: Target precursors: 12,780 (61.09%)
+1 day, 17:46:17.942062 PROGRESS: Decoy precursors: 8,139 (38.91%)
+1 day, 17:46:17.942109 PROGRESS: 
+1 day, 17:46:17.942154 PROGRESS: Precursor Summary:
+1 day, 17:46:17.943247 PROGRESS: Channel   0:	 0.05 FDR:   456; 0.01 FDR:   218; 0.001 FDR:     0
+1 day, 17:46:17.943339 PROGRESS: 
+1 day, 17:46:17.943396 PROGRESS: Protein Summary:
+1 day, 17:46:17.944605 PROGRESS: Channel   0:	 0.05 FDR:   436; 0.01 FDR:   210; 0.001 FDR:     0
+1 day, 17:46:17.944697 PROGRESS: =========================================================================
+1 day, 17:46:17.950377 INFO: fragments_df_filtered: 2564
+1 day, 17:46:18.121882 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:46:18.171175 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:46:18.209549 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:46:18.248412 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:46:18.371130 INFO: calibration group: precursor, predicting mz
+1 day, 17:46:18.378815 INFO: calibration group: precursor, predicting rt
+1 day, 17:46:18.407143 INFO: calibration group: precursor, predicting mobility
+1 day, 17:46:18.415408 INFO: calibration group: fragment, predicting mz
+1 day, 17:46:18.470242 INFO: === checking if optimization conditions were reached ===
+1 day, 17:46:18.470498 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 17:46:18.472368 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 164.2230.
+1 day, 17:46:18.472421 INFO: ==============================================
+1 day, 17:46:18.472515 INFO: Starting optimization step 2.
+1 day, 17:46:18.472580 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:46:18.472644 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:46:18.484191 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:46:18.484293 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:46:18.484343 INFO: FWHM in RT is 2.96 seconds, sigma is 0.65
+1 day, 17:46:18.484366 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.15
+1 day, 17:46:18.493345 INFO: Starting candidate selection
+1 day, 17:46:37.083113 INFO: Starting candidate scoring
+1 day, 17:46:39.387483 INFO: Finished candidate processing
+1 day, 17:46:39.387756 INFO: Collecting candidate features
+1 day, 17:46:39.507144 WARNING: intensity_correlation has 43 NaNs ( 0.06 % out of 77242)
+1 day, 17:46:39.507435 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 77242)
+1 day, 17:46:39.513253 INFO: Collecting fragment features
+1 day, 17:46:39.557643 INFO: Finished candidate scoring
+1 day, 17:46:39.592804 PROGRESS: === Extracted 77242 precursors and 726855 fragments ===
+1 day, 17:46:39.593190 INFO: performing precursor FDR with 47 features
+1 day, 17:46:39.593228 INFO: Decoy channel: -1
+1 day, 17:46:39.593252 INFO: Competetive: True
+1 day, 17:46:39.615822 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:46:39.630248 WARNING: dropped 18 target PSMs due to missing features
+1 day, 17:46:39.630378 WARNING: dropped 28 decoy PSMs due to missing features
+1 day, 17:46:41.167894 INFO: Test AUC: 0.545
+1 day, 17:46:41.168017 INFO: Train AUC: 0.583
+1 day, 17:46:41.168047 INFO: AUC difference: 6.54%
+1 day, 17:46:41.168069 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:46:41.254221 INFO: Resetting torch num_threads to 100
+1 day, 17:46:41.256665 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:46:41.260203 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:46:41.260359 PROGRESS: Total precursors accumulated: 20,859
+1 day, 17:46:41.260423 PROGRESS: Target precursors: 12,675 (60.77%)
+1 day, 17:46:41.260473 PROGRESS: Decoy precursors: 8,184 (39.23%)
+1 day, 17:46:41.260522 PROGRESS: 
+1 day, 17:46:41.260567 PROGRESS: Precursor Summary:
+1 day, 17:46:41.261705 PROGRESS: Channel   0:	 0.05 FDR:   466; 0.01 FDR:   314; 0.001 FDR:   258
+1 day, 17:46:41.261801 PROGRESS: 
+1 day, 17:46:41.261859 PROGRESS: Protein Summary:
+1 day, 17:46:41.263118 PROGRESS: Channel   0:	 0.05 FDR:   445; 0.01 FDR:   301; 0.001 FDR:   247
+1 day, 17:46:41.263212 PROGRESS: =========================================================================
+1 day, 17:46:41.269421 INFO: fragments_df_filtered: 3406
+1 day, 17:46:41.434344 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:46:41.481002 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:46:41.532013 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:46:41.581368 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:46:41.791194 INFO: calibration group: precursor, predicting mz
+1 day, 17:46:41.799097 INFO: calibration group: precursor, predicting rt
+1 day, 17:46:41.827661 INFO: calibration group: precursor, predicting mobility
+1 day, 17:46:41.834568 INFO: calibration group: fragment, predicting mz
+1 day, 17:46:41.888230 INFO: === checking if optimization conditions were reached ===
+1 day, 17:46:41.888479 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 17:46:41.890412 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 137.8908.
+1 day, 17:46:41.890466 INFO: ==============================================
+1 day, 17:46:41.890557 INFO: Starting optimization step 3.
+1 day, 17:46:41.890624 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:46:41.890682 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:46:41.902031 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:46:41.902145 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:46:41.902186 INFO: FWHM in RT is 2.93 seconds, sigma is 0.64
+1 day, 17:46:41.902210 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.98
+1 day, 17:46:41.911145 INFO: Starting candidate selection
+1 day, 17:46:56.874146 INFO: Starting candidate scoring
+1 day, 17:46:59.238033 INFO: Finished candidate processing
+1 day, 17:46:59.238197 INFO: Collecting candidate features
+1 day, 17:46:59.386116 WARNING: intensity_correlation has 45 NaNs ( 0.06 % out of 76792)
+1 day, 17:46:59.386402 WARNING: height_correlation has 4 NaNs ( 0.01 % out of 76792)
+1 day, 17:46:59.392182 INFO: Collecting fragment features
+1 day, 17:46:59.435023 INFO: Finished candidate scoring
+1 day, 17:46:59.472191 PROGRESS: === Extracted 76792 precursors and 720204 fragments ===
+1 day, 17:46:59.472564 INFO: performing precursor FDR with 47 features
+1 day, 17:46:59.472602 INFO: Decoy channel: -1
+1 day, 17:46:59.472627 INFO: Competetive: True
+1 day, 17:46:59.495618 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:46:59.510195 WARNING: dropped 24 target PSMs due to missing features
+1 day, 17:46:59.510318 WARNING: dropped 22 decoy PSMs due to missing features
+1 day, 17:47:01.022101 INFO: Test AUC: 0.545
+1 day, 17:47:01.022219 INFO: Train AUC: 0.581
+1 day, 17:47:01.022249 INFO: AUC difference: 6.28%
+1 day, 17:47:01.022270 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:47:01.110503 INFO: Resetting torch num_threads to 100
+1 day, 17:47:01.112935 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:47:01.116482 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:47:01.116636 PROGRESS: Total precursors accumulated: 20,755
+1 day, 17:47:01.116718 PROGRESS: Target precursors: 12,426 (59.87%)
+1 day, 17:47:01.116775 PROGRESS: Decoy precursors: 8,329 (40.13%)
+1 day, 17:47:01.116825 PROGRESS: 
+1 day, 17:47:01.116872 PROGRESS: Precursor Summary:
+1 day, 17:47:01.118036 PROGRESS: Channel   0:	 0.05 FDR:   485; 0.01 FDR:   310; 0.001 FDR:   233
+1 day, 17:47:01.118138 PROGRESS: 
+1 day, 17:47:01.118196 PROGRESS: Protein Summary:
+1 day, 17:47:01.119456 PROGRESS: Channel   0:	 0.05 FDR:   463; 0.01 FDR:   298; 0.001 FDR:   226
+1 day, 17:47:01.119549 PROGRESS: =========================================================================
+1 day, 17:47:01.125679 INFO: fragments_df_filtered: 3347
+1 day, 17:47:01.291062 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:47:01.329004 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:47:01.366968 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:47:01.407051 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:47:01.585429 INFO: calibration group: precursor, predicting mz
+1 day, 17:47:01.592957 INFO: calibration group: precursor, predicting rt
+1 day, 17:47:01.621740 INFO: calibration group: precursor, predicting mobility
+1 day, 17:47:01.628542 INFO: calibration group: fragment, predicting mz
+1 day, 17:47:01.683066 INFO: === checking if optimization conditions were reached ===
+1 day, 17:47:01.683335 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 17:47:01.685814 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 120.0969.
+1 day, 17:47:01.685876 INFO: ==============================================
+1 day, 17:47:01.685979 INFO: Starting optimization step 4.
+1 day, 17:47:01.686065 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:47:01.686136 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:47:01.702955 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:47:01.703083 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:47:01.703131 INFO: FWHM in RT is 2.93 seconds, sigma is 0.64
+1 day, 17:47:01.703160 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 17:47:01.728270 INFO: Starting candidate selection
+1 day, 17:47:15.084409 INFO: Starting candidate scoring
+1 day, 17:47:17.394373 INFO: Finished candidate processing
+1 day, 17:47:17.394485 INFO: Collecting candidate features
+1 day, 17:47:17.542156 WARNING: intensity_correlation has 49 NaNs ( 0.06 % out of 76717)
+1 day, 17:47:17.542516 WARNING: height_correlation has 4 NaNs ( 0.01 % out of 76717)
+1 day, 17:47:17.548481 INFO: Collecting fragment features
+1 day, 17:47:17.598696 INFO: Finished candidate scoring
+1 day, 17:47:17.633620 PROGRESS: === Extracted 76717 precursors and 719010 fragments ===
+1 day, 17:47:17.634131 INFO: performing precursor FDR with 47 features
+1 day, 17:47:17.634171 INFO: Decoy channel: -1
+1 day, 17:47:17.634204 INFO: Competetive: True
+1 day, 17:47:17.660315 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:47:17.674568 WARNING: dropped 23 target PSMs due to missing features
+1 day, 17:47:17.674694 WARNING: dropped 27 decoy PSMs due to missing features
+1 day, 17:47:18.888919 INFO: Test AUC: 0.550
+1 day, 17:47:18.889051 INFO: Train AUC: 0.591
+1 day, 17:47:18.889088 INFO: AUC difference: 6.96%
+1 day, 17:47:18.889115 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:47:18.975925 INFO: Resetting torch num_threads to 100
+1 day, 17:47:18.978499 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:47:18.981966 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:47:18.982138 PROGRESS: Total precursors accumulated: 20,750
+1 day, 17:47:18.982226 PROGRESS: Target precursors: 12,642 (60.93%)
+1 day, 17:47:18.982296 PROGRESS: Decoy precursors: 8,108 (39.07%)
+1 day, 17:47:18.982358 PROGRESS: 
+1 day, 17:47:18.982415 PROGRESS: Precursor Summary:
+1 day, 17:47:18.983644 PROGRESS: Channel   0:	 0.05 FDR:   487; 0.01 FDR:   325; 0.001 FDR:   245
+1 day, 17:47:18.983758 PROGRESS: 
+1 day, 17:47:18.983828 PROGRESS: Protein Summary:
+1 day, 17:47:18.985174 PROGRESS: Channel   0:	 0.05 FDR:   464; 0.01 FDR:   313; 0.001 FDR:   238
+1 day, 17:47:18.985279 PROGRESS: =========================================================================
+1 day, 17:47:18.991967 INFO: fragments_df_filtered: 3402
+1 day, 17:47:19.158171 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:47:19.203319 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:47:19.251398 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:47:19.303108 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:47:19.508205 INFO: calibration group: precursor, predicting mz
+1 day, 17:47:19.515543 INFO: calibration group: precursor, predicting rt
+1 day, 17:47:19.544321 INFO: calibration group: precursor, predicting mobility
+1 day, 17:47:19.551083 INFO: calibration group: fragment, predicting mz
+1 day, 17:47:19.605045 INFO: === checking if optimization conditions were reached ===
+1 day, 17:47:19.605315 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 17:47:19.607366 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 112.9888.
+1 day, 17:47:19.607420 INFO: ==============================================
+1 day, 17:47:19.607537 INFO: Starting optimization step 5.
+1 day, 17:47:19.607617 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:47:19.607695 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:47:19.619421 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:47:19.619531 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:47:19.619590 INFO: FWHM in RT is 2.92 seconds, sigma is 0.64
+1 day, 17:47:19.619619 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.98
+1 day, 17:47:19.628736 INFO: Starting candidate selection
+1 day, 17:47:32.186696 INFO: Starting candidate scoring
+1 day, 17:47:34.494447 INFO: Finished candidate processing
+1 day, 17:47:34.494654 INFO: Collecting candidate features
+1 day, 17:47:34.631890 WARNING: intensity_correlation has 54 NaNs ( 0.07 % out of 76658)
+1 day, 17:47:34.632185 WARNING: height_correlation has 5 NaNs ( 0.01 % out of 76658)
+1 day, 17:47:34.638006 INFO: Collecting fragment features
+1 day, 17:47:34.681860 INFO: Finished candidate scoring
+1 day, 17:47:34.716261 PROGRESS: === Extracted 76658 precursors and 717919 fragments ===
+1 day, 17:47:34.717871 INFO: performing precursor FDR with 47 features
+1 day, 17:47:34.717914 INFO: Decoy channel: -1
+1 day, 17:47:34.717937 INFO: Competetive: True
+1 day, 17:47:34.740330 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:47:34.754628 WARNING: dropped 27 target PSMs due to missing features
+1 day, 17:47:34.754752 WARNING: dropped 28 decoy PSMs due to missing features
+1 day, 17:47:35.941512 INFO: Test AUC: 0.549
+1 day, 17:47:35.941636 INFO: Train AUC: 0.584
+1 day, 17:47:35.941666 INFO: AUC difference: 6.02%
+1 day, 17:47:35.941687 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:47:36.027073 INFO: Resetting torch num_threads to 100
+1 day, 17:47:36.029520 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:47:36.032909 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:47:36.033072 PROGRESS: Total precursors accumulated: 20,718
+1 day, 17:47:36.033139 PROGRESS: Target precursors: 12,421 (59.95%)
+1 day, 17:47:36.033193 PROGRESS: Decoy precursors: 8,297 (40.05%)
+1 day, 17:47:36.033243 PROGRESS: 
+1 day, 17:47:36.033289 PROGRESS: Precursor Summary:
+1 day, 17:47:36.034410 PROGRESS: Channel   0:	 0.05 FDR:   469; 0.01 FDR:   316; 0.001 FDR:   281
+1 day, 17:47:36.034508 PROGRESS: 
+1 day, 17:47:36.034566 PROGRESS: Protein Summary:
+1 day, 17:47:36.035826 PROGRESS: Channel   0:	 0.05 FDR:   448; 0.01 FDR:   304; 0.001 FDR:   270
+1 day, 17:47:36.035921 PROGRESS: =========================================================================
+1 day, 17:47:36.042150 INFO: fragments_df_filtered: 3350
+1 day, 17:47:36.206849 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 17:47:36.244935 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 17:47:36.282606 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 17:47:36.322237 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 17:47:36.504015 INFO: calibration group: precursor, predicting mz
+1 day, 17:47:36.511403 INFO: calibration group: precursor, predicting rt
+1 day, 17:47:36.539803 INFO: calibration group: precursor, predicting mobility
+1 day, 17:47:36.547201 INFO: calibration group: fragment, predicting mz
+1 day, 17:47:36.599852 INFO: === checking if optimization conditions were reached ===
+1 day, 17:47:36.600134 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 17:47:36.602474 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 112.5614.
+1 day, 17:47:36.602540 INFO: ==============================================
+1 day, 17:47:36.602654 INFO: Starting optimization step 6.
+1 day, 17:47:36.602736 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:47:36.602805 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:47:36.618891 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:47:36.619018 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:47:36.619067 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:47:36.619097 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:47:36.628009 INFO: Starting candidate selection
+1 day, 17:47:48.337815 INFO: Starting candidate scoring
+1 day, 17:47:49.393976 INFO: Finished candidate processing
+1 day, 17:47:49.394113 INFO: Collecting candidate features
+1 day, 17:47:49.496839 WARNING: intensity_correlation has 1102 NaNs ( 1.67 % out of 65909)
+1 day, 17:47:49.497128 WARNING: height_correlation has 30 NaNs ( 0.05 % out of 65909)
+1 day, 17:47:49.502627 INFO: Collecting fragment features
+1 day, 17:47:49.534071 INFO: Finished candidate scoring
+1 day, 17:47:49.567731 PROGRESS: === Extracted 65909 precursors and 309748 fragments ===
+1 day, 17:47:49.568115 INFO: performing precursor FDR with 47 features
+1 day, 17:47:49.568153 INFO: Decoy channel: -1
+1 day, 17:47:49.568180 INFO: Competetive: True
+1 day, 17:47:49.587890 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:47:49.599499 WARNING: dropped 566 target PSMs due to missing features
+1 day, 17:47:49.599622 WARNING: dropped 549 decoy PSMs due to missing features
+1 day, 17:47:50.599329 INFO: Test AUC: 0.510
+1 day, 17:47:50.599452 INFO: Train AUC: 0.574
+1 day, 17:47:50.599483 INFO: AUC difference: 11.20%
+1 day, 17:47:50.599505 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:47:50.682910 INFO: Resetting torch num_threads to 100
+1 day, 17:47:50.685156 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:47:50.688568 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:47:50.688712 PROGRESS: Total precursors accumulated: 19,574
+1 day, 17:47:50.688783 PROGRESS: Target precursors: 11,116 (56.79%)
+1 day, 17:47:50.688837 PROGRESS: Decoy precursors: 8,458 (43.21%)
+1 day, 17:47:50.688888 PROGRESS: 
+1 day, 17:47:50.688938 PROGRESS: Precursor Summary:
+1 day, 17:47:50.689885 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:47:50.689991 PROGRESS: 
+1 day, 17:47:50.690052 PROGRESS: Protein Summary:
+1 day, 17:47:50.691039 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:47:50.691130 PROGRESS: =========================================================================
+1 day, 17:47:50.883201 INFO: calibration group: precursor, predicting mz
+1 day, 17:47:50.892663 INFO: calibration group: precursor, predicting rt
+1 day, 17:47:50.932424 INFO: calibration group: precursor, predicting mobility
+1 day, 17:47:50.942853 INFO: calibration group: fragment, predicting mz
+1 day, 17:47:51.014052 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:47:51.014325 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+1 day, 17:47:51.014389 INFO: Starting optimization step 7.
+1 day, 17:47:51.014457 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 17:47:51.014520 PROGRESS: Extracting batch of 63016 precursors
+1 day, 17:47:51.029621 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:47:51.029747 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:47:51.029790 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:47:51.029813 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:47:51.038877 INFO: Starting candidate selection
+1 day, 17:48:06.029098 INFO: Starting candidate scoring
+1 day, 17:48:07.434436 INFO: Finished candidate processing
+1 day, 17:48:07.434598 INFO: Collecting candidate features
+1 day, 17:48:07.599836 WARNING: intensity_correlation has 1433 NaNs ( 1.63 % out of 87915)
+1 day, 17:48:07.600157 WARNING: height_correlation has 31 NaNs ( 0.04 % out of 87915)
+1 day, 17:48:07.606477 INFO: Collecting fragment features
+1 day, 17:48:07.651929 INFO: Finished candidate scoring
+1 day, 17:48:07.752431 PROGRESS: === Extracted 153824 precursors and 721077 fragments ===
+1 day, 17:48:07.765832 INFO: performing precursor FDR with 47 features
+1 day, 17:48:07.765951 INFO: Decoy channel: -1
+1 day, 17:48:07.765982 INFO: Competetive: True
+1 day, 17:48:07.828803 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:48:07.858958 WARNING: dropped 1292 target PSMs due to missing features
+1 day, 17:48:07.859096 WARNING: dropped 1272 decoy PSMs due to missing features
+1 day, 17:48:10.585593 INFO: Test AUC: 0.520
+1 day, 17:48:10.585707 INFO: Train AUC: 0.564
+1 day, 17:48:10.585738 INFO: AUC difference: 7.75%
+1 day, 17:48:10.585760 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:48:10.676279 INFO: Resetting torch num_threads to 100
+1 day, 17:48:10.682641 INFO: === FDR correction performed with classifier version 4 ===
+1 day, 17:48:10.690272 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:48:10.690573 PROGRESS: Total precursors accumulated: 45,714
+1 day, 17:48:10.690642 PROGRESS: Target precursors: 25,720 (56.26%)
+1 day, 17:48:10.690697 PROGRESS: Decoy precursors: 19,994 (43.74%)
+1 day, 17:48:10.690748 PROGRESS: 
+1 day, 17:48:10.690795 PROGRESS: Precursor Summary:
+1 day, 17:48:10.691953 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 17:48:10.692048 PROGRESS: 
+1 day, 17:48:10.692108 PROGRESS: Protein Summary:
+1 day, 17:48:10.693284 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 17:48:10.693379 PROGRESS: =========================================================================
+1 day, 17:48:10.959905 INFO: calibration group: precursor, predicting mz
+1 day, 17:48:10.978278 INFO: calibration group: precursor, predicting rt
+1 day, 17:48:11.054770 INFO: calibration group: precursor, predicting mobility
+1 day, 17:48:11.076420 INFO: calibration group: fragment, predicting mz
+1 day, 17:48:11.237650 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:48:11.237938 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+1 day, 17:48:11.238595 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 112.9888 found after 6 searches.
+1 day, 17:48:11.238669 PROGRESS: Optimization finished for rt_error.
+1 day, 17:48:11.410927 INFO: calibration group: precursor, predicting mz
+1 day, 17:48:11.418567 INFO: calibration group: precursor, predicting rt
+1 day, 17:48:11.447163 INFO: calibration group: precursor, predicting mobility
+1 day, 17:48:11.454865 INFO: calibration group: fragment, predicting mz
+1 day, 17:48:11.535239 INFO: Starting optimization step 0.
+1 day, 17:48:11.535457 PROGRESS: === Extracting elution groups 0 to 24000 ===
+1 day, 17:48:11.535538 PROGRESS: Extracting batch of 47305 precursors
+1 day, 17:48:11.547054 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:48:11.547167 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:48:11.547219 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:48:11.547244 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:48:11.548388 INFO: Starting candidate selection
+1 day, 17:48:23.139961 INFO: Starting candidate scoring
+1 day, 17:48:24.209262 INFO: Finished candidate processing
+1 day, 17:48:24.209381 INFO: Collecting candidate features
+1 day, 17:48:24.315571 WARNING: intensity_correlation has 1108 NaNs ( 1.68 % out of 65927)
+1 day, 17:48:24.315851 WARNING: height_correlation has 30 NaNs ( 0.05 % out of 65927)
+1 day, 17:48:24.321369 INFO: Collecting fragment features
+1 day, 17:48:24.352859 INFO: Finished candidate scoring
+1 day, 17:48:24.387225 PROGRESS: === Extracted 65927 precursors and 309865 fragments ===
+1 day, 17:48:24.387603 INFO: performing precursor FDR with 47 features
+1 day, 17:48:24.387644 INFO: Decoy channel: -1
+1 day, 17:48:24.387675 INFO: Competetive: True
+1 day, 17:48:24.407215 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:48:24.418811 WARNING: dropped 562 target PSMs due to missing features
+1 day, 17:48:24.418935 WARNING: dropped 559 decoy PSMs due to missing features
+1 day, 17:48:25.424581 INFO: Test AUC: 0.527
+1 day, 17:48:25.425265 INFO: Train AUC: 0.566
+1 day, 17:48:25.425302 INFO: AUC difference: 6.92%
+1 day, 17:48:25.425326 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:48:25.512371 INFO: Resetting torch num_threads to 100
+1 day, 17:48:25.514607 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:48:25.517763 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:48:25.517908 PROGRESS: Total precursors accumulated: 19,573
+1 day, 17:48:25.517974 PROGRESS: Target precursors: 11,016 (56.28%)
+1 day, 17:48:25.518027 PROGRESS: Decoy precursors: 8,557 (43.72%)
+1 day, 17:48:25.518076 PROGRESS: 
+1 day, 17:48:25.518125 PROGRESS: Precursor Summary:
+1 day, 17:48:25.519117 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1 day, 17:48:25.519210 PROGRESS: 
+1 day, 17:48:25.519265 PROGRESS: Protein Summary:
+1 day, 17:48:25.520284 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1 day, 17:48:25.520373 PROGRESS: =========================================================================
+1 day, 17:48:25.673833 INFO: calibration group: precursor, predicting mz
+1 day, 17:48:25.683381 INFO: calibration group: precursor, predicting rt
+1 day, 17:48:25.721856 INFO: calibration group: precursor, predicting mobility
+1 day, 17:48:25.732365 INFO: calibration group: fragment, predicting mz
+1 day, 17:48:25.804423 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:48:25.804715 PROGRESS: === Optimization of mobility_error has been skipped 1 time(s); maximum number is 1 ===
+1 day, 17:48:25.804778 INFO: Starting optimization step 1.
+1 day, 17:48:25.804848 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1 day, 17:48:25.804910 PROGRESS: Extracting batch of 63016 precursors
+1 day, 17:48:25.820297 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:48:25.820424 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:48:25.820465 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:48:25.820488 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:48:25.821505 INFO: Starting candidate selection
+1 day, 17:48:42.455943 INFO: Starting candidate scoring
+1 day, 17:48:43.873012 INFO: Finished candidate processing
+1 day, 17:48:43.873187 INFO: Collecting candidate features
+1 day, 17:48:44.016017 WARNING: intensity_correlation has 1428 NaNs ( 1.62 % out of 87923)
+1 day, 17:48:44.016417 WARNING: height_correlation has 31 NaNs ( 0.04 % out of 87923)
+1 day, 17:48:44.026621 INFO: Collecting fragment features
+1 day, 17:48:44.074786 INFO: Finished candidate scoring
+1 day, 17:48:44.154572 PROGRESS: === Extracted 153850 precursors and 721242 fragments ===
+1 day, 17:48:44.166933 INFO: performing precursor FDR with 47 features
+1 day, 17:48:44.167059 INFO: Decoy channel: -1
+1 day, 17:48:44.167087 INFO: Competetive: True
+1 day, 17:48:44.230530 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:48:44.258214 WARNING: dropped 1296 target PSMs due to missing features
+1 day, 17:48:44.258352 WARNING: dropped 1269 decoy PSMs due to missing features
+1 day, 17:48:46.750659 INFO: Test AUC: 0.529
+1 day, 17:48:46.750788 INFO: Train AUC: 0.564
+1 day, 17:48:46.750818 INFO: AUC difference: 6.09%
+1 day, 17:48:46.750840 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:48:46.842579 INFO: Resetting torch num_threads to 100
+1 day, 17:48:46.849042 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:48:46.857138 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:48:46.857422 PROGRESS: Total precursors accumulated: 45,712
+1 day, 17:48:46.857492 PROGRESS: Target precursors: 25,680 (56.18%)
+1 day, 17:48:46.857546 PROGRESS: Decoy precursors: 20,032 (43.82%)
+1 day, 17:48:46.857612 PROGRESS: 
+1 day, 17:48:46.857659 PROGRESS: Precursor Summary:
+1 day, 17:48:46.858838 PROGRESS: Channel   0:	 0.05 FDR:     7; 0.01 FDR:     7; 0.001 FDR:     7
+1 day, 17:48:46.858934 PROGRESS: 
+1 day, 17:48:46.858992 PROGRESS: Protein Summary:
+1 day, 17:48:46.860149 PROGRESS: Channel   0:	 0.05 FDR:     7; 0.01 FDR:     7; 0.001 FDR:     7
+1 day, 17:48:46.860244 PROGRESS: =========================================================================
+1 day, 17:48:47.113766 INFO: calibration group: precursor, predicting mz
+1 day, 17:48:47.131549 INFO: calibration group: precursor, predicting rt
+1 day, 17:48:47.207249 INFO: calibration group: precursor, predicting mobility
+1 day, 17:48:47.227574 INFO: calibration group: fragment, predicting mz
+1 day, 17:48:47.391726 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:48:47.392019 PROGRESS: === Optimization of mobility_error has been skipped 2 time(s); maximum number is 1 ===
+1 day, 17:48:47.392082 INFO: Starting optimization step 2.
+1 day, 17:48:47.392150 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+1 day, 17:48:47.392210 PROGRESS: Extracting batch of 126066 precursors
+1 day, 17:48:47.423588 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:48:47.423718 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:48:47.423768 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:48:47.423793 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:48:47.424909 INFO: Starting candidate selection
+1 day, 17:49:17.256544 INFO: Starting candidate scoring
+1 day, 17:49:19.880260 INFO: Finished candidate processing
+1 day, 17:49:19.880425 INFO: Collecting candidate features
+1 day, 17:49:20.178585 WARNING: intensity_correlation has 3005 NaNs ( 1.71 % out of 175609)
+1 day, 17:49:20.178977 WARNING: height_correlation has 81 NaNs ( 0.05 % out of 175609)
+1 day, 17:49:20.188161 INFO: Collecting fragment features
+1 day, 17:49:20.283715 INFO: Finished candidate scoring
+1 day, 17:49:20.482767 PROGRESS: === Extracted 329459 precursors and 1541001 fragments ===
+1 day, 17:49:20.508322 INFO: performing precursor FDR with 47 features
+1 day, 17:49:20.508459 INFO: Decoy channel: -1
+1 day, 17:49:20.508486 INFO: Competetive: True
+1 day, 17:49:20.647584 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:49:20.705495 WARNING: dropped 2854 target PSMs due to missing features
+1 day, 17:49:20.705636 WARNING: dropped 2753 decoy PSMs due to missing features
+1 day, 17:49:26.097325 INFO: Test AUC: 0.529
+1 day, 17:49:26.097465 INFO: Train AUC: 0.556
+1 day, 17:49:26.097496 INFO: AUC difference: 4.76%
+1 day, 17:49:26.201892 INFO: Resetting torch num_threads to 100
+1 day, 17:49:26.217192 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:49:26.235373 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:49:26.235649 PROGRESS: Total precursors accumulated: 97,967
+1 day, 17:49:26.235723 PROGRESS: Target precursors: 54,618 (55.75%)
+1 day, 17:49:26.235778 PROGRESS: Decoy precursors: 43,349 (44.25%)
+1 day, 17:49:26.235826 PROGRESS: 
+1 day, 17:49:26.235872 PROGRESS: Precursor Summary:
+1 day, 17:49:26.237410 PROGRESS: Channel   0:	 0.05 FDR:    10; 0.01 FDR:    10; 0.001 FDR:    10
+1 day, 17:49:26.237509 PROGRESS: 
+1 day, 17:49:26.237566 PROGRESS: Protein Summary:
+1 day, 17:49:26.238976 PROGRESS: Channel   0:	 0.05 FDR:    10; 0.01 FDR:    10; 0.001 FDR:    10
+1 day, 17:49:26.239070 PROGRESS: =========================================================================
+1 day, 17:49:26.660630 INFO: calibration group: precursor, predicting mz
+1 day, 17:49:26.694714 INFO: calibration group: precursor, predicting rt
+1 day, 17:49:26.846511 INFO: calibration group: precursor, predicting mobility
+1 day, 17:49:26.881846 INFO: calibration group: fragment, predicting mz
+1 day, 17:49:27.182734 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:49:27.183054 PROGRESS: === Optimization of mobility_error has been skipped 3 time(s); maximum number is 1 ===
+1 day, 17:49:27.183130 INFO: Starting optimization step 3.
+1 day, 17:49:27.183213 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+1 day, 17:49:27.183283 PROGRESS: Extracting batch of 252186 precursors
+1 day, 17:49:27.245810 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:49:27.245943 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:49:27.245994 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:49:27.246016 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:49:27.247029 INFO: Starting candidate selection
+1 day, 17:50:26.168698 INFO: Starting candidate scoring
+1 day, 17:50:31.561855 INFO: Finished candidate processing
+1 day, 17:50:31.562033 INFO: Collecting candidate features
+1 day, 17:50:32.229355 WARNING: intensity_correlation has 5909 NaNs ( 1.68 % out of 351434)
+1 day, 17:50:32.229915 WARNING: height_correlation has 158 NaNs ( 0.04 % out of 351434)
+1 day, 17:50:32.244555 INFO: Collecting fragment features
+1 day, 17:50:32.440062 INFO: Finished candidate scoring
+1 day, 17:50:32.910722 PROGRESS: === Extracted 680893 precursors and 3184468 fragments ===
+1 day, 17:50:32.969312 INFO: performing precursor FDR with 47 features
+1 day, 17:50:32.969454 INFO: Decoy channel: -1
+1 day, 17:50:32.969481 INFO: Competetive: True
+1 day, 17:50:33.267516 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:50:33.404114 WARNING: dropped 5969 target PSMs due to missing features
+1 day, 17:50:33.404273 WARNING: dropped 5640 decoy PSMs due to missing features
+1 day, 17:50:46.085515 INFO: Test AUC: 0.518
+1 day, 17:50:46.085664 INFO: Train AUC: 0.550
+1 day, 17:50:46.085697 INFO: AUC difference: 5.82%
+1 day, 17:50:46.085718 WARNING: AUC difference > 5%. This may indicate overfitting.
+1 day, 17:50:46.218993 INFO: Resetting torch num_threads to 100
+1 day, 17:50:46.251297 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:50:46.289168 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:50:46.289523 PROGRESS: Total precursors accumulated: 202,522
+1 day, 17:50:46.289588 PROGRESS: Target precursors: 112,592 (55.59%)
+1 day, 17:50:46.289641 PROGRESS: Decoy precursors: 89,930 (44.41%)
+1 day, 17:50:46.289690 PROGRESS: 
+1 day, 17:50:46.289737 PROGRESS: Precursor Summary:
+1 day, 17:50:46.291843 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 17:50:46.291944 PROGRESS: 
+1 day, 17:50:46.292008 PROGRESS: Protein Summary:
+1 day, 17:50:46.293909 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 17:50:46.294009 PROGRESS: =========================================================================
+1 day, 17:50:46.921798 INFO: calibration group: precursor, predicting mz
+1 day, 17:50:46.988159 INFO: calibration group: precursor, predicting rt
+1 day, 17:50:47.301455 INFO: calibration group: precursor, predicting mobility
+1 day, 17:50:47.373459 INFO: calibration group: fragment, predicting mz
+1 day, 17:50:47.979356 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:50:47.979684 PROGRESS: === Optimization of mobility_error has been skipped 4 time(s); maximum number is 1 ===
+1 day, 17:50:47.979759 INFO: Starting optimization step 4.
+1 day, 17:50:47.979828 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+1 day, 17:50:47.979897 PROGRESS: Extracting batch of 504181 precursors
+1 day, 17:50:48.103699 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:50:48.103840 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:50:48.103891 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:50:48.103915 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:50:48.104809 INFO: Starting candidate selection
+1 day, 17:52:41.674897 INFO: Starting candidate scoring
+1 day, 17:52:54.006785 INFO: Finished candidate processing
+1 day, 17:52:54.006958 INFO: Collecting candidate features
+1 day, 17:52:55.448265 WARNING: intensity_correlation has 11521 NaNs ( 1.64 % out of 702935)
+1 day, 17:52:55.449159 WARNING: height_correlation has 296 NaNs ( 0.04 % out of 702935)
+1 day, 17:52:55.474373 INFO: Collecting fragment features
+1 day, 17:52:55.865563 INFO: Finished candidate scoring
+1 day, 17:52:56.642632 PROGRESS: === Extracted 1383828 precursors and 6470363 fragments ===
+1 day, 17:52:56.762367 INFO: performing precursor FDR with 47 features
+1 day, 17:52:56.762504 INFO: Decoy channel: -1
+1 day, 17:52:56.762534 INFO: Competetive: True
+1 day, 17:52:57.366883 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:52:57.659904 WARNING: dropped 12099 target PSMs due to missing features
+1 day, 17:52:57.660048 WARNING: dropped 11181 decoy PSMs due to missing features
+1 day, 17:53:22.423123 INFO: Test AUC: 0.535
+1 day, 17:53:22.423267 INFO: Train AUC: 0.547
+1 day, 17:53:22.423306 INFO: AUC difference: 2.18%
+1 day, 17:53:22.605375 INFO: Resetting torch num_threads to 100
+1 day, 17:53:22.669815 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:53:22.742495 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:53:22.742847 PROGRESS: Total precursors accumulated: 411,828
+1 day, 17:53:22.742918 PROGRESS: Target precursors: 228,104 (55.39%)
+1 day, 17:53:22.742978 PROGRESS: Decoy precursors: 183,724 (44.61%)
+1 day, 17:53:22.743032 PROGRESS: 
+1 day, 17:53:22.743083 PROGRESS: Precursor Summary:
+1 day, 17:53:22.746352 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 17:53:22.746473 PROGRESS: 
+1 day, 17:53:22.746534 PROGRESS: Protein Summary:
+1 day, 17:53:22.749277 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 17:53:22.749380 PROGRESS: =========================================================================
+1 day, 17:53:23.704388 INFO: calibration group: precursor, predicting mz
+1 day, 17:53:23.843301 INFO: calibration group: precursor, predicting rt
+1 day, 17:53:24.469658 INFO: calibration group: precursor, predicting mobility
+1 day, 17:53:24.607506 INFO: calibration group: fragment, predicting mz
+1 day, 17:53:25.870774 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:53:25.871061 PROGRESS: === Optimization of mobility_error has been skipped 5 time(s); maximum number is 1 ===
+1 day, 17:53:25.871164 INFO: Starting optimization step 5.
+1 day, 17:53:25.871252 PROGRESS: === Extracting elution groups 504000 to 1016000 ===
+1 day, 17:53:25.871340 PROGRESS: Extracting batch of 1008477 precursors
+1 day, 17:53:26.117003 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:53:26.117144 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:53:26.117217 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:53:26.117248 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:53:26.118221 INFO: Starting candidate selection
+1 day, 17:57:12.193126 INFO: Starting candidate scoring
+1 day, 17:57:32.006037 INFO: Finished candidate processing
+1 day, 17:57:32.006545 INFO: Collecting candidate features
+1 day, 17:57:34.966227 WARNING: intensity_correlation has 22787 NaNs ( 1.62 % out of 1405606)
+1 day, 17:57:34.967618 WARNING: height_correlation has 566 NaNs ( 0.04 % out of 1405606)
+1 day, 17:57:35.015625 INFO: Collecting fragment features
+1 day, 17:57:35.781620 INFO: Finished candidate scoring
+1 day, 17:57:38.120566 PROGRESS: === Extracted 2789434 precursors and 13041701 fragments ===
+1 day, 17:57:38.365039 INFO: performing precursor FDR with 47 features
+1 day, 17:57:38.365165 INFO: Decoy channel: -1
+1 day, 17:57:38.365195 INFO: Competetive: True
+1 day, 17:57:39.607853 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 17:57:40.154268 WARNING: dropped 23919 target PSMs due to missing features
+1 day, 17:57:40.154415 WARNING: dropped 22455 decoy PSMs due to missing features
+1 day, 17:58:29.056545 INFO: Test AUC: 0.540
+1 day, 17:58:29.056797 INFO: Train AUC: 0.547
+1 day, 17:58:29.056836 INFO: AUC difference: 1.29%
+1 day, 17:58:29.339377 INFO: Resetting torch num_threads to 100
+1 day, 17:58:29.487337 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 17:58:29.641829 PROGRESS: ============================= Precursor FDR =============================
+1 day, 17:58:29.642182 PROGRESS: Total precursors accumulated: 830,449
+1 day, 17:58:29.642247 PROGRESS: Target precursors: 460,143 (55.41%)
+1 day, 17:58:29.642298 PROGRESS: Decoy precursors: 370,306 (44.59%)
+1 day, 17:58:29.642347 PROGRESS: 
+1 day, 17:58:29.642392 PROGRESS: Precursor Summary:
+1 day, 17:58:29.647342 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:58:29.647463 PROGRESS: 
+1 day, 17:58:29.647520 PROGRESS: Protein Summary:
+1 day, 17:58:29.651788 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 17:58:29.651896 PROGRESS: =========================================================================
+1 day, 17:58:31.337794 INFO: calibration group: precursor, predicting mz
+1 day, 17:58:31.627021 INFO: calibration group: precursor, predicting rt
+1 day, 17:58:32.907491 INFO: calibration group: precursor, predicting mobility
+1 day, 17:58:33.195879 INFO: calibration group: fragment, predicting mz
+1 day, 17:58:35.729824 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 17:58:35.730096 PROGRESS: === Optimization of mobility_error has been skipped 6 time(s); maximum number is 1 ===
+1 day, 17:58:35.730172 INFO: Starting optimization step 6.
+1 day, 17:58:35.730241 PROGRESS: === Extracting elution groups 1016000 to 2040000 ===
+1 day, 17:58:35.730310 PROGRESS: Extracting batch of 2017059 precursors
+1 day, 17:58:36.215248 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 17:58:36.215379 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 17:58:36.215426 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 17:58:36.215450 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 17:58:36.216495 INFO: Starting candidate selection
+1 day, 18:06:08.677301 INFO: Starting candidate scoring
+1 day, 18:06:49.334146 INFO: Finished candidate processing
+1 day, 18:06:49.334371 INFO: Collecting candidate features
+1 day, 18:06:54.895133 WARNING: intensity_correlation has 46333 NaNs ( 1.65 % out of 2810872)
+1 day, 18:06:54.897743 WARNING: height_correlation has 1175 NaNs ( 0.04 % out of 2810872)
+1 day, 18:06:54.993690 INFO: Collecting fragment features
+1 day, 18:06:56.582739 INFO: Finished candidate scoring
+1 day, 18:07:01.843475 PROGRESS: === Extracted 5600306 precursors and 26186053 fragments ===
+1 day, 18:07:02.364622 INFO: performing precursor FDR with 47 features
+1 day, 18:07:02.364759 INFO: Decoy channel: -1
+1 day, 18:07:02.364789 INFO: Competetive: True
+1 day, 18:07:04.710940 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 18:07:05.769288 WARNING: dropped 48041 target PSMs due to missing features
+1 day, 18:07:05.769438 WARNING: dropped 45317 decoy PSMs due to missing features
+1 day, 18:08:39.533093 INFO: Test AUC: 0.543
+1 day, 18:08:39.533339 INFO: Train AUC: 0.547
+1 day, 18:08:39.533383 INFO: AUC difference: 0.64%
+1 day, 18:08:39.975860 INFO: Resetting torch num_threads to 100
+1 day, 18:08:40.278599 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 18:08:40.583127 PROGRESS: ============================= Precursor FDR =============================
+1 day, 18:08:40.583468 PROGRESS: Total precursors accumulated: 1,666,966
+1 day, 18:08:40.583535 PROGRESS: Target precursors: 929,774 (55.78%)
+1 day, 18:08:40.583588 PROGRESS: Decoy precursors: 737,192 (44.22%)
+1 day, 18:08:40.583638 PROGRESS: 
+1 day, 18:08:40.583685 PROGRESS: Precursor Summary:
+1 day, 18:08:40.592647 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1 day, 18:08:40.592798 PROGRESS: 
+1 day, 18:08:40.592857 PROGRESS: Protein Summary:
+1 day, 18:08:40.600976 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+1 day, 18:08:40.601127 PROGRESS: =========================================================================
+1 day, 18:08:43.707723 INFO: calibration group: precursor, predicting mz
+1 day, 18:08:44.253416 INFO: calibration group: precursor, predicting rt
+1 day, 18:08:46.777275 INFO: calibration group: precursor, predicting mobility
+1 day, 18:08:47.332608 INFO: calibration group: fragment, predicting mz
+1 day, 18:08:52.300974 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 18:08:52.301258 PROGRESS: === Optimization of mobility_error has been skipped 7 time(s); maximum number is 1 ===
+1 day, 18:08:52.301348 INFO: Starting optimization step 7.
+1 day, 18:08:52.301414 PROGRESS: === Extracting elution groups 2040000 to 4088000 ===
+1 day, 18:08:52.301485 PROGRESS: Extracting batch of 4034279 precursors
+1 day, 18:08:53.220826 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 18:08:53.220950 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 18:08:53.221000 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 18:08:53.221035 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 18:08:53.222274 INFO: Starting candidate selection
+1 day, 18:23:59.315708 INFO: Starting candidate scoring
+1 day, 18:25:20.343647 INFO: Finished candidate processing
+1 day, 18:25:20.344159 INFO: Collecting candidate features
+1 day, 18:25:31.240594 WARNING: intensity_correlation has 92975 NaNs ( 1.65 % out of 5620179)
+1 day, 18:25:31.245666 WARNING: height_correlation has 2427 NaNs ( 0.04 % out of 5620179)
+1 day, 18:25:31.431551 INFO: Collecting fragment features
+1 day, 18:25:34.637425 INFO: Finished candidate scoring
+1 day, 18:25:41.346387 PROGRESS: === Extracted 11220485 precursors and 52460522 fragments ===
+1 day, 18:25:42.370475 INFO: performing precursor FDR with 47 features
+1 day, 18:25:42.370608 INFO: Decoy channel: -1
+1 day, 18:25:42.370638 INFO: Competetive: True
+1 day, 18:25:46.933302 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 18:25:48.995420 WARNING: dropped 96269 target PSMs due to missing features
+1 day, 18:25:48.995565 WARNING: dropped 91337 decoy PSMs due to missing features
+1 day, 18:29:15.779953 INFO: Test AUC: 0.545
+1 day, 18:29:15.780182 INFO: Train AUC: 0.548
+1 day, 18:29:15.780219 INFO: AUC difference: 0.52%
+1 day, 18:29:16.484305 INFO: Resetting torch num_threads to 100
+1 day, 18:29:17.034324 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 18:29:17.637860 PROGRESS: ============================= Precursor FDR =============================
+1 day, 18:29:17.638196 PROGRESS: Total precursors accumulated: 3,340,379
+1 day, 18:29:17.638268 PROGRESS: Target precursors: 1,855,403 (55.54%)
+1 day, 18:29:17.638323 PROGRESS: Decoy precursors: 1,484,976 (44.46%)
+1 day, 18:29:17.638375 PROGRESS: 
+1 day, 18:29:17.638443 PROGRESS: Precursor Summary:
+1 day, 18:29:17.655052 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 18:29:17.655313 PROGRESS: 
+1 day, 18:29:17.655376 PROGRESS: Protein Summary:
+1 day, 18:29:17.671526 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+1 day, 18:29:17.671748 PROGRESS: =========================================================================
+1 day, 18:29:19.640043 INFO: calibration group: precursor, predicting mz
+1 day, 18:29:19.958207 INFO: calibration group: precursor, predicting rt
+1 day, 18:29:21.359593 INFO: calibration group: precursor, predicting mobility
+1 day, 18:29:21.678687 INFO: calibration group: fragment, predicting mz
+1 day, 18:29:24.478315 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 18:29:24.478601 PROGRESS: === Optimization of mobility_error has been skipped 8 time(s); maximum number is 1 ===
+1 day, 18:29:24.478687 INFO: Starting optimization step 8.
+1 day, 18:29:24.478762 PROGRESS: === Extracting elution groups 4088000 to 5215079 ===
+1 day, 18:29:24.478841 PROGRESS: Extracting batch of 2220101 precursors
+1 day, 18:29:25.004787 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 18:29:25.004920 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 18:29:25.004971 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 18:29:25.004996 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 18:29:25.006057 INFO: Starting candidate selection
+1 day, 18:37:43.978028 INFO: Starting candidate scoring
+1 day, 18:38:28.411030 INFO: Finished candidate processing
+1 day, 18:38:28.411562 INFO: Collecting candidate features
+1 day, 18:38:34.644504 WARNING: intensity_correlation has 51174 NaNs ( 1.66 % out of 3091246)
+1 day, 18:38:34.647371 WARNING: height_correlation has 1253 NaNs ( 0.04 % out of 3091246)
+1 day, 18:38:34.749555 INFO: Collecting fragment features
+1 day, 18:38:36.512935 INFO: Finished candidate scoring
+1 day, 18:38:42.378485 PROGRESS: === Extracted 14311731 precursors and 66906054 fragments ===
+1 day, 18:38:43.728666 INFO: performing precursor FDR with 47 features
+1 day, 18:38:43.728803 INFO: Decoy channel: -1
+1 day, 18:38:43.728833 INFO: Competetive: True
+1 day, 18:38:49.649457 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 18:38:52.305269 WARNING: dropped 122860 target PSMs due to missing features
+1 day, 18:38:52.305414 WARNING: dropped 116591 decoy PSMs due to missing features
+1 day, 18:45:23.826970 INFO: Test AUC: 0.545
+1 day, 18:45:23.827212 INFO: Train AUC: 0.548
+1 day, 18:45:23.827250 INFO: AUC difference: 0.60%
+1 day, 18:45:25.059351 INFO: Resetting torch num_threads to 100
+1 day, 18:45:25.788862 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 18:45:26.577315 PROGRESS: ============================= Precursor FDR =============================
+1 day, 18:45:26.577648 PROGRESS: Total precursors accumulated: 4,261,164
+1 day, 18:45:26.577740 PROGRESS: Target precursors: 2,361,718 (55.42%)
+1 day, 18:45:26.577798 PROGRESS: Decoy precursors: 1,899,446 (44.58%)
+1 day, 18:45:26.577848 PROGRESS: 
+1 day, 18:45:26.577897 PROGRESS: Precursor Summary:
+1 day, 18:45:26.601650 PROGRESS: Channel   0:	 0.05 FDR:    49; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 18:45:26.601904 PROGRESS: 
+1 day, 18:45:26.601969 PROGRESS: Protein Summary:
+1 day, 18:45:26.624777 PROGRESS: Channel   0:	 0.05 FDR:    45; 0.01 FDR:     3; 0.001 FDR:     3
+1 day, 18:45:26.625016 PROGRESS: =========================================================================
+1 day, 18:45:26.720686 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 18:45:26.720994 PROGRESS: ==============================================
+1 day, 18:45:27.205659 INFO: fragments_df_filtered: 58
+1 day, 18:45:27.554934 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 18:45:27.555212 WARNING: Using current optimal value for ms2_error: 15.00.
+1 day, 18:45:27.904058 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 18:45:27.904328 WARNING: Using current optimal value for ms1_error: 10.00.
+1 day, 18:45:28.253296 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 18:45:28.255034 WARNING: Using current optimal value for rt_error: 112.99.
+1 day, 18:45:28.602826 WARNING: No more batches to process. Will proceed to extraction using best parameters available in optimization manager.
+1 day, 18:45:28.603843 WARNING: Using current optimal value for mobility_error: 0.10.
+1 day, 18:45:28.609330 PROGRESS: ms2_error      : 15.0000
+1 day, 18:45:28.609496 PROGRESS: ms1_error      : 10.0000
+1 day, 18:45:28.609555 PROGRESS: rt_error       : 112.9888
+1 day, 18:45:28.609605 PROGRESS: mobility_error : 0.1000
+1 day, 18:45:28.609654 PROGRESS: ==============================================
+1 day, 18:45:28.735965 INFO: calibration group: precursor, predicting mz
+1 day, 18:45:30.208418 INFO: calibration group: precursor, predicting rt
+1 day, 18:45:36.618520 INFO: calibration group: precursor, predicting mobility
+1 day, 18:45:38.092106 INFO: calibration group: fragment, predicting mz
+1 day, 18:45:50.772021 PROGRESS: Extracting batch of 10272670 precursors
+1 day, 18:45:52.872109 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 18:45:52.872237 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 18:45:52.872286 INFO: FWHM in RT is 2.97 seconds, sigma is 0.65
+1 day, 18:45:52.872312 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 18:45:52.873245 INFO: Starting candidate selection
+1 day, 19:24:31.737102 INFO: Applying score cutoff of 19.273183670043945
+1 day, 19:24:32.129829 INFO: Removed 6964295 precursors with score below cutoff
+1 day, 19:24:34.610301 INFO: Starting candidate scoring
+1 day, 19:26:58.372094 INFO: Finished candidate processing
+1 day, 19:26:58.372587 INFO: Collecting candidate features
+1 day, 19:27:16.937750 WARNING: intensity_correlation has 119043 NaNs ( 1.19 % out of 10026843)
+1 day, 19:27:16.946498 WARNING: height_correlation has 1779 NaNs ( 0.02 % out of 10026843)
+1 day, 19:27:17.276631 INFO: Collecting fragment features
+1 day, 19:27:22.907412 INFO: Finished candidate scoring
+1 day, 19:27:33.984353 INFO: === FDR correction performed with classifier version 21 ===
+1 day, 19:27:33.989353 INFO: performing precursor FDR with 47 features
+1 day, 19:27:33.989429 INFO: Decoy channel: -1
+1 day, 19:27:33.989459 INFO: Competetive: True
+1 day, 19:27:36.703177 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:27:38.367440 WARNING: dropped 62257 target PSMs due to missing features
+1 day, 19:27:38.367587 WARNING: dropped 57822 decoy PSMs due to missing features
+1 day, 19:30:40.475855 INFO: Test AUC: 0.544
+1 day, 19:30:40.476112 INFO: Train AUC: 0.548
+1 day, 19:30:40.476150 INFO: AUC difference: 0.70%
+1 day, 19:30:41.124534 INFO: Resetting torch num_threads to 100
+1 day, 19:30:41.376329 INFO: Removing fragments below FDR threshold
+1 day, 19:30:41.469179 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:30:41.469484 PROGRESS: Total precursors accumulated: 0
+1 day, 19:30:41.469562 PROGRESS: Target precursors: 0 (0.00%)
+1 day, 19:30:41.469617 PROGRESS: Decoy precursors: 0 (0.00%)
+1 day, 19:30:41.469671 PROGRESS: 
+1 day, 19:30:41.469722 PROGRESS: Precursor Summary:
+1 day, 19:30:41.469860 PROGRESS: 
+1 day, 19:30:41.469927 PROGRESS: Protein Summary:
+1 day, 19:30:41.470003 PROGRESS: =========================================================================
+1 day, 19:30:41.613632 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 19:31:04.685991 PROGRESS: Processing search outputs
+1 day, 19:31:04.686146 PROGRESS: Performing protein grouping and FDR
+1 day, 19:31:04.686187 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:31:04.721499 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:31:04.796762 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:31:04.802194 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 19:31:04.841212 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 19:31:04.849621 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 19:31:04.857166 INFO: Building combined output
+1 day, 19:31:05.122480 INFO: Performing protein inference
+1 day, 19:31:05.268548 INFO: Inference strategy: heuristic. Using maximum parsimony with grouping for protein inference
+1 day, 19:31:23.724998 INFO: Performing protein FDR
+1 day, 19:31:28.002651 INFO: Normalizing q-values using 12,421 targets and 1,281 decoys
+1 day, 19:31:28.011658 INFO: Test AUC: 0.891
+1 day, 19:31:28.011713 INFO: Train AUC: 0.911
+1 day, 19:31:28.011741 INFO: AUC difference: 2.17%
+1 day, 19:31:29.494340 PROGRESS: ================ Protein FDR =================
+1 day, 19:31:29.494478 PROGRESS: Unique protein groups in output
+1 day, 19:31:29.494509 PROGRESS:   1% protein FDR: 8,253
+1 day, 19:31:29.494531 PROGRESS: 
+1 day, 19:31:29.494549 PROGRESS: Unique precursor in output
+1 day, 19:31:29.494567 PROGRESS:   1% protein FDR: 82,039
+1 day, 19:31:29.494585 PROGRESS: ================================================
+1 day, 19:31:29.513350 PROGRESS: Building search statistics
+1 day, 19:31:29.543371 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/optimization_manager.pkl
+1 day, 19:31:29.543565 INFO: Initializing OptimizationManager
+1 day, 19:31:29.543798 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/calibration_manager.pkl
+1 day, 19:31:29.543873 INFO: Initializing CalibrationManager
+1 day, 19:31:29.544065 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/raw_file_manager.pkl
+1 day, 19:31:29.544140 INFO: Initializing RawFileManager
+1 day, 19:31:29.563887 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/optimization_manager.pkl
+1 day, 19:31:29.564087 INFO: Initializing OptimizationManager
+1 day, 19:31:29.564306 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/calibration_manager.pkl
+1 day, 19:31:29.564389 INFO: Initializing CalibrationManager
+1 day, 19:31:29.564577 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/raw_file_manager.pkl
+1 day, 19:31:29.564655 INFO: Initializing RawFileManager
+1 day, 19:31:29.572140 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/optimization_manager.pkl
+1 day, 19:31:29.572483 INFO: Initializing OptimizationManager
+1 day, 19:31:29.572680 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/calibration_manager.pkl
+1 day, 19:31:29.572757 INFO: Initializing CalibrationManager
+1 day, 19:31:29.572947 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/raw_file_manager.pkl
+1 day, 19:31:29.573020 INFO: Initializing RawFileManager
+1 day, 19:31:29.593644 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/optimization_manager.pkl
+1 day, 19:31:29.593854 INFO: Initializing OptimizationManager
+1 day, 19:31:29.594070 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/calibration_manager.pkl
+1 day, 19:31:29.594148 INFO: Initializing CalibrationManager
+1 day, 19:31:29.594352 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/raw_file_manager.pkl
+1 day, 19:31:29.594429 INFO: Initializing RawFileManager
+1 day, 19:31:29.602222 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/optimization_manager.pkl
+1 day, 19:31:29.602330 INFO: Initializing OptimizationManager
+1 day, 19:31:29.602511 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/calibration_manager.pkl
+1 day, 19:31:29.602584 INFO: Initializing CalibrationManager
+1 day, 19:31:29.602753 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/raw_file_manager.pkl
+1 day, 19:31:29.602828 INFO: Initializing RawFileManager
+1 day, 19:31:29.608904 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/optimization_manager.pkl
+1 day, 19:31:29.609002 INFO: Initializing OptimizationManager
+1 day, 19:31:29.609194 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/calibration_manager.pkl
+1 day, 19:31:29.609266 INFO: Initializing CalibrationManager
+1 day, 19:31:29.609430 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/raw_file_manager.pkl
+1 day, 19:31:29.609502 INFO: Initializing RawFileManager
+1 day, 19:31:29.610585 INFO: Writing stat output to disk
+1 day, 19:31:29.610637 INFO: Saving run_output/alphadia_1.10_defaultMBR/library/stat.tsv to disk
+1 day, 19:31:29.613763 PROGRESS: Building internal statistics
+1 day, 19:31:29.613954 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/timing_manager.pkl
+1 day, 19:31:29.613994 INFO: Initializing TimingManager
+1 day, 19:31:29.614203 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/timing_manager.pkl
+1 day, 19:31:29.614244 INFO: Initializing TimingManager
+1 day, 19:31:29.614412 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/timing_manager.pkl
+1 day, 19:31:29.614449 INFO: Initializing TimingManager
+1 day, 19:31:29.614605 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/timing_manager.pkl
+1 day, 19:31:29.614641 INFO: Initializing TimingManager
+1 day, 19:31:29.614794 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/timing_manager.pkl
+1 day, 19:31:29.614830 INFO: Initializing TimingManager
+1 day, 19:31:29.614977 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/library/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/timing_manager.pkl
+1 day, 19:31:29.615012 INFO: Initializing TimingManager
+1 day, 19:31:29.615341 INFO: Writing internal output to disk
+1 day, 19:31:29.615383 INFO: Saving run_output/alphadia_1.10_defaultMBR/library/internal.tsv to disk
+1 day, 19:31:29.615767 PROGRESS: Performing label free quantification
+1 day, 19:31:29.637040 INFO: Accumulating fragment data
+1 day, 19:31:29.637197 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:31:29.796524 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:31:30.589436 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:31:30.937771 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 19:31:32.038258 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 19:31:32.882965 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 19:31:33.457048 PROGRESS: Performing label free quantification on the precursor level
+1 day, 19:31:33.457177 INFO: Filtering fragments by quality
+1 day, 19:31:33.691065 INFO: Performing label-free quantification using directLFQ
+1 day, 19:31:34.064174 INFO: to few values for normalization without missing values. Including missing values
+1 day, 19:31:35.235312 INFO: 82039 lfq-groups total
+1 day, 19:32:44.930786 INFO: using 100 processes
+1 day, 19:32:45.273114 INFO: lfq-object 0
+1 day, 19:32:45.366448 INFO: lfq-object 100
+1 day, 19:32:45.411746 INFO: lfq-object 300
+1 day, 19:32:45.458503 INFO: lfq-object 200
+1 day, 19:32:45.477567 INFO: lfq-object 500
+1 day, 19:32:45.503522 INFO: lfq-object 400
+1 day, 19:32:45.523110 INFO: lfq-object 700
+1 day, 19:32:45.542461 INFO: lfq-object 900
+1 day, 19:32:45.565803 INFO: lfq-object 600
+1 day, 19:32:45.613052 INFO: lfq-object 1100
+1 day, 19:32:45.622195 INFO: lfq-object 800
+1 day, 19:32:45.637378 INFO: lfq-object 1000
+1 day, 19:32:45.667165 INFO: lfq-object 1300
+1 day, 19:32:45.702373 INFO: lfq-object 1200
+1 day, 19:32:45.750244 INFO: lfq-object 1500
+1 day, 19:32:45.762196 INFO: lfq-object 1400
+1 day, 19:32:45.840820 INFO: lfq-object 1600
+1 day, 19:32:45.852813 INFO: lfq-object 1700
+1 day, 19:32:45.949342 INFO: lfq-object 1800
+1 day, 19:32:45.953471 INFO: lfq-object 1900
+1 day, 19:32:46.043139 INFO: lfq-object 2000
+1 day, 19:32:46.053246 INFO: lfq-object 2100
+1 day, 19:32:46.139682 INFO: lfq-object 2300
+1 day, 19:32:46.147605 INFO: lfq-object 2200
+1 day, 19:32:46.187345 INFO: lfq-object 2500
+1 day, 19:32:46.233005 INFO: lfq-object 2400
+1 day, 19:32:46.274402 INFO: lfq-object 2700
+1 day, 19:32:46.276997 INFO: lfq-object 2600
+1 day, 19:32:46.337434 INFO: lfq-object 2900
+1 day, 19:32:46.367722 INFO: lfq-object 2800
+1 day, 19:32:46.402733 INFO: lfq-object 3100
+1 day, 19:32:46.425839 INFO: lfq-object 3000
+1 day, 19:32:46.466044 INFO: lfq-object 3300
+1 day, 19:32:46.499328 INFO: lfq-object 3200
+1 day, 19:32:46.554735 INFO: lfq-object 3400
+1 day, 19:32:46.626505 INFO: lfq-object 3600
+1 day, 19:32:46.648666 INFO: lfq-object 3500
+1 day, 19:32:46.661524 INFO: lfq-object 3800
+1 day, 19:32:46.720782 INFO: lfq-object 3700
+1 day, 19:32:46.749845 INFO: lfq-object 3900
+1 day, 19:32:46.766085 INFO: lfq-object 4000
+1 day, 19:32:46.834126 INFO: lfq-object 4200
+1 day, 19:32:46.858511 INFO: lfq-object 4100
+1 day, 19:32:46.914034 INFO: lfq-object 4400
+1 day, 19:32:46.932037 INFO: lfq-object 4300
+1 day, 19:32:46.996849 INFO: lfq-object 4600
+1 day, 19:32:47.001529 INFO: lfq-object 4500
+1 day, 19:32:47.060791 INFO: lfq-object 4800
+1 day, 19:32:47.089678 INFO: lfq-object 4700
+1 day, 19:32:47.146884 INFO: lfq-object 5000
+1 day, 19:32:47.151121 INFO: lfq-object 4900
+1 day, 19:32:47.211093 INFO: lfq-object 5200
+1 day, 19:32:47.243561 INFO: lfq-object 5100
+1 day, 19:32:47.285552 INFO: lfq-object 5400
+1 day, 19:32:47.316387 INFO: lfq-object 5300
+1 day, 19:32:47.362737 INFO: lfq-object 5600
+1 day, 19:32:47.374705 INFO: lfq-object 5500
+1 day, 19:32:47.424594 INFO: lfq-object 5800
+1 day, 19:32:47.474960 INFO: lfq-object 5700
+1 day, 19:32:47.497708 INFO: lfq-object 6000
+1 day, 19:32:47.516886 INFO: lfq-object 5900
+1 day, 19:32:47.592781 INFO: lfq-object 6100
+1 day, 19:32:50.315716 INFO: lfq-object 6200
+1 day, 19:32:50.409244 INFO: lfq-object 6400
+1 day, 19:32:50.412331 INFO: lfq-object 6300
+1 day, 19:32:50.443786 INFO: lfq-object 6600
+1 day, 19:32:50.499854 INFO: lfq-object 6500
+1 day, 19:32:50.535037 INFO: lfq-object 6700
+1 day, 19:32:50.552907 INFO: lfq-object 6800
+1 day, 19:32:50.651141 INFO: lfq-object 6900
+1 day, 19:32:50.741263 INFO: lfq-object 7100
+1 day, 19:32:50.745575 INFO: lfq-object 7000
+1 day, 19:32:50.834388 INFO: lfq-object 7200
+1 day, 19:32:50.840480 INFO: lfq-object 7300
+1 day, 19:32:50.895841 INFO: lfq-object 7500
+1 day, 19:32:50.933276 INFO: lfq-object 7400
+1 day, 19:32:50.946402 INFO: lfq-object 7700
+1 day, 19:32:50.995332 INFO: lfq-object 7600
+1 day, 19:32:51.020378 INFO: lfq-object 7900
+1 day, 19:32:51.046095 INFO: lfq-object 7800
+1 day, 19:32:51.097741 INFO: lfq-object 8100
+1 day, 19:32:51.118781 INFO: lfq-object 8000
+1 day, 19:32:51.150203 INFO: lfq-object 8300
+1 day, 19:32:51.189332 INFO: lfq-object 8200
+1 day, 19:32:51.237900 INFO: lfq-object 8400
+1 day, 19:32:51.261283 INFO: lfq-object 8500
+1 day, 19:32:51.313970 INFO: lfq-object 8700
+1 day, 19:32:51.350426 INFO: lfq-object 8600
+1 day, 19:32:51.408949 INFO: lfq-object 8800
+1 day, 19:32:51.411553 INFO: lfq-object 8900
+1 day, 19:32:51.487197 INFO: lfq-object 9100
+1 day, 19:32:51.501266 INFO: lfq-object 9000
+1 day, 19:32:51.574499 INFO: lfq-object 9200
+1 day, 19:32:51.601446 INFO: lfq-object 9300
+1 day, 19:32:51.677857 INFO: lfq-object 9500
+1 day, 19:32:51.696799 INFO: lfq-object 9400
+1 day, 19:32:51.738285 INFO: lfq-object 9700
+1 day, 19:32:51.770289 INFO: lfq-object 9600
+1 day, 19:32:51.831054 INFO: lfq-object 9800
+1 day, 19:32:51.831910 INFO: lfq-object 9900
+1 day, 19:32:51.859539 INFO: lfq-object 10100
+1 day, 19:32:51.925732 INFO: lfq-object 10000
+1 day, 19:32:51.945148 INFO: lfq-object 10200
+1 day, 19:32:51.947128 INFO: lfq-object 10300
+1 day, 19:32:52.051992 INFO: lfq-object 10400
+1 day, 19:32:52.140737 INFO: lfq-object 10600
+1 day, 19:32:52.144667 INFO: lfq-object 10500
+1 day, 19:32:52.185072 INFO: lfq-object 10800
+1 day, 19:32:52.230304 INFO: lfq-object 10700
+1 day, 19:32:52.267589 INFO: lfq-object 11000
+1 day, 19:32:52.278208 INFO: lfq-object 10900
+1 day, 19:32:52.358869 INFO: lfq-object 11100
+1 day, 19:32:52.383165 INFO: lfq-object 11200
+1 day, 19:32:52.460164 INFO: lfq-object 11400
+1 day, 19:32:52.478618 INFO: lfq-object 11300
+1 day, 19:32:52.552970 INFO: lfq-object 11500
+1 day, 19:32:52.562751 INFO: lfq-object 11600
+1 day, 19:32:52.603898 INFO: lfq-object 11800
+1 day, 19:32:52.659221 INFO: lfq-object 11700
+1 day, 19:32:52.678877 INFO: lfq-object 12000
+1 day, 19:32:52.694620 INFO: lfq-object 11900
+1 day, 19:32:52.750914 INFO: lfq-object 12200
+1 day, 19:32:52.778615 INFO: lfq-object 12100
+1 day, 19:32:52.829533 INFO: lfq-object 12400
+1 day, 19:32:52.846181 INFO: lfq-object 12300
+1 day, 19:32:52.852449 INFO: lfq-object 12600
+1 day, 19:32:52.924284 INFO: lfq-object 12500
+1 day, 19:32:52.943110 INFO: lfq-object 12700
+1 day, 19:32:52.950171 INFO: lfq-object 12800
+1 day, 19:32:53.010892 INFO: lfq-object 13000
+1 day, 19:32:53.045636 INFO: lfq-object 12900
+1 day, 19:32:53.067510 INFO: lfq-object 13200
+1 day, 19:32:53.106057 INFO: lfq-object 13100
+1 day, 19:32:53.143606 INFO: lfq-object 13400
+1 day, 19:32:53.161732 INFO: lfq-object 13300
+1 day, 19:32:53.184836 INFO: lfq-object 13600
+1 day, 19:32:53.236568 INFO: lfq-object 13500
+1 day, 19:32:53.276448 INFO: lfq-object 13700
+1 day, 19:32:53.370008 INFO: lfq-object 13800
+1 day, 19:32:53.369960 INFO: lfq-object 13900
+1 day, 19:32:53.462848 INFO: lfq-object 14000
+1 day, 19:32:53.472492 INFO: lfq-object 14100
+1 day, 19:32:53.546862 INFO: lfq-object 14300
+1 day, 19:32:53.561125 INFO: lfq-object 14200
+1 day, 19:32:53.620855 INFO: lfq-object 14500
+1 day, 19:32:53.639363 INFO: lfq-object 14400
+1 day, 19:32:53.710624 INFO: lfq-object 14600
+1 day, 19:32:53.717962 INFO: lfq-object 14700
+1 day, 19:32:53.803584 INFO: lfq-object 14900
+1 day, 19:32:53.812890 INFO: lfq-object 14800
+1 day, 19:32:53.894851 INFO: lfq-object 15000
+1 day, 19:32:53.905891 INFO: lfq-object 15100
+1 day, 19:32:53.983027 INFO: lfq-object 15300
+1 day, 19:32:53.995919 INFO: lfq-object 15200
+1 day, 19:32:54.075357 INFO: lfq-object 15500
+1 day, 19:32:54.075489 INFO: lfq-object 15400
+1 day, 19:32:54.164116 INFO: lfq-object 15700
+1 day, 19:32:54.165418 INFO: lfq-object 15600
+1 day, 19:32:54.253548 INFO: lfq-object 15800
+1 day, 19:32:54.261276 INFO: lfq-object 15900
+1 day, 19:32:54.354634 INFO: lfq-object 16000
+1 day, 19:32:54.362024 INFO: lfq-object 16100
+1 day, 19:32:54.436562 INFO: lfq-object 16300
+1 day, 19:32:54.454001 INFO: lfq-object 16200
+1 day, 19:32:54.486394 INFO: lfq-object 16500
+1 day, 19:32:54.536131 INFO: lfq-object 16400
+1 day, 19:32:54.544023 INFO: lfq-object 16700
+1 day, 19:32:54.579827 INFO: lfq-object 16600
+1 day, 19:32:54.624462 INFO: lfq-object 16900
+1 day, 19:32:54.634088 INFO: lfq-object 16800
+1 day, 19:32:54.689091 INFO: lfq-object 17100
+1 day, 19:32:54.718049 INFO: lfq-object 17000
+1 day, 19:32:54.778252 INFO: lfq-object 17200
+1 day, 19:32:54.837626 INFO: lfq-object 17400
+1 day, 19:32:54.873987 INFO: lfq-object 17300
+1 day, 19:32:54.930922 INFO: lfq-object 17500
+1 day, 19:32:54.962219 INFO: lfq-object 17600
+1 day, 19:32:55.057992 INFO: lfq-object 17700
+1 day, 19:32:55.092731 INFO: lfq-object 17800
+1 day, 19:32:55.182345 INFO: lfq-object 17900
+1 day, 19:32:55.231683 INFO: lfq-object 18000
+1 day, 19:32:55.279385 INFO: lfq-object 18200
+1 day, 19:32:55.321419 INFO: lfq-object 18100
+1 day, 19:32:55.336837 INFO: lfq-object 18400
+1 day, 19:32:55.383625 INFO: lfq-object 18300
+1 day, 19:32:55.409175 INFO: lfq-object 18600
+1 day, 19:32:55.425471 INFO: lfq-object 18500
+1 day, 19:32:55.455977 INFO: lfq-object 18800
+1 day, 19:32:55.501560 INFO: lfq-object 18700
+1 day, 19:32:55.522621 INFO: lfq-object 19000
+1 day, 19:32:55.545112 INFO: lfq-object 18900
+1 day, 19:32:55.613940 INFO: lfq-object 19100
+1 day, 19:32:55.620640 INFO: lfq-object 19200
+1 day, 19:32:55.714375 INFO: lfq-object 19300
+1 day, 19:32:55.720705 INFO: lfq-object 19400
+1 day, 19:32:55.816274 INFO: lfq-object 19500
+1 day, 19:32:55.824075 INFO: lfq-object 19600
+1 day, 19:32:55.915123 INFO: lfq-object 19700
+1 day, 19:32:58.740328 INFO: lfq-object 19800
+1 day, 19:32:58.802149 INFO: lfq-object 20000
+1 day, 19:32:58.831275 INFO: lfq-object 19900
+1 day, 19:32:58.842546 INFO: lfq-object 20200
+1 day, 19:32:58.882807 INFO: lfq-object 20400
+1 day, 19:32:58.893942 INFO: lfq-object 20100
+1 day, 19:32:58.912940 INFO: lfq-object 20600
+1 day, 19:32:58.936470 INFO: lfq-object 20300
+1 day, 19:32:58.993170 INFO: lfq-object 20500
+1 day, 19:32:59.004871 INFO: lfq-object 20700
+1 day, 19:32:59.039617 INFO: lfq-object 20900
+1 day, 19:32:59.092031 INFO: lfq-object 20800
+1 day, 19:32:59.117172 INFO: lfq-object 21100
+1 day, 19:32:59.127305 INFO: lfq-object 21000
+1 day, 19:32:59.162140 INFO: lfq-object 21300
+1 day, 19:32:59.209102 INFO: lfq-object 21200
+1 day, 19:32:59.251169 INFO: lfq-object 21400
+1 day, 19:32:59.283314 INFO: lfq-object 21500
+1 day, 19:32:59.368572 INFO: lfq-object 21700
+1 day, 19:32:59.370850 INFO: lfq-object 21600
+1 day, 19:32:59.454404 INFO: lfq-object 21900
+1 day, 19:32:59.461220 INFO: lfq-object 21800
+1 day, 19:32:59.540458 INFO: lfq-object 22100
+1 day, 19:32:59.541128 INFO: lfq-object 22000
+1 day, 19:32:59.607475 INFO: lfq-object 22300
+1 day, 19:32:59.628839 INFO: lfq-object 22200
+1 day, 19:32:59.671554 INFO: lfq-object 22500
+1 day, 19:32:59.697065 INFO: lfq-object 22400
+1 day, 19:32:59.767050 INFO: lfq-object 22700
+1 day, 19:32:59.769040 INFO: lfq-object 22600
+1 day, 19:32:59.857234 INFO: lfq-object 22800
+1 day, 19:32:59.858927 INFO: lfq-object 22900
+1 day, 19:32:59.935905 INFO: lfq-object 23100
+1 day, 19:32:59.946655 INFO: lfq-object 23000
+1 day, 19:33:00.009751 INFO: lfq-object 23300
+1 day, 19:33:00.026916 INFO: lfq-object 23200
+1 day, 19:33:00.086840 INFO: lfq-object 23500
+1 day, 19:33:00.100400 INFO: lfq-object 23400
+1 day, 19:33:00.142088 INFO: lfq-object 23700
+1 day, 19:33:00.177491 INFO: lfq-object 23600
+1 day, 19:33:00.211828 INFO: lfq-object 23900
+1 day, 19:33:00.233122 INFO: lfq-object 23800
+1 day, 19:33:00.312673 INFO: lfq-object 24000
+1 day, 19:33:00.388445 INFO: lfq-object 24200
+1 day, 19:33:00.406117 INFO: lfq-object 24100
+1 day, 19:33:00.477855 INFO: lfq-object 24400
+1 day, 19:33:00.481137 INFO: lfq-object 24300
+1 day, 19:33:00.549300 INFO: lfq-object 24600
+1 day, 19:33:00.570000 INFO: lfq-object 24500
+1 day, 19:33:00.634167 INFO: lfq-object 24800
+1 day, 19:33:00.640189 INFO: lfq-object 24700
+1 day, 19:33:00.693224 INFO: lfq-object 25000
+1 day, 19:33:00.727099 INFO: lfq-object 24900
+1 day, 19:33:00.741557 INFO: lfq-object 25200
+1 day, 19:33:00.787647 INFO: lfq-object 25100
+1 day, 19:33:00.825324 INFO: lfq-object 25400
+1 day, 19:33:00.829747 INFO: lfq-object 25300
+1 day, 19:33:00.894632 INFO: lfq-object 25600
+1 day, 19:33:00.917671 INFO: lfq-object 25500
+1 day, 19:33:00.959569 INFO: lfq-object 25800
+1 day, 19:33:00.985212 INFO: lfq-object 25700
+1 day, 19:33:01.050124 INFO: lfq-object 25900
+1 day, 19:33:01.064219 INFO: lfq-object 26000
+1 day, 19:33:01.098931 INFO: lfq-object 26200
+1 day, 19:33:01.155762 INFO: lfq-object 26100
+1 day, 19:33:01.184359 INFO: lfq-object 26400
+1 day, 19:33:01.192922 INFO: lfq-object 26300
+1 day, 19:33:01.237792 INFO: lfq-object 26600
+1 day, 19:33:01.268191 INFO: lfq-object 26800
+1 day, 19:33:01.272727 INFO: lfq-object 26500
+1 day, 19:33:01.328341 INFO: lfq-object 26700
+1 day, 19:33:01.344838 INFO: lfq-object 27000
+1 day, 19:33:01.359458 INFO: lfq-object 26900
+1 day, 19:33:01.405640 INFO: lfq-object 27200
+1 day, 19:33:01.441804 INFO: lfq-object 27100
+1 day, 19:33:01.455531 INFO: lfq-object 27400
+1 day, 19:33:01.504511 INFO: lfq-object 27300
+1 day, 19:33:01.542380 INFO: lfq-object 27500
+1 day, 19:33:01.611117 INFO: lfq-object 27700
+1 day, 19:33:01.638074 INFO: lfq-object 27600
+1 day, 19:33:01.660220 INFO: lfq-object 27900
+1 day, 19:33:01.704038 INFO: lfq-object 27800
+1 day, 19:33:01.722957 INFO: lfq-object 28100
+1 day, 19:33:01.747864 INFO: lfq-object 28000
+1 day, 19:33:01.802494 INFO: lfq-object 28300
+1 day, 19:33:01.814531 INFO: lfq-object 28200
+1 day, 19:33:01.864107 INFO: lfq-object 28500
+1 day, 19:33:01.894166 INFO: lfq-object 28400
+1 day, 19:33:01.913048 INFO: lfq-object 28700
+1 day, 19:33:01.953590 INFO: lfq-object 28600
+1 day, 19:33:01.995864 INFO: lfq-object 28900
+1 day, 19:33:02.007303 INFO: lfq-object 28800
+1 day, 19:33:02.084232 INFO: lfq-object 29000
+1 day, 19:33:02.093042 INFO: lfq-object 29100
+1 day, 19:33:02.183869 INFO: lfq-object 29200
+1 day, 19:33:02.194211 INFO: lfq-object 29300
+1 day, 19:33:02.270140 INFO: lfq-object 29500
+1 day, 19:33:02.287199 INFO: lfq-object 29400
+1 day, 19:33:02.332713 INFO: lfq-object 29700
+1 day, 19:33:02.356920 INFO: lfq-object 29600
+1 day, 19:33:02.389045 INFO: lfq-object 29900
+1 day, 19:33:02.422278 INFO: lfq-object 29800
+1 day, 19:33:02.448879 INFO: lfq-object 30100
+1 day, 19:33:02.481170 INFO: lfq-object 30000
+1 day, 19:33:02.520427 INFO: lfq-object 30300
+1 day, 19:33:02.547727 INFO: lfq-object 30200
+1 day, 19:33:02.598958 INFO: lfq-object 30500
+1 day, 19:33:02.611438 INFO: lfq-object 30400
+1 day, 19:33:02.681936 INFO: lfq-object 30700
+1 day, 19:33:02.689814 INFO: lfq-object 30600
+1 day, 19:33:02.773424 INFO: lfq-object 30900
+1 day, 19:33:02.776469 INFO: lfq-object 30800
+1 day, 19:33:02.865366 INFO: lfq-object 31000
+1 day, 19:33:02.950959 INFO: lfq-object 31200
+1 day, 19:33:02.955533 INFO: lfq-object 31100
+1 day, 19:33:03.010947 INFO: lfq-object 31400
+1 day, 19:33:03.041441 INFO: lfq-object 31300
+1 day, 19:33:03.067996 INFO: lfq-object 31600
+1 day, 19:33:03.102687 INFO: lfq-object 31500
+1 day, 19:33:03.128237 INFO: lfq-object 31800
+1 day, 19:33:03.157927 INFO: lfq-object 31700
+1 day, 19:33:03.202636 INFO: lfq-object 32000
+1 day, 19:33:03.211327 INFO: lfq-object 31900
+1 day, 19:33:03.275759 INFO: lfq-object 32200
+1 day, 19:33:03.294386 INFO: lfq-object 32100
+1 day, 19:33:03.344473 INFO: lfq-object 32400
+1 day, 19:33:03.368834 INFO: lfq-object 32300
+1 day, 19:33:03.401763 INFO: lfq-object 32600
+1 day, 19:33:03.428617 INFO: lfq-object 32500
+1 day, 19:33:03.489474 INFO: lfq-object 32700
+1 day, 19:33:03.490800 INFO: lfq-object 32800
+1 day, 19:33:03.549741 INFO: lfq-object 33000
+1 day, 19:33:03.584132 INFO: lfq-object 32900
+1 day, 19:33:03.606658 INFO: lfq-object 33200
+1 day, 19:33:03.637542 INFO: lfq-object 33100
+1 day, 19:33:03.696007 INFO: lfq-object 33300
+1 day, 19:33:03.700440 INFO: lfq-object 33400
+1 day, 19:33:03.743443 INFO: lfq-object 33600
+1 day, 19:33:03.790668 INFO: lfq-object 33500
+1 day, 19:33:03.832033 INFO: lfq-object 33700
+1 day, 19:33:03.841908 INFO: lfq-object 33800
+1 day, 19:33:03.940435 INFO: lfq-object 33900
+1 day, 19:33:03.940426 INFO: lfq-object 34000
+1 day, 19:33:04.035259 INFO: lfq-object 34200
+1 day, 19:33:04.035445 INFO: lfq-object 34100
+1 day, 19:33:04.144018 INFO: lfq-object 34300
+1 day, 19:33:04.217987 INFO: lfq-object 34500
+1 day, 19:33:04.230957 INFO: lfq-object 34400
+1 day, 19:33:04.305974 INFO: lfq-object 34600
+1 day, 19:33:07.294823 INFO: lfq-object 34700
+1 day, 19:33:07.386138 INFO: lfq-object 34800
+1 day, 19:33:07.405076 INFO: lfq-object 34900
+1 day, 19:33:07.491396 INFO: lfq-object 35100
+1 day, 19:33:07.495625 INFO: lfq-object 35000
+1 day, 19:33:07.541292 INFO: lfq-object 35300
+1 day, 19:33:07.579928 INFO: lfq-object 35200
+1 day, 19:33:07.627931 INFO: lfq-object 35500
+1 day, 19:33:07.633282 INFO: lfq-object 35400
+1 day, 19:33:07.718225 INFO: lfq-object 35600
+1 day, 19:33:07.721925 INFO: lfq-object 35700
+1 day, 19:33:07.747628 INFO: lfq-object 35900
+1 day, 19:33:07.813107 INFO: lfq-object 35800
+1 day, 19:33:07.828251 INFO: lfq-object 36100
+1 day, 19:33:07.844187 INFO: lfq-object 36000
+1 day, 19:33:07.890413 INFO: lfq-object 36300
+1 day, 19:33:07.924215 INFO: lfq-object 36200
+1 day, 19:33:07.962654 INFO: lfq-object 36500
+1 day, 19:33:07.984746 INFO: lfq-object 36400
+1 day, 19:33:08.036102 INFO: lfq-object 36700
+1 day, 19:33:08.053866 INFO: lfq-object 36600
+1 day, 19:33:08.129258 INFO: lfq-object 36800
+1 day, 19:33:08.142108 INFO: lfq-object 36900
+1 day, 19:33:08.216270 INFO: lfq-object 37100
+1 day, 19:33:08.229987 INFO: lfq-object 37000
+1 day, 19:33:08.289899 INFO: lfq-object 37300
+1 day, 19:33:08.307810 INFO: lfq-object 37200
+1 day, 19:33:08.366066 INFO: lfq-object 37500
+1 day, 19:33:08.376723 INFO: lfq-object 37400
+1 day, 19:33:08.409397 INFO: lfq-object 37700
+1 day, 19:33:08.461811 INFO: lfq-object 37600
+1 day, 19:33:08.498780 INFO: lfq-object 37800
+1 day, 19:33:08.574835 INFO: lfq-object 38000
+1 day, 19:33:08.592012 INFO: lfq-object 37900
+1 day, 19:33:08.655872 INFO: lfq-object 38200
+1 day, 19:33:08.669814 INFO: lfq-object 38100
+1 day, 19:33:08.729980 INFO: lfq-object 38400
+1 day, 19:33:08.746842 INFO: lfq-object 38300
+1 day, 19:33:08.796689 INFO: lfq-object 38600
+1 day, 19:33:08.821802 INFO: lfq-object 38500
+1 day, 19:33:08.855329 INFO: lfq-object 38800
+1 day, 19:33:08.887626 INFO: lfq-object 38700
+1 day, 19:33:08.939318 INFO: lfq-object 39000
+1 day, 19:33:08.946063 INFO: lfq-object 38900
+1 day, 19:33:08.994512 INFO: lfq-object 39200
+1 day, 19:33:09.027674 INFO: lfq-object 39100
+1 day, 19:33:09.031561 INFO: lfq-object 39400
+1 day, 19:33:09.083751 INFO: lfq-object 39300
+1 day, 19:33:09.100476 INFO: lfq-object 39600
+1 day, 19:33:09.121931 INFO: lfq-object 39500
+1 day, 19:33:09.188809 INFO: lfq-object 39800
+1 day, 19:33:09.192422 INFO: lfq-object 39700
+1 day, 19:33:09.241437 INFO: lfq-object 40000
+1 day, 19:33:09.280006 INFO: lfq-object 39900
+1 day, 19:33:09.312379 INFO: lfq-object 40200
+1 day, 19:33:09.333231 INFO: lfq-object 40100
+1 day, 19:33:09.339350 INFO: lfq-object 40400
+1 day, 19:33:09.404034 INFO: lfq-object 40300
+1 day, 19:33:09.417084 INFO: lfq-object 40600
+1 day, 19:33:09.427617 INFO: lfq-object 40500
+1 day, 19:33:09.495552 INFO: lfq-object 40800
+1 day, 19:33:09.509480 INFO: lfq-object 40700
+1 day, 19:33:09.570291 INFO: lfq-object 41000
+1 day, 19:33:09.585630 INFO: lfq-object 40900
+1 day, 19:33:09.655562 INFO: lfq-object 41100
+1 day, 19:33:09.656244 INFO: lfq-object 41200
+1 day, 19:33:09.742960 INFO: lfq-object 41300
+1 day, 19:33:09.843410 INFO: lfq-object 41400
+1 day, 19:33:09.859884 INFO: lfq-object 41500
+1 day, 19:33:09.935368 INFO: lfq-object 41700
+1 day, 19:33:09.950072 INFO: lfq-object 41600
+1 day, 19:33:09.988450 INFO: lfq-object 41900
+1 day, 19:33:10.038183 INFO: lfq-object 41800
+1 day, 19:33:10.047018 INFO: lfq-object 42100
+1 day, 19:33:10.085143 INFO: lfq-object 42000
+1 day, 19:33:10.097234 INFO: lfq-object 42300
+1 day, 19:33:10.137551 INFO: lfq-object 42200
+1 day, 19:33:10.162936 INFO: lfq-object 42500
+1 day, 19:33:10.191797 INFO: lfq-object 42400
+1 day, 19:33:10.240906 INFO: lfq-object 42700
+1 day, 19:33:10.252247 INFO: lfq-object 42600
+1 day, 19:33:10.318331 INFO: lfq-object 42900
+1 day, 19:33:10.330399 INFO: lfq-object 42800
+1 day, 19:33:10.407629 INFO: lfq-object 43000
+1 day, 19:33:10.413933 INFO: lfq-object 43100
+1 day, 19:33:10.502956 INFO: lfq-object 43200
+1 day, 19:33:10.537582 INFO: lfq-object 43300
+1 day, 19:33:10.627355 INFO: lfq-object 43400
+1 day, 19:33:10.691546 INFO: lfq-object 43500
+1 day, 19:33:10.782044 INFO: lfq-object 43600
+1 day, 19:33:10.832973 INFO: lfq-object 43700
+1 day, 19:33:10.892012 INFO: lfq-object 43900
+1 day, 19:33:10.919071 INFO: lfq-object 43800
+1 day, 19:33:10.932539 INFO: lfq-object 44100
+1 day, 19:33:10.978330 INFO: lfq-object 44300
+1 day, 19:33:10.986126 INFO: lfq-object 44000
+1 day, 19:33:11.016240 INFO: lfq-object 44200
+1 day, 19:33:11.054669 INFO: lfq-object 44500
+1 day, 19:33:11.071282 INFO: lfq-object 44400
+1 day, 19:33:11.144876 INFO: lfq-object 44600
+1 day, 19:33:11.188430 INFO: lfq-object 44800
+1 day, 19:33:11.238000 INFO: lfq-object 44700
+1 day, 19:33:11.266639 INFO: lfq-object 45000
+1 day, 19:33:11.278441 INFO: lfq-object 44900
+1 day, 19:33:11.349563 INFO: lfq-object 45200
+1 day, 19:33:11.359427 INFO: lfq-object 45100
+1 day, 19:33:11.390552 INFO: lfq-object 45400
+1 day, 19:33:11.454367 INFO: lfq-object 45300
+1 day, 19:33:11.478627 INFO: lfq-object 45500
+1 day, 19:33:11.481365 INFO: lfq-object 45600
+1 day, 19:33:11.556104 INFO: lfq-object 45800
+1 day, 19:33:11.578892 INFO: lfq-object 45700
+1 day, 19:33:11.628053 INFO: lfq-object 46000
+1 day, 19:33:11.649693 INFO: lfq-object 45900
+1 day, 19:33:11.702732 INFO: lfq-object 46200
+1 day, 19:33:11.719850 INFO: lfq-object 46100
+1 day, 19:33:11.739495 INFO: lfq-object 46400
+1 day, 19:33:11.803146 INFO: lfq-object 46300
+1 day, 19:33:11.809314 INFO: lfq-object 46600
+1 day, 19:33:11.826689 INFO: lfq-object 46500
+1 day, 19:33:11.883704 INFO: lfq-object 46800
+1 day, 19:33:11.898696 INFO: lfq-object 46700
+1 day, 19:33:11.949668 INFO: lfq-object 47000
+1 day, 19:33:11.972794 INFO: lfq-object 46900
+1 day, 19:33:12.011332 INFO: lfq-object 47200
+1 day, 19:33:12.041472 INFO: lfq-object 47100
+1 day, 19:33:12.071833 INFO: lfq-object 47400
+1 day, 19:33:12.095954 INFO: lfq-object 47300
+1 day, 19:33:12.130148 INFO: lfq-object 47600
+1 day, 19:33:12.167050 INFO: lfq-object 47500
+1 day, 19:33:12.185771 INFO: lfq-object 47800
+1 day, 19:33:12.224814 INFO: lfq-object 47700
+1 day, 19:33:12.245609 INFO: lfq-object 48000
+1 day, 19:33:12.271132 INFO: lfq-object 47900
+1 day, 19:33:12.334954 INFO: lfq-object 48100
+1 day, 19:33:12.392685 INFO: lfq-object 48300
+1 day, 19:33:12.451594 INFO: lfq-object 48200
+1 day, 19:33:12.469021 INFO: lfq-object 48500
+1 day, 19:33:12.482505 INFO: lfq-object 48400
+1 day, 19:33:12.512124 INFO: lfq-object 48700
+1 day, 19:33:12.561636 INFO: lfq-object 48600
+1 day, 19:33:12.599720 INFO: lfq-object 48900
+1 day, 19:33:12.601418 INFO: lfq-object 48800
+1 day, 19:33:12.638777 INFO: lfq-object 49100
+1 day, 19:33:12.689799 INFO: lfq-object 49000
+1 day, 19:33:12.694989 INFO: lfq-object 49300
+1 day, 19:33:12.729668 INFO: lfq-object 49200
+1 day, 19:33:12.769659 INFO: lfq-object 49500
+1 day, 19:33:12.785972 INFO: lfq-object 49400
+1 day, 19:33:12.817123 INFO: lfq-object 49700
+1 day, 19:33:12.854374 INFO: lfq-object 49600
+1 day, 19:33:12.864607 INFO: lfq-object 49900
+1 day, 19:33:12.909065 INFO: lfq-object 49800
+1 day, 19:33:12.940172 INFO: lfq-object 50100
+1 day, 19:33:12.957815 INFO: lfq-object 50000
+1 day, 19:33:13.017737 INFO: lfq-object 50300
+1 day, 19:33:13.031527 INFO: lfq-object 50200
+1 day, 19:33:13.109315 INFO: lfq-object 50400
+1 day, 19:33:13.121360 INFO: lfq-object 50500
+1 day, 19:33:13.214785 INFO: lfq-object 50600
+1 day, 19:33:16.510148 INFO: lfq-object 50700
+1 day, 19:33:16.594340 INFO: lfq-object 50900
+1 day, 19:33:16.595662 INFO: lfq-object 50800
+1 day, 19:33:16.678638 INFO: lfq-object 51100
+1 day, 19:33:16.683787 INFO: lfq-object 51000
+1 day, 19:33:16.737038 INFO: lfq-object 51300
+1 day, 19:33:16.767440 INFO: lfq-object 51200
+1 day, 19:33:16.804564 INFO: lfq-object 51500
+1 day, 19:33:16.838459 INFO: lfq-object 51400
+1 day, 19:33:16.890591 INFO: lfq-object 51600
+1 day, 19:33:16.951463 INFO: lfq-object 51800
+1 day, 19:33:16.984061 INFO: lfq-object 51700
+1 day, 19:33:17.038645 INFO: lfq-object 52000
+1 day, 19:33:17.047860 INFO: lfq-object 51900
+1 day, 19:33:17.091850 INFO: lfq-object 52200
+1 day, 19:33:17.128848 INFO: lfq-object 52100
+1 day, 19:33:17.155259 INFO: lfq-object 52400
+1 day, 19:33:17.180313 INFO: lfq-object 52300
+1 day, 19:33:17.227984 INFO: lfq-object 52600
+1 day, 19:33:17.249545 INFO: lfq-object 52500
+1 day, 19:33:17.289040 INFO: lfq-object 52800
+1 day, 19:33:17.317599 INFO: lfq-object 52700
+1 day, 19:33:17.334335 INFO: lfq-object 53000
+1 day, 19:33:17.381352 INFO: lfq-object 52900
+1 day, 19:33:17.394287 INFO: lfq-object 53200
+1 day, 19:33:17.438632 INFO: lfq-object 53100
+1 day, 19:33:17.460662 INFO: lfq-object 53400
+1 day, 19:33:17.483030 INFO: lfq-object 53300
+1 day, 19:33:17.526353 INFO: lfq-object 53600
+1 day, 19:33:17.557329 INFO: lfq-object 53500
+1 day, 19:33:17.562719 INFO: lfq-object 53800
+1 day, 19:33:17.617684 INFO: lfq-object 53700
+1 day, 19:33:17.653343 INFO: lfq-object 53900
+1 day, 19:33:17.681294 INFO: lfq-object 54000
+1 day, 19:33:17.776829 INFO: lfq-object 54100
+1 day, 19:33:17.799030 INFO: lfq-object 54200
+1 day, 19:33:17.873519 INFO: lfq-object 54400
+1 day, 19:33:17.890630 INFO: lfq-object 54300
+1 day, 19:33:17.950130 INFO: lfq-object 54600
+1 day, 19:33:17.965234 INFO: lfq-object 54500
+1 day, 19:33:18.000368 INFO: lfq-object 54800
+1 day, 19:33:18.051459 INFO: lfq-object 54700
+1 day, 19:33:18.107379 INFO: lfq-object 54900
+1 day, 19:33:18.166152 INFO: lfq-object 55100
+1 day, 19:33:18.197651 INFO: lfq-object 55000
+1 day, 19:33:18.210853 INFO: lfq-object 55300
+1 day, 19:33:18.256366 INFO: lfq-object 55200
+1 day, 19:33:18.288018 INFO: lfq-object 55500
+1 day, 19:33:18.296639 INFO: lfq-object 55400
+1 day, 19:33:18.377363 INFO: lfq-object 55600
+1 day, 19:33:18.398565 INFO: lfq-object 55700
+1 day, 19:33:18.489755 INFO: lfq-object 55800
+1 day, 19:33:18.527247 INFO: lfq-object 55900
+1 day, 19:33:18.612163 INFO: lfq-object 56000
+1 day, 19:33:18.700629 INFO: lfq-object 56100
+1 day, 19:33:18.792692 INFO: lfq-object 56200
+1 day, 19:33:18.834841 INFO: lfq-object 56300
+1 day, 19:33:18.918401 INFO: lfq-object 56500
+1 day, 19:33:18.926191 INFO: lfq-object 56400
+1 day, 19:33:18.942395 INFO: lfq-object 56700
+1 day, 19:33:18.997628 INFO: lfq-object 56900
+1 day, 19:33:19.008111 INFO: lfq-object 56600
+1 day, 19:33:19.032052 INFO: lfq-object 56800
+1 day, 19:33:19.066646 INFO: lfq-object 57100
+1 day, 19:33:19.089825 INFO: lfq-object 57000
+1 day, 19:33:19.112860 INFO: lfq-object 57300
+1 day, 19:33:19.149760 INFO: lfq-object 57200
+1 day, 19:33:19.189537 INFO: lfq-object 57500
+1 day, 19:33:19.206575 INFO: lfq-object 57400
+1 day, 19:33:19.235692 INFO: lfq-object 57700
+1 day, 19:33:19.283260 INFO: lfq-object 57600
+1 day, 19:33:19.310337 INFO: lfq-object 57900
+1 day, 19:33:19.326080 INFO: lfq-object 57800
+1 day, 19:33:19.359862 INFO: lfq-object 58100
+1 day, 19:33:19.400132 INFO: lfq-object 58000
+1 day, 19:33:19.429667 INFO: lfq-object 58300
+1 day, 19:33:19.445117 INFO: lfq-object 58200
+1 day, 19:33:19.520221 INFO: lfq-object 58400
+1 day, 19:33:19.602839 INFO: lfq-object 58600
+1 day, 19:33:19.612492 INFO: lfq-object 58500
+1 day, 19:33:19.690383 INFO: lfq-object 58700
+1 day, 19:33:19.692493 INFO: lfq-object 58800
+1 day, 19:33:19.777844 INFO: lfq-object 59000
+1 day, 19:33:19.784730 INFO: lfq-object 58900
+1 day, 19:33:19.839889 INFO: lfq-object 59200
+1 day, 19:33:19.865898 INFO: lfq-object 59100
+1 day, 19:33:19.885730 INFO: lfq-object 59400
+1 day, 19:33:19.926557 INFO: lfq-object 59300
+1 day, 19:33:19.961862 INFO: lfq-object 59600
+1 day, 19:33:19.970971 INFO: lfq-object 59500
+1 day, 19:33:19.993062 INFO: lfq-object 59800
+1 day, 19:33:20.049541 INFO: lfq-object 59700
+1 day, 19:33:20.085250 INFO: lfq-object 59900
+1 day, 19:33:20.109227 INFO: lfq-object 60000
+1 day, 19:33:20.133420 INFO: lfq-object 60200
+1 day, 19:33:20.197888 INFO: lfq-object 60100
+1 day, 19:33:20.221954 INFO: lfq-object 60400
+1 day, 19:33:20.228490 INFO: lfq-object 60300
+1 day, 19:33:20.297506 INFO: lfq-object 60600
+1 day, 19:33:20.314214 INFO: lfq-object 60500
+1 day, 19:33:20.388885 INFO: lfq-object 60700
+1 day, 19:33:20.441195 INFO: lfq-object 60800
+1 day, 19:33:20.532756 INFO: lfq-object 60900
+1 day, 19:33:20.589996 INFO: lfq-object 61000
+1 day, 19:33:20.680137 INFO: lfq-object 61100
+1 day, 19:33:20.740843 INFO: lfq-object 61200
+1 day, 19:33:20.827571 INFO: lfq-object 61300
+1 day, 19:33:20.874343 INFO: lfq-object 61400
+1 day, 19:33:20.969373 INFO: lfq-object 61500
+1 day, 19:33:20.988900 INFO: lfq-object 61600
+1 day, 19:33:21.079416 INFO: lfq-object 61700
+1 day, 19:33:21.147717 INFO: lfq-object 61800
+1 day, 19:33:21.261117 INFO: lfq-object 61900
+1 day, 19:33:21.355112 INFO: lfq-object 62000
+1 day, 19:33:21.408135 INFO: lfq-object 62100
+1 day, 19:33:21.493689 INFO: lfq-object 62200
+1 day, 19:33:21.542996 INFO: lfq-object 62300
+1 day, 19:33:21.626948 INFO: lfq-object 62400
+1 day, 19:33:21.632212 INFO: lfq-object 62500
+1 day, 19:33:21.664701 INFO: lfq-object 62700
+1 day, 19:33:21.726449 INFO: lfq-object 62600
+1 day, 19:33:21.745527 INFO: lfq-object 62900
+1 day, 19:33:21.761961 INFO: lfq-object 62800
+1 day, 19:33:21.807721 INFO: lfq-object 63100
+1 day, 19:33:21.834735 INFO: lfq-object 63000
+1 day, 19:33:21.850175 INFO: lfq-object 63300
+1 day, 19:33:21.897690 INFO: lfq-object 63200
+1 day, 19:33:21.928556 INFO: lfq-object 63500
+1 day, 19:33:21.943033 INFO: lfq-object 63400
+1 day, 19:33:21.999251 INFO: lfq-object 63700
+1 day, 19:33:22.015386 INFO: lfq-object 63600
+1 day, 19:33:22.041003 INFO: lfq-object 63900
+1 day, 19:33:22.088696 INFO: lfq-object 63800
+1 day, 19:33:22.098928 INFO: lfq-object 64100
+1 day, 19:33:22.138172 INFO: lfq-object 64000
+1 day, 19:33:22.163622 INFO: lfq-object 64300
+1 day, 19:33:22.189466 INFO: lfq-object 64200
+1 day, 19:33:22.218881 INFO: lfq-object 64500
+1 day, 19:33:22.248684 INFO: lfq-object 64400
+1 day, 19:33:22.280353 INFO: lfq-object 64700
+1 day, 19:33:22.313721 INFO: lfq-object 64600
+1 day, 19:33:22.370150 INFO: lfq-object 64800
+1 day, 19:33:22.386874 INFO: lfq-object 64900
+1 day, 19:33:22.468783 INFO: lfq-object 65100
+1 day, 19:33:22.489360 INFO: lfq-object 65000
+1 day, 19:33:22.580162 INFO: lfq-object 65200
+1 day, 19:33:22.606266 INFO: lfq-object 65400
+1 day, 19:33:22.671790 INFO: lfq-object 65300
+1 day, 19:33:22.696325 INFO: lfq-object 65600
+1 day, 19:33:22.696477 INFO: lfq-object 65500
+1 day, 19:33:22.747627 INFO: lfq-object 65800
+1 day, 19:33:22.789271 INFO: lfq-object 65700
+1 day, 19:33:22.826190 INFO: lfq-object 66000
+1 day, 19:33:22.837884 INFO: lfq-object 65900
+1 day, 19:33:22.892123 INFO: lfq-object 66200
+1 day, 19:33:22.917794 INFO: lfq-object 66100
+1 day, 19:33:22.946281 INFO: lfq-object 66400
+1 day, 19:33:22.987159 INFO: lfq-object 66300
+1 day, 19:33:23.015018 INFO: lfq-object 66600
+1 day, 19:33:23.034443 INFO: lfq-object 66500
+1 day, 19:33:23.090455 INFO: lfq-object 66800
+1 day, 19:33:23.108471 INFO: lfq-object 66700
+1 day, 19:33:23.181651 INFO: lfq-object 66900
+1 day, 19:33:23.182500 INFO: lfq-object 67000
+1 day, 19:33:23.242238 INFO: lfq-object 67200
+1 day, 19:33:23.272003 INFO: lfq-object 67100
+1 day, 19:33:23.292743 INFO: lfq-object 67400
+1 day, 19:33:23.334677 INFO: lfq-object 67300
+1 day, 19:33:23.356784 INFO: lfq-object 67600
+1 day, 19:33:23.383012 INFO: lfq-object 67500
+1 day, 19:33:23.405859 INFO: lfq-object 67800
+1 day, 19:33:23.448686 INFO: lfq-object 67700
+1 day, 19:33:23.469366 INFO: lfq-object 68000
+1 day, 19:33:23.496830 INFO: lfq-object 67900
+1 day, 19:33:23.527529 INFO: lfq-object 68200
+1 day, 19:33:23.564823 INFO: lfq-object 68100
+1 day, 19:33:23.589508 INFO: lfq-object 68400
+1 day, 19:33:23.618773 INFO: lfq-object 68300
+1 day, 19:33:23.681501 INFO: lfq-object 68500
+1 day, 19:33:27.356973 INFO: lfq-object 68600
+1 day, 19:33:27.442059 INFO: lfq-object 68700
+1 day, 19:33:27.529874 INFO: lfq-object 68900
+1 day, 19:33:27.536783 INFO: lfq-object 68800
+1 day, 19:33:27.586439 INFO: lfq-object 69100
+1 day, 19:33:27.627139 INFO: lfq-object 69000
+1 day, 19:33:27.658432 INFO: lfq-object 69300
+1 day, 19:33:27.678467 INFO: lfq-object 69200
+1 day, 19:33:27.733977 INFO: lfq-object 69500
+1 day, 19:33:27.752970 INFO: lfq-object 69400
+1 day, 19:33:27.819615 INFO: lfq-object 69700
+1 day, 19:33:27.823859 INFO: lfq-object 69600
+1 day, 19:33:27.892765 INFO: lfq-object 69900
+1 day, 19:33:27.929201 INFO: lfq-object 69800
+1 day, 19:33:27.963854 INFO: lfq-object 70100
+1 day, 19:33:27.983349 INFO: lfq-object 70000
+1 day, 19:33:28.033353 INFO: lfq-object 70300
+1 day, 19:33:28.058810 INFO: lfq-object 70200
+1 day, 19:33:28.085328 INFO: lfq-object 70500
+1 day, 19:33:28.124159 INFO: lfq-object 70400
+1 day, 19:33:28.180076 INFO: lfq-object 70600
+1 day, 19:33:28.195595 INFO: lfq-object 70700
+1 day, 19:33:28.286031 INFO: lfq-object 70800
+1 day, 19:33:28.313167 INFO: lfq-object 70900
+1 day, 19:33:28.400459 INFO: lfq-object 71100
+1 day, 19:33:28.402721 INFO: lfq-object 71000
+1 day, 19:33:28.442847 INFO: lfq-object 71300
+1 day, 19:33:28.495820 INFO: lfq-object 71200
+1 day, 19:33:28.525606 INFO: lfq-object 71500
+1 day, 19:33:28.535958 INFO: lfq-object 71400
+1 day, 19:33:28.568003 INFO: lfq-object 71700
+1 day, 19:33:28.617043 INFO: lfq-object 71600
+1 day, 19:33:28.643451 INFO: lfq-object 71900
+1 day, 19:33:28.663900 INFO: lfq-object 71800
+1 day, 19:33:28.714944 INFO: lfq-object 72100
+1 day, 19:33:28.730169 INFO: lfq-object 72000
+1 day, 19:33:28.807134 INFO: lfq-object 72200
+1 day, 19:33:28.888648 INFO: lfq-object 72400
+1 day, 19:33:28.901674 INFO: lfq-object 72300
+1 day, 19:33:28.976475 INFO: lfq-object 72600
+1 day, 19:33:28.986737 INFO: lfq-object 72500
+1 day, 19:33:29.072684 INFO: lfq-object 72700
+1 day, 19:33:29.072996 INFO: lfq-object 72800
+1 day, 19:33:29.162356 INFO: lfq-object 72900
+1 day, 19:33:29.170628 INFO: lfq-object 73000
+1 day, 19:33:29.238150 INFO: lfq-object 73200
+1 day, 19:33:29.260724 INFO: lfq-object 73100
+1 day, 19:33:29.263903 INFO: lfq-object 73400
+1 day, 19:33:29.334210 INFO: lfq-object 73300
+1 day, 19:33:29.354123 INFO: lfq-object 73500
+1 day, 19:33:29.362245 INFO: lfq-object 73600
+1 day, 19:33:29.442274 INFO: lfq-object 73800
+1 day, 19:33:29.450593 INFO: lfq-object 73700
+1 day, 19:33:29.517670 INFO: lfq-object 74000
+1 day, 19:33:29.530111 INFO: lfq-object 73900
+1 day, 19:33:29.604398 INFO: lfq-object 74200
+1 day, 19:33:29.615719 INFO: lfq-object 74100
+1 day, 19:33:29.688506 INFO: lfq-object 74400
+1 day, 19:33:29.690996 INFO: lfq-object 74300
+1 day, 19:33:29.767743 INFO: lfq-object 74600
+1 day, 19:33:29.779428 INFO: lfq-object 74500
+1 day, 19:33:29.824279 INFO: lfq-object 74800
+1 day, 19:33:29.860869 INFO: lfq-object 74700
+1 day, 19:33:29.884475 INFO: lfq-object 75000
+1 day, 19:33:29.916257 INFO: lfq-object 74900
+1 day, 19:33:29.929355 INFO: lfq-object 75200
+1 day, 19:33:29.980089 INFO: lfq-object 75100
+1 day, 19:33:29.991573 INFO: lfq-object 75400
+1 day, 19:33:30.032964 INFO: lfq-object 75300
+1 day, 19:33:30.095802 INFO: lfq-object 75500
+1 day, 19:33:30.139053 INFO: lfq-object 75700
+1 day, 19:33:30.185700 INFO: lfq-object 75600
+1 day, 19:33:30.209036 INFO: lfq-object 75900
+1 day, 19:33:30.228191 INFO: lfq-object 75800
+1 day, 19:33:30.237820 INFO: lfq-object 76100
+1 day, 19:33:30.298516 INFO: lfq-object 76000
+1 day, 19:33:30.300994 INFO: lfq-object 76300
+1 day, 19:33:30.332934 INFO: lfq-object 76200
+1 day, 19:33:30.352732 INFO: lfq-object 76500
+1 day, 19:33:30.393014 INFO: lfq-object 76400
+1 day, 19:33:30.425463 INFO: lfq-object 76700
+1 day, 19:33:30.438336 INFO: lfq-object 76600
+1 day, 19:33:30.502648 INFO: lfq-object 76900
+1 day, 19:33:30.526336 INFO: lfq-object 76800
+1 day, 19:33:30.596977 INFO: lfq-object 77000
+1 day, 19:33:30.602282 INFO: lfq-object 77100
+1 day, 19:33:30.667286 INFO: lfq-object 77300
+1 day, 19:33:30.696183 INFO: lfq-object 77200
+1 day, 19:33:30.760804 INFO: lfq-object 77400
+1 day, 19:33:30.768417 INFO: lfq-object 77500
+1 day, 19:33:30.846376 INFO: lfq-object 77700
+1 day, 19:33:30.862638 INFO: lfq-object 77600
+1 day, 19:33:30.938615 INFO: lfq-object 77800
+1 day, 19:33:30.943350 INFO: lfq-object 77900
+1 day, 19:33:31.025541 INFO: lfq-object 78100
+1 day, 19:33:31.035076 INFO: lfq-object 78000
+1 day, 19:33:31.119500 INFO: lfq-object 78200
+1 day, 19:33:31.175766 INFO: lfq-object 78300
+1 day, 19:33:31.270845 INFO: lfq-object 78400
+1 day, 19:33:31.280956 INFO: lfq-object 78500
+1 day, 19:33:31.367780 INFO: lfq-object 78700
+1 day, 19:33:31.374572 INFO: lfq-object 78600
+1 day, 19:33:31.436529 INFO: lfq-object 78900
+1 day, 19:33:31.469522 INFO: lfq-object 78800
+1 day, 19:33:31.541955 INFO: lfq-object 79000
+1 day, 19:33:31.633171 INFO: lfq-object 79100
+1 day, 19:33:31.650973 INFO: lfq-object 79200
+1 day, 19:33:31.742701 INFO: lfq-object 79300
+1 day, 19:33:31.745478 INFO: lfq-object 79400
+1 day, 19:33:31.834986 INFO: lfq-object 79500
+1 day, 19:33:31.837687 INFO: lfq-object 79600
+1 day, 19:33:31.921586 INFO: lfq-object 79800
+1 day, 19:33:31.934460 INFO: lfq-object 79700
+1 day, 19:33:32.007610 INFO: lfq-object 80000
+1 day, 19:33:32.016569 INFO: lfq-object 79900
+1 day, 19:33:32.047734 INFO: lfq-object 80200
+1 day, 19:33:32.074460 INFO: lfq-object 80400
+1 day, 19:33:32.101840 INFO: lfq-object 80100
+1 day, 19:33:32.139322 INFO: lfq-object 80300
+1 day, 19:33:32.169009 INFO: lfq-object 80500
+1 day, 19:33:32.187613 INFO: lfq-object 80600
+1 day, 19:33:32.270978 INFO: lfq-object 80800
+1 day, 19:33:32.273936 INFO: lfq-object 80700
+1 day, 19:33:32.333828 INFO: lfq-object 81000
+1 day, 19:33:32.363283 INFO: lfq-object 80900
+1 day, 19:33:32.423009 INFO: lfq-object 81100
+1 day, 19:33:32.448836 INFO: lfq-object 81200
+1 day, 19:33:32.525501 INFO: lfq-object 81400
+1 day, 19:33:32.543038 INFO: lfq-object 81300
+1 day, 19:33:32.592805 INFO: lfq-object 81600
+1 day, 19:33:32.613558 INFO: lfq-object 81500
+1 day, 19:33:32.683011 INFO: lfq-object 81700
+1 day, 19:33:32.692635 INFO: lfq-object 81800
+1 day, 19:33:32.704273 INFO: lfq-object 82000
+1 day, 19:33:32.786039 INFO: lfq-object 81900
+1 day, 19:33:39.956500 INFO: Writing precursor output to disk
+1 day, 19:33:39.956800 INFO: Saving run_output/alphadia_1.10_defaultMBR/library/precursor.matrix.tsv to disk
+1 day, 19:33:40.256849 PROGRESS: Performing label free quantification on the pg level
+1 day, 19:33:40.256957 INFO: Filtering fragments by quality
+1 day, 19:33:40.501283 INFO: Performing label-free quantification using directLFQ
+1 day, 19:33:40.585169 INFO: to few values for normalization without missing values. Including missing values
+1 day, 19:33:40.637851 INFO: 8253 lfq-groups total
+1 day, 19:34:38.049301 INFO: using 100 processes
+1 day, 19:34:38.139071 INFO: lfq-object 0
+1 day, 19:34:38.194073 INFO: lfq-object 100
+1 day, 19:34:38.224090 INFO: lfq-object 200
+1 day, 19:34:38.246884 INFO: lfq-object 300
+1 day, 19:34:38.301414 INFO: lfq-object 400
+1 day, 19:34:38.365495 INFO: lfq-object 500
+1 day, 19:34:38.381797 INFO: lfq-object 600
+1 day, 19:34:38.422663 INFO: lfq-object 700
+1 day, 19:34:38.456917 INFO: lfq-object 800
+1 day, 19:34:38.511763 INFO: lfq-object 900
+1 day, 19:34:38.536697 INFO: lfq-object 1000
+1 day, 19:34:38.581578 INFO: lfq-object 1100
+1 day, 19:34:38.618726 INFO: lfq-object 1200
+1 day, 19:34:38.664472 INFO: lfq-object 1300
+1 day, 19:34:38.709743 INFO: lfq-object 1400
+1 day, 19:34:38.735992 INFO: lfq-object 1500
+1 day, 19:34:38.766707 INFO: lfq-object 1600
+1 day, 19:34:38.806159 INFO: lfq-object 1700
+1 day, 19:34:38.852524 INFO: lfq-object 1800
+1 day, 19:34:38.864753 INFO: lfq-object 1900
+1 day, 19:34:38.892415 INFO: lfq-object 2000
+1 day, 19:34:38.930564 INFO: lfq-object 2100
+1 day, 19:34:38.990080 INFO: lfq-object 2200
+1 day, 19:34:39.044372 INFO: lfq-object 2300
+1 day, 19:34:39.065952 INFO: lfq-object 2400
+1 day, 19:34:39.110615 INFO: lfq-object 2500
+1 day, 19:34:39.178890 INFO: lfq-object 2600
+1 day, 19:34:39.220537 INFO: lfq-object 2700
+1 day, 19:34:39.251107 INFO: lfq-object 2800
+1 day, 19:34:39.306841 INFO: lfq-object 2900
+1 day, 19:34:39.360645 INFO: lfq-object 3000
+1 day, 19:34:39.406588 INFO: lfq-object 3100
+1 day, 19:34:39.457697 INFO: lfq-object 3200
+1 day, 19:34:39.495131 INFO: lfq-object 3300
+1 day, 19:34:39.551625 INFO: lfq-object 3400
+1 day, 19:34:39.605068 INFO: lfq-object 3500
+1 day, 19:34:39.659521 INFO: lfq-object 3600
+1 day, 19:34:39.689733 INFO: lfq-object 3700
+1 day, 19:34:39.747677 INFO: lfq-object 3800
+1 day, 19:34:39.777558 INFO: lfq-object 3900
+1 day, 19:34:39.820688 INFO: lfq-object 4000
+1 day, 19:34:39.863634 INFO: lfq-object 4100
+1 day, 19:34:39.911435 INFO: lfq-object 4200
+1 day, 19:34:39.984066 INFO: lfq-object 4400
+1 day, 19:34:39.994783 INFO: lfq-object 4300
+1 day, 19:34:40.032037 INFO: lfq-object 4500
+1 day, 19:34:40.067412 INFO: lfq-object 4600
+1 day, 19:34:40.141730 INFO: lfq-object 4700
+1 day, 19:34:40.171113 INFO: lfq-object 4800
+1 day, 19:34:40.196626 INFO: lfq-object 4900
+1 day, 19:34:40.235079 INFO: lfq-object 5000
+1 day, 19:34:40.306247 INFO: lfq-object 5100
+1 day, 19:34:40.353687 INFO: lfq-object 5200
+1 day, 19:34:40.392111 INFO: lfq-object 5300
+1 day, 19:34:40.438839 INFO: lfq-object 5400
+1 day, 19:34:40.496005 INFO: lfq-object 5500
+1 day, 19:34:40.550163 INFO: lfq-object 5600
+1 day, 19:34:40.590546 INFO: lfq-object 5700
+1 day, 19:34:40.634358 INFO: lfq-object 5800
+1 day, 19:34:40.706251 INFO: lfq-object 5900
+1 day, 19:34:40.768299 INFO: lfq-object 6000
+1 day, 19:34:40.804901 INFO: lfq-object 6100
+1 day, 19:34:40.827110 INFO: lfq-object 6200
+1 day, 19:34:40.854682 INFO: lfq-object 6300
+1 day, 19:34:40.933943 INFO: lfq-object 6400
+1 day, 19:34:40.942538 INFO: lfq-object 6500
+1 day, 19:34:40.970484 INFO: lfq-object 6600
+1 day, 19:34:41.018735 INFO: lfq-object 6700
+1 day, 19:34:41.080607 INFO: lfq-object 6800
+1 day, 19:34:41.117091 INFO: lfq-object 6900
+1 day, 19:34:41.153878 INFO: lfq-object 7000
+1 day, 19:34:41.190946 INFO: lfq-object 7100
+1 day, 19:34:41.249511 INFO: lfq-object 7200
+1 day, 19:34:41.303601 INFO: lfq-object 7300
+1 day, 19:34:41.342445 INFO: lfq-object 7400
+1 day, 19:34:41.389215 INFO: lfq-object 7500
+1 day, 19:34:41.452620 INFO: lfq-object 7600
+1 day, 19:34:41.485219 INFO: lfq-object 7700
+1 day, 19:34:41.511447 INFO: lfq-object 7800
+1 day, 19:34:41.553454 INFO: lfq-object 7900
+1 day, 19:34:41.612118 INFO: lfq-object 8000
+1 day, 19:34:41.656154 INFO: lfq-object 8100
+1 day, 19:34:41.693172 INFO: lfq-object 8200
+1 day, 19:34:44.619056 INFO: Writing pg output to disk
+1 day, 19:34:44.619234 INFO: Saving run_output/alphadia_1.10_defaultMBR/library/pg.matrix.tsv to disk
+1 day, 19:34:44.723868 INFO: Writing psm output to disk
+1 day, 19:34:44.724012 INFO: Saving run_output/alphadia_1.10_defaultMBR/library/precursors.tsv to disk
+1 day, 19:34:52.536367 PROGRESS: Building spectral library
+1 day, 19:34:52.560998 INFO: Building MBR spectral library
+1 day, 19:34:52.561147 INFO: Running MbrLibraryBuilder
+1 day, 19:34:53.913669 INFO: MBR spectral library contains 82,039 precursors, 8,253 proteins
+1 day, 19:34:53.913809 INFO: Writing MBR spectral library to disk
+1 day, 19:34:54.925928 PROGRESS: =================== Search Finished ===================
+1 day, 19:34:55.898103 INFO: Running step 'mbr'
+1 day, 19:34:55.901054 INFO: Extracted extra_config from previous step: defaultdict(<class 'dict'>, {'search': {'target_ms1_tolerance': 10.0, 'target_ms2_tolerance': 15.0}})
+1 day, 19:34:55.901194 INFO: loading config from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/default.yaml
+1 day, 19:34:55.912693 INFO: loading additional config provided via CLI
+1 day, 19:34:55.912766 INFO: loading additional config provided via CLI parameters
+1 day, 19:34:55.913016 INFO: Updating config with 'user defined'
+1 day, 19:34:55.913129 INFO: Updating config with 'user defined (cli)'
+1 day, 19:34:55.913154 INFO: Updating config with 'multistep search'
+1 day, 19:34:55.913196 INFO: ├──version: 1
+1 day, 19:34:55.913222 INFO: ├──workflow_name: None
+1 day, 19:34:55.913247 INFO: [32;20m├──output_directory: run_output/alphadia_1.10_defaultMBR [multistep search, default: None][0m
+1 day, 19:34:55.913270 INFO: [32;20m├──library_path: run_output/alphadia_1.10_defaultMBR/library/speclib.mbr.hdf [multistep search, default: None][0m
+1 day, 19:34:55.913292 INFO: ├──raw_paths:
+1 day, 19:34:55.913311 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913331 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913351 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913369 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913402 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913421 INFO: │   [32;20m- ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d [user defined (cli), default: None][0m
+1 day, 19:34:55.913440 INFO: ├──fasta_paths:
+1 day, 19:34:55.913460 INFO: ├──quant_directory: None
+1 day, 19:34:55.913479 INFO: ├──general
+1 day, 19:34:55.913501 INFO: │   [32;20m├──thread_count: 100 [user defined, default: 10][0m
+1 day, 19:34:55.913525 INFO: │   ├──transfer_step_enabled: False
+1 day, 19:34:55.913544 INFO: │   ├──mbr_step_enabled: True
+1 day, 19:34:55.913563 INFO: │   ├──reuse_calibration: False
+1 day, 19:34:55.913583 INFO: │   ├──reuse_quant: False
+1 day, 19:34:55.913601 INFO: │   ├──astral_ms1: False
+1 day, 19:34:55.913619 INFO: │   ├──log_level: INFO
+1 day, 19:34:55.913639 INFO: │   ├──mmap_detector_events: False
+1 day, 19:34:55.913661 INFO: │   [32;20m├──use_gpu: False [user defined, default: True][0m
+1 day, 19:34:55.913681 INFO: │   ├──save_library: True
+1 day, 19:34:55.913701 INFO: │   └──save_mbr_library: True
+1 day, 19:34:55.913720 INFO: ├──library_loading
+1 day, 19:34:55.913742 INFO: │   └──rt_heuristic: 180
+1 day, 19:34:55.913760 INFO: ├──library_prediction
+1 day, 19:34:55.913779 INFO: │   ├──enabled: False
+1 day, 19:34:55.913799 INFO: │   [32;20m├──enzyme: trypsin/p [user defined, default: trypsin][0m
+1 day, 19:34:55.913818 INFO: │   ├──fixed_modifications: Carbamidomethyl@C
+1 day, 19:34:55.913836 INFO: │   ├──variable_modifications: Oxidation@M;Acetyl@Protein_N-term
+1 day, 19:34:55.913856 INFO: │   [32;20m├──max_var_mod_num: 1 [user defined, default: 2][0m
+1 day, 19:34:55.913875 INFO: │   ├──missed_cleavages: 1
+1 day, 19:34:55.913893 INFO: │   ├──precursor_len:
+1 day, 19:34:55.913913 INFO: │   │   [32;20m- 6 [user defined, default: 7][0m
+1 day, 19:34:55.913932 INFO: │   │   [32;20m- 30 [user defined, default: 35][0m
+1 day, 19:34:55.913949 INFO: │   ├──precursor_charge:
+1 day, 19:34:55.913969 INFO: │   │   [32;20m- 1 [user defined, default: 2][0m
+1 day, 19:34:55.913986 INFO: │   │   [32;20m- 4[0m
+1 day, 19:34:55.914004 INFO: │   ├──precursor_mz:
+1 day, 19:34:55.914023 INFO: │   │   [32;20m- 400[0m
+1 day, 19:34:55.914041 INFO: │   │   [32;20m- 1000 [user defined, default: 1200][0m
+1 day, 19:34:55.914059 INFO: │   ├──fragment_mz:
+1 day, 19:34:55.914078 INFO: │   │   [32;20m- 50 [user defined, default: 200][0m
+1 day, 19:34:55.914099 INFO: │   │   [32;20m- 2000[0m
+1 day, 19:34:55.914117 INFO: │   ├──nce: 25
+1 day, 19:34:55.914136 INFO: │   ├──fragment_types:
+1 day, 19:34:55.914155 INFO: │   │   [32;20m- b[0m
+1 day, 19:34:55.914172 INFO: │   │   [32;20m- y[0m
+1 day, 19:34:55.914193 INFO: │   ├──max_fragment_charge: 2
+1 day, 19:34:55.914212 INFO: │   [32;20m├──instrument: timsTOF [user defined, default: Lumos][0m
+1 day, 19:34:55.914230 INFO: │   ├──peptdeep_model_path: None
+1 day, 19:34:55.914251 INFO: │   └──peptdeep_model_type: generic
+1 day, 19:34:55.914269 INFO: ├──custom_modifications:
+1 day, 19:34:55.914289 INFO: │   ├──name: Dimethyl:d12@K
+1 day, 19:34:55.914309 INFO: │   └──composition: H(-2)2H(8)13C(2)
+1 day, 19:34:55.914327 INFO: │   ├──name: Dimethyl:d12@Any_N-term
+1 day, 19:34:55.914346 INFO: │   └──composition: H(-2)2H(8)13C(2)
+1 day, 19:34:55.914366 INFO: │   ├──name: Dimethyl:d12@Protein_N-term
+1 day, 19:34:55.914384 INFO: │   └──composition: H(-2)2H(8)13C(2)
+1 day, 19:34:55.914402 INFO: │   ├──name: mTRAQ:d12@K
+1 day, 19:34:55.914422 INFO: │   └──composition: H(12)C(1)13C(10)15N(2)O(1)
+1 day, 19:34:55.914440 INFO: │   ├──name: mTRAQ:d12@Any_N-term
+1 day, 19:34:55.914457 INFO: │   └──composition: H(12)C(1)13C(14)15N(2)O(1)
+1 day, 19:34:55.914484 INFO: │   ├──name: mTRAQ:d12@Protein_N-term
+1 day, 19:34:55.914501 INFO: │   └──composition: H(12)C(1)13C(14)15N(2)O(1)
+1 day, 19:34:55.914522 INFO: │   ├──name: Label:13C(12)@K
+1 day, 19:34:55.914543 INFO: │   └──composition: C(12)
+1 day, 19:34:55.914561 INFO: ├──search
+1 day, 19:34:55.914585 INFO: │   [32;20m├──target_ms1_tolerance: 10.0 [multistep search, default: 5][0m
+1 day, 19:34:55.914605 INFO: │   [32;20m├──target_ms2_tolerance: 15.0 [multistep search, default: 10][0m
+1 day, 19:34:55.914623 INFO: │   ├──target_rt_tolerance: 0
+1 day, 19:34:55.914644 INFO: │   ├──target_mobility_tolerance: 0
+1 day, 19:34:55.914662 INFO: │   ├──quant_window: 3
+1 day, 19:34:55.914681 INFO: │   [32;20m├──target_num_candidates: 2 [user defined, default: 3][0m
+1 day, 19:34:55.914700 INFO: │   ├──channel_filter: 
+1 day, 19:34:55.914719 INFO: │   ├──exclude_shared_ions: True
+1 day, 19:34:55.914737 INFO: │   ├──compete_for_fragments: True
+1 day, 19:34:55.914756 INFO: │   ├──quant_all: True
+1 day, 19:34:55.914775 INFO: │   ├──top_k_fragments: 12
+1 day, 19:34:55.914796 INFO: │   └──experimental_xic: True
+1 day, 19:34:55.914817 INFO: ├──calibration
+1 day, 19:34:55.914837 INFO: │   ├──batch_size: 8000
+1 day, 19:34:55.914857 INFO: │   ├──optimization_lock_target: 200
+1 day, 19:34:55.914876 INFO: │   ├──max_steps: 20
+1 day, 19:34:55.914894 INFO: │   ├──min_steps: 2
+1 day, 19:34:55.914914 INFO: │   ├──max_skips: 1
+1 day, 19:34:55.914932 INFO: │   ├──norm_rt_mode: linear
+1 day, 19:34:55.914951 INFO: │   ├──max_fragments: 5000
+1 day, 19:34:55.914976 INFO: │   └──min_correlation: 0.7
+1 day, 19:34:55.914994 INFO: ├──search_initial
+1 day, 19:34:55.915012 INFO: │   ├──initial_num_candidates: 1
+1 day, 19:34:55.915032 INFO: │   ├──initial_ms1_tolerance: 30
+1 day, 19:34:55.915050 INFO: │   ├──initial_ms2_tolerance: 30
+1 day, 19:34:55.915068 INFO: │   ├──initial_mobility_tolerance: 0.1
+1 day, 19:34:55.915089 INFO: │   └──initial_rt_tolerance: 0.5
+1 day, 19:34:55.915107 INFO: ├──selection_config
+1 day, 19:34:55.915126 INFO: │   ├──peak_len_rt: 10.0
+1 day, 19:34:55.915148 INFO: │   ├──sigma_scale_rt: 0.5
+1 day, 19:34:55.915166 INFO: │   ├──peak_len_mobility: 0.01
+1 day, 19:34:55.915184 INFO: │   ├──sigma_scale_mobility: 1.0
+1 day, 19:34:55.915206 INFO: │   ├──top_k_precursors: 3
+1 day, 19:34:55.915224 INFO: │   ├──kernel_size: 30
+1 day, 19:34:55.915244 INFO: │   ├──f_mobility: 1.0
+1 day, 19:34:55.915263 INFO: │   ├──f_rt: 0.99
+1 day, 19:34:55.915281 INFO: │   ├──center_fraction: 0.5
+1 day, 19:34:55.915301 INFO: │   ├──min_size_mobility: 8
+1 day, 19:34:55.915319 INFO: │   ├──min_size_rt: 3
+1 day, 19:34:55.915336 INFO: │   ├──max_size_mobility: 20
+1 day, 19:34:55.915355 INFO: │   ├──max_size_rt: 15
+1 day, 19:34:55.915374 INFO: │   ├──group_channels: False
+1 day, 19:34:55.915393 INFO: │   ├──use_weighted_score: True
+1 day, 19:34:55.915413 INFO: │   ├──join_close_candidates: False
+1 day, 19:34:55.915431 INFO: │   ├──join_close_candidates_scan_threshold: 0.6
+1 day, 19:34:55.915449 INFO: │   └──join_close_candidates_cycle_threshold: 0.6
+1 day, 19:34:55.915471 INFO: ├──scoring_config
+1 day, 19:34:55.915489 INFO: │   ├──score_grouped: False
+1 day, 19:34:55.915507 INFO: │   ├──top_k_isotopes: 3
+1 day, 19:34:55.915528 INFO: │   ├──reference_channel: -1
+1 day, 19:34:55.915545 INFO: │   ├──precursor_mz_tolerance: 10
+1 day, 19:34:55.915564 INFO: │   └──fragment_mz_tolerance: 15
+1 day, 19:34:55.915586 INFO: ├──library_multiplexing
+1 day, 19:34:55.915604 INFO: │   ├──enabled: False
+1 day, 19:34:55.915623 INFO: │   ├──input_channel: 0
+1 day, 19:34:55.915649 INFO: │   └──multiplex_mapping:
+1 day, 19:34:55.915668 INFO: ├──multiplexing
+1 day, 19:34:55.915686 INFO: │   ├──enabled: False
+1 day, 19:34:55.915706 INFO: │   ├──target_channels: 4,8
+1 day, 19:34:55.915724 INFO: │   ├──decoy_channel: 12
+1 day, 19:34:55.915742 INFO: │   ├──reference_channel: 0
+1 day, 19:34:55.915763 INFO: │   └──competetive_scoring: True
+1 day, 19:34:55.915781 INFO: ├──fdr
+1 day, 19:34:55.915802 INFO: │   ├──fdr: 0.01
+1 day, 19:34:55.915821 INFO: │   ├──group_level: proteins
+1 day, 19:34:55.915841 INFO: │   [32;20m├──inference_strategy: library [multistep search, default: heuristic][0m
+1 day, 19:34:55.915861 INFO: │   ├──competetive_scoring: True
+1 day, 19:34:55.915882 INFO: │   ├──keep_decoys: False
+1 day, 19:34:55.915901 INFO: │   ├──channel_wise_fdr: False
+1 day, 19:34:55.915923 INFO: │   ├──enable_two_step_classifier: False
+1 day, 19:34:55.915942 INFO: │   ├──two_step_classifier_max_iterations: 5
+1 day, 19:34:55.915962 INFO: │   └──enable_nn_hyperparameter_tuning: False
+1 day, 19:34:55.915981 INFO: ├──search_output
+1 day, 19:34:55.916001 INFO: │   ├──file_format: tsv
+1 day, 19:34:55.916019 INFO: │   ├──peptide_level_lfq: False
+1 day, 19:34:55.916039 INFO: │   [32;20m├──precursor_level_lfq: True [user defined, default: False][0m
+1 day, 19:34:55.916057 INFO: │   ├──min_k_fragments: 12
+1 day, 19:34:55.916077 INFO: │   ├──min_correlation: 0.9
+1 day, 19:34:55.916096 INFO: │   ├──num_samples_quadratic: 50
+1 day, 19:34:55.916114 INFO: │   ├──min_nonnan: 3
+1 day, 19:34:55.916136 INFO: │   ├──normalize_lfq: True
+1 day, 19:34:55.916157 INFO: │   └──save_fragment_quant_matrix: False
+1 day, 19:34:55.916176 INFO: ├──optimization
+1 day, 19:34:55.916196 INFO: │   ├──order_of_optimization: None
+1 day, 19:34:55.916216 INFO: │   ├──ms2_error
+1 day, 19:34:55.916236 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+1 day, 19:34:55.916257 INFO: │   │   ├──targeted_update_factor: 1.0
+1 day, 19:34:55.916275 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+1 day, 19:34:55.916294 INFO: │   │   ├──automatic_update_factor: 1.1
+1 day, 19:34:55.916314 INFO: │   │   ├──try_narrower_values: True
+1 day, 19:34:55.916332 INFO: │   │   ├──maximal_decrease: 0.5
+1 day, 19:34:55.916352 INFO: │   │   ├──favour_narrower_optimum: False
+1 day, 19:34:55.916373 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+1 day, 19:34:55.916391 INFO: │   ├──ms1_error
+1 day, 19:34:55.916410 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+1 day, 19:34:55.916430 INFO: │   │   ├──targeted_update_factor: 1.0
+1 day, 19:34:55.916448 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+1 day, 19:34:55.916466 INFO: │   │   ├──automatic_update_factor: 1.1
+1 day, 19:34:55.916485 INFO: │   │   ├──try_narrower_values: False
+1 day, 19:34:55.916504 INFO: │   │   ├──maximal_decrease: 0.2
+1 day, 19:34:55.916522 INFO: │   │   ├──favour_narrower_optimum: False
+1 day, 19:34:55.916542 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+1 day, 19:34:55.916560 INFO: │   ├──mobility_error
+1 day, 19:34:55.916578 INFO: │   │   ├──targeted_update_percentile_range: 0.95
+1 day, 19:34:55.916598 INFO: │   │   ├──targeted_update_factor: 1.0
+1 day, 19:34:55.916615 INFO: │   │   ├──automatic_update_percentile_range: 0.99
+1 day, 19:34:55.916634 INFO: │   │   ├──automatic_update_factor: 1.1
+1 day, 19:34:55.916654 INFO: │   │   ├──try_narrower_values: False
+1 day, 19:34:55.916672 INFO: │   │   ├──maximal_decrease: 0.2
+1 day, 19:34:55.916694 INFO: │   │   ├──favour_narrower_optimum: False
+1 day, 19:34:55.916713 INFO: │   │   └──maximum_decrease_from_maximum: 0.1
+1 day, 19:34:55.916736 INFO: │   └──rt_error
+1 day, 19:34:55.916757 INFO: │       ├──targeted_update_percentile_range: 0.95
+1 day, 19:34:55.916777 INFO: │       ├──targeted_update_factor: 1.0
+1 day, 19:34:55.916797 INFO: │       ├──automatic_update_percentile_range: 0.99
+1 day, 19:34:55.916817 INFO: │       ├──automatic_update_factor: 1.1
+1 day, 19:34:55.916834 INFO: │       ├──try_narrower_values: True
+1 day, 19:34:55.916852 INFO: │       ├──maximal_decrease: 0.2
+1 day, 19:34:55.916872 INFO: │       ├──favour_narrower_optimum: True
+1 day, 19:34:55.916891 INFO: │       └──maximum_decrease_from_maximum: 0.1
+1 day, 19:34:55.916909 INFO: ├──optimization_manager
+1 day, 19:34:55.916929 INFO: │   ├──fwhm_rt: 5
+1 day, 19:34:55.916948 INFO: │   ├──fwhm_mobility: 0.01
+1 day, 19:34:55.916966 INFO: │   └──score_cutoff: 0
+1 day, 19:34:55.916985 INFO: ├──transfer_library
+1 day, 19:34:55.917004 INFO: │   ├──enabled: False
+1 day, 19:34:55.917022 INFO: │   ├──fragment_types:
+1 day, 19:34:55.917049 INFO: │   │   [32;20m- b[0m
+1 day, 19:34:55.917067 INFO: │   │   [32;20m- y[0m
+1 day, 19:34:55.917085 INFO: │   ├──max_charge: 2
+1 day, 19:34:55.917105 INFO: │   ├──top_k_samples: 3
+1 day, 19:34:55.917123 INFO: │   ├──norm_delta_max: True
+1 day, 19:34:55.917141 INFO: │   ├──precursor_correlation_cutoff: 0.5
+1 day, 19:34:55.917162 INFO: │   └──fragment_correlation_ratio: 0.75
+1 day, 19:34:55.917181 INFO: └──transfer_learning
+1 day, 19:34:55.917199 INFO:     ├──enabled: False
+1 day, 19:34:55.917219 INFO:     ├──batch_size: 2000
+1 day, 19:34:55.917238 INFO:     ├──max_lr: 0.0001
+1 day, 19:34:55.917256 INFO:     ├──train_fraction: 0.7
+1 day, 19:34:55.917276 INFO:     ├──validation_fraction: 0.2
+1 day, 19:34:55.917296 INFO:     ├──test_fraction: 0.1
+1 day, 19:34:55.917315 INFO:     ├──test_interval: 1
+1 day, 19:34:55.917334 INFO:     ├──lr_patience: 3
+1 day, 19:34:55.917353 INFO:     ├──epochs: 51
+1 day, 19:34:55.917371 INFO:     ├──warmup_epochs: 5
+1 day, 19:34:55.917390 INFO:     ├──nce: 25
+1 day, 19:34:55.917409 INFO:     [32;20m└──instrument: timsTOF [user defined, default: Lumos][0m
+1 day, 19:34:55.922755 INFO: Registering 7 custom modifications
+1 day, 19:34:55.938542 INFO: Running DynamicLoader
+1 day, 19:34:55.938639 INFO: Loading .hdf library from run_output/alphadia_1.10_defaultMBR/library/speclib.mbr.hdf
+1 day, 19:34:56.325090 INFO: Running PrecursorInitializer
+1 day, 19:34:56.325383 INFO: Running AnnotateFasta
+1 day, 19:34:56.325723 INFO: Dropping decoys from input library before annotation
+1 day, 19:34:56.341764 INFO: Running IsotopeGenerator
+1 day, 19:34:56.342026 WARNING: Input library already contains isotope information. Skipping isotope generation. 
+ Please note that isotope generation outside of alphabase is not supported.
+1 day, 19:34:56.342068 INFO: Running RTNormalization
+1 day, 19:34:56.345990 INFO: Saving library to run_output/alphadia_1.10_defaultMBR/speclib.hdf
+1 day, 19:34:56.925797 INFO: Running DecoyGenerator
+1 day, 19:35:11.791888 INFO: Running FlattenLibrary
+1 day, 19:35:12.655309 INFO: Running InitFlatColumns
+1 day, 19:35:12.659824 INFO: Running LogFlatLibraryStats
+1 day, 19:35:12.659937 INFO: ============ Library Stats ============
+1 day, 19:35:12.659969 INFO: Number of precursors: 164,063
+1 day, 19:35:12.693861 INFO: 	thereof targets:82,039
+1 day, 19:35:12.693999 INFO: 	thereof decoys: 82,024
+1 day, 19:35:12.695463 INFO: Number of elution groups: 82,039
+1 day, 19:35:12.695527 INFO: 	average size: 2.00
+1 day, 19:35:12.704649 INFO: Number of proteins: 8,253
+1 day, 19:35:12.705387 INFO: Number of channels: 1 ([0])
+1 day, 19:35:12.705477 INFO: Isotopes Distribution for 4 isotopes
+1 day, 19:35:12.705505 INFO: =======================================
+1 day, 19:35:12.705614 INFO: Searching 6 files:
+1 day, 19:35:12.705643 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:12.705678 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:35:12.705696 INFO:   ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:35:12.705715 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:35:12.705733 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 19:35:12.705750 INFO:   ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 19:35:12.705767 INFO: Using 0 fasta files:
+1 day, 19:35:12.705786 INFO: Using library: run_output/alphadia_1.10_defaultMBR/library/speclib.mbr.hdf
+1 day, 19:35:12.705805 INFO: Saving output to: run_output/alphadia_1.10_defaultMBR
+1 day, 19:35:12.705837 PROGRESS: Starting Search Workflows
+1 day, 19:35:12.705881 PROGRESS: Loading raw file 1/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:35:12.705932 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 19:35:12.705987 INFO: Creating parent folder for workflows at run_output/alphadia_1.10_defaultMBR/quant
+1 day, 19:35:12.706098 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:35:12.706488 INFO: Initializing RawFileManager
+1 day, 19:35:12.706604 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:12.706651 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:12.706692 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:12.908470 INFO: Reading 39,128 frames with 2,835,410,867 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.550457 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d...
+1 day, 19:35:18.551442 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.553858 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.554080 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.554434 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.555900 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.563320 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:18.563511 INFO: Indexing quadrupole dimension
+1 day, 19:35:19.023917 INFO: Transposing detector events
+1 day, 19:35:28.106594 INFO: Finished transposing data
+1 day, 19:35:28.143578 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d
+1 day, 19:35:28.144693 INFO: RT (min)            : 0.0 - 70.0
+1 day, 19:35:28.144786 INFO: RT duration (sec)   : 4199.9
+1 day, 19:35:28.144840 INFO: RT duration (min)   : 70.0
+1 day, 19:35:28.144889 INFO: Cycle len (scans)   : 9
+1 day, 19:35:28.144934 INFO: Cycle len (sec)     : 0.97
+1 day, 19:35:28.144979 INFO: Number of cycles    : 4347
+1 day, 19:35:28.145037 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 19:35:28.164516 INFO: Initializing CalibrationManager
+1 day, 19:35:28.164954 INFO: Loading calibration config
+1 day, 19:35:28.165636 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 19:35:28.165804 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 19:35:28.165946 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 19:35:28.166133 INFO: Initializing OptimizationManager
+1 day, 19:35:28.166368 INFO: initial parameter: ms1_error = 30
+1 day, 19:35:28.166455 INFO: initial parameter: ms2_error = 30
+1 day, 19:35:28.166548 INFO: initial parameter: rt_error = 2099.928159
+1 day, 19:35:28.166631 INFO: initial parameter: mobility_error = 0.1
+1 day, 19:35:28.166709 INFO: initial parameter: column_type = library
+1 day, 19:35:28.166783 INFO: initial parameter: num_candidates = 1
+1 day, 19:35:28.166852 INFO: initial parameter: classifier_version = -1
+1 day, 19:35:28.166925 INFO: initial parameter: fwhm_rt = 5
+1 day, 19:35:28.166997 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 19:35:28.167065 INFO: initial parameter: score_cutoff = 0
+1 day, 19:35:28.167158 INFO: Initializing TimingManager
+1 day, 19:35:28.167248 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:35:28.167386 INFO: FDRManager not loaded from disk.
+1 day, 19:35:28.167425 INFO: Initializing FDRManager
+1 day, 19:35:28.167480 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 19:35:28.195530 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 19:35:28.232268 PROGRESS: Starting initial search for precursors.
+1 day, 19:35:28.251213 INFO: Starting optimization step 0.
+1 day, 19:35:28.251471 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:35:28.251551 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:35:28.254650 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:35:28.254706 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:35:28.254738 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 19:35:28.254762 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 19:35:28.258513 INFO: Starting candidate selection
+1 day, 19:36:57.100953 INFO: Starting candidate scoring
+1 day, 19:36:58.169969 INFO: Finished candidate processing
+1 day, 19:36:58.170129 INFO: Collecting candidate features
+1 day, 19:36:58.234171 INFO: Collecting fragment features
+1 day, 19:36:58.249573 INFO: Finished candidate scoring
+1 day, 19:36:58.259198 PROGRESS: === Extracted 15885 precursors and 175814 fragments ===
+1 day, 19:36:58.259640 INFO: performing precursor FDR with 47 features
+1 day, 19:36:58.259680 INFO: Decoy channel: -1
+1 day, 19:36:58.259703 INFO: Competetive: True
+1 day, 19:36:58.265234 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:36:58.446169 INFO: Test AUC: 0.801
+1 day, 19:36:58.446294 INFO: Train AUC: 0.805
+1 day, 19:36:58.446325 INFO: AUC difference: 0.50%
+1 day, 19:36:58.548839 INFO: Resetting torch num_threads to 100
+1 day, 19:36:58.550288 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 19:36:58.552384 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:36:58.552554 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:36:58.552662 PROGRESS: Target precursors: 6,547 (81.84%)
+1 day, 19:36:58.552757 PROGRESS: Decoy precursors: 1,453 (18.16%)
+1 day, 19:36:58.552845 PROGRESS: 
+1 day, 19:36:58.552930 PROGRESS: Precursor Summary:
+1 day, 19:36:58.555916 PROGRESS: Channel   0:	 0.05 FDR: 4,436; 0.01 FDR: 3,151; 0.001 FDR: 1,590
+1 day, 19:36:58.556104 PROGRESS: 
+1 day, 19:36:58.556205 PROGRESS: Protein Summary:
+1 day, 19:36:58.559910 PROGRESS: Channel   0:	 0.05 FDR: 2,714; 0.01 FDR: 2,070; 0.001 FDR: 1,158
+1 day, 19:36:58.560614 PROGRESS: =========================================================================
+1 day, 19:36:58.573642 INFO: fragments_df_filtered: 5000
+1 day, 19:36:58.591326 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:36:58.821963 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:36:59.060456 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:36:59.275424 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:36:59.691191 INFO: calibration group: precursor, predicting mz
+1 day, 19:36:59.694117 INFO: calibration group: precursor, predicting rt
+1 day, 19:36:59.703738 INFO: calibration group: precursor, predicting mobility
+1 day, 19:36:59.706125 INFO: calibration group: fragment, predicting mz
+1 day, 19:36:59.724176 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 19:36:59.724386 INFO: Starting optimization step 1.
+1 day, 19:36:59.724467 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:36:59.724543 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:36:59.730234 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:36:59.730296 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:36:59.730345 INFO: FWHM in RT is 3.37 seconds, sigma is 0.74
+1 day, 19:36:59.730375 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.33
+1 day, 19:36:59.740526 INFO: Starting candidate selection
+1 day, 19:38:36.310704 INFO: Starting candidate scoring
+1 day, 19:38:38.335253 INFO: Finished candidate processing
+1 day, 19:38:38.335399 INFO: Collecting candidate features
+1 day, 19:38:38.394382 INFO: Collecting fragment features
+1 day, 19:38:38.422580 INFO: Finished candidate scoring
+1 day, 19:38:38.438566 PROGRESS: === Extracted 30416 precursors and 336567 fragments ===
+1 day, 19:38:38.439045 INFO: performing precursor FDR with 47 features
+1 day, 19:38:38.439085 INFO: Decoy channel: -1
+1 day, 19:38:38.439110 INFO: Competetive: True
+1 day, 19:38:38.451237 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:38:38.738583 INFO: Test AUC: 0.742
+1 day, 19:38:38.738714 INFO: Train AUC: 0.747
+1 day, 19:38:38.738744 INFO: AUC difference: 0.63%
+1 day, 19:38:38.825428 INFO: Resetting torch num_threads to 100
+1 day, 19:38:38.826716 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 19:38:38.828497 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:38:38.828601 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:38:38.828664 PROGRESS: Target precursors: 6,984 (87.30%)
+1 day, 19:38:38.828721 PROGRESS: Decoy precursors: 1,016 (12.70%)
+1 day, 19:38:38.828769 PROGRESS: 
+1 day, 19:38:38.828819 PROGRESS: Precursor Summary:
+1 day, 19:38:38.830967 PROGRESS: Channel   0:	 0.05 FDR: 5,722; 0.01 FDR: 3,894; 0.001 FDR: 1,056
+1 day, 19:38:38.831079 PROGRESS: 
+1 day, 19:38:38.831147 PROGRESS: Protein Summary:
+1 day, 19:38:38.834029 PROGRESS: Channel   0:	 0.05 FDR: 3,270; 0.01 FDR: 2,415; 0.001 FDR:   778
+1 day, 19:38:38.834139 PROGRESS: =========================================================================
+1 day, 19:38:38.848934 INFO: fragments_df_filtered: 5000
+1 day, 19:38:38.867275 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:38:39.164162 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:38:39.468775 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:38:39.762937 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:38:40.181383 INFO: calibration group: precursor, predicting mz
+1 day, 19:38:40.184242 INFO: calibration group: precursor, predicting rt
+1 day, 19:38:40.194098 INFO: calibration group: precursor, predicting mobility
+1 day, 19:38:40.196461 INFO: calibration group: fragment, predicting mz
+1 day, 19:38:40.214632 INFO: === checking if optimization conditions were reached ===
+1 day, 19:38:40.216758 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 19:38:40.218496 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 19:38:40.218557 INFO: ==============================================
+1 day, 19:38:40.218667 INFO: Starting optimization step 2.
+1 day, 19:38:40.218744 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:38:40.218817 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:38:40.224789 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:38:40.224856 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:38:40.224905 INFO: FWHM in RT is 3.14 seconds, sigma is 0.69
+1 day, 19:38:40.224933 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.06
+1 day, 19:38:40.226121 INFO: Starting candidate selection
+1 day, 19:40:12.146936 INFO: Starting candidate scoring
+1 day, 19:40:13.248697 INFO: Finished candidate processing
+1 day, 19:40:13.248801 INFO: Collecting candidate features
+1 day, 19:40:13.304849 INFO: Collecting fragment features
+1 day, 19:40:13.325215 INFO: Finished candidate scoring
+1 day, 19:40:13.339367 PROGRESS: === Extracted 30457 precursors and 332720 fragments ===
+1 day, 19:40:13.339815 INFO: performing precursor FDR with 47 features
+1 day, 19:40:13.339856 INFO: Decoy channel: -1
+1 day, 19:40:13.339883 INFO: Competetive: True
+1 day, 19:40:13.349332 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:40:13.731996 INFO: Test AUC: 0.796
+1 day, 19:40:13.732127 INFO: Train AUC: 0.794
+1 day, 19:40:13.732158 INFO: AUC difference: 0.31%
+1 day, 19:40:13.820930 INFO: Resetting torch num_threads to 100
+1 day, 19:40:13.822162 INFO: === FDR correction performed with classifier version 1 ===
+1 day, 19:40:13.823684 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:40:13.823798 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:40:13.823859 PROGRESS: Target precursors: 7,460 (93.25%)
+1 day, 19:40:13.823910 PROGRESS: Decoy precursors: 540 (6.75%)
+1 day, 19:40:13.823964 PROGRESS: 
+1 day, 19:40:13.824010 PROGRESS: Precursor Summary:
+1 day, 19:40:13.826927 PROGRESS: Channel   0:	 0.05 FDR: 7,161; 0.01 FDR: 6,344; 0.001 FDR: 3,258
+1 day, 19:40:13.827055 PROGRESS: 
+1 day, 19:40:13.827116 PROGRESS: Protein Summary:
+1 day, 19:40:13.830847 PROGRESS: Channel   0:	 0.05 FDR: 3,869; 0.01 FDR: 3,526; 0.001 FDR: 2,065
+1 day, 19:40:13.830960 PROGRESS: =========================================================================
+1 day, 19:40:13.853209 INFO: fragments_df_filtered: 5000
+1 day, 19:40:13.872257 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:40:14.409264 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:40:14.968434 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:40:15.507056 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:40:15.860709 INFO: calibration group: precursor, predicting mz
+1 day, 19:40:15.863507 INFO: calibration group: precursor, predicting rt
+1 day, 19:40:15.872713 INFO: calibration group: precursor, predicting mobility
+1 day, 19:40:15.874993 INFO: calibration group: fragment, predicting mz
+1 day, 19:40:15.896977 INFO: === checking if optimization conditions were reached ===
+1 day, 19:40:15.899795 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 19:40:15.901659 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 19:40:15.901713 INFO: ==============================================
+1 day, 19:40:15.901840 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 19:40:15.921079 INFO: calibration group: precursor, predicting mz
+1 day, 19:40:15.924007 INFO: calibration group: precursor, predicting rt
+1 day, 19:40:15.934054 INFO: calibration group: precursor, predicting mobility
+1 day, 19:40:15.936403 INFO: calibration group: fragment, predicting mz
+1 day, 19:40:15.958604 INFO: Starting optimization step 0.
+1 day, 19:40:15.958780 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:40:15.958874 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:40:15.964280 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:40:15.964355 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:40:15.964413 INFO: FWHM in RT is 2.94 seconds, sigma is 0.65
+1 day, 19:40:15.964437 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.12
+1 day, 19:40:15.973623 INFO: Starting candidate selection
+1 day, 19:41:44.126138 INFO: Starting candidate scoring
+1 day, 19:41:45.251166 INFO: Finished candidate processing
+1 day, 19:41:45.251292 INFO: Collecting candidate features
+1 day, 19:41:45.309924 INFO: Collecting fragment features
+1 day, 19:41:45.332429 INFO: Finished candidate scoring
+1 day, 19:41:45.348111 PROGRESS: === Extracted 30386 precursors and 331681 fragments ===
+1 day, 19:41:45.349281 INFO: performing precursor FDR with 47 features
+1 day, 19:41:45.349323 INFO: Decoy channel: -1
+1 day, 19:41:45.349347 INFO: Competetive: True
+1 day, 19:41:45.359977 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:41:45.779636 INFO: Test AUC: 0.805
+1 day, 19:41:45.779774 INFO: Train AUC: 0.807
+1 day, 19:41:45.779805 INFO: AUC difference: 0.26%
+1 day, 19:41:45.868924 INFO: Resetting torch num_threads to 100
+1 day, 19:41:45.870426 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:41:45.872123 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:41:45.872235 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:41:45.872297 PROGRESS: Target precursors: 7,470 (93.38%)
+1 day, 19:41:45.872351 PROGRESS: Decoy precursors: 530 (6.62%)
+1 day, 19:41:45.872399 PROGRESS: 
+1 day, 19:41:45.872445 PROGRESS: Precursor Summary:
+1 day, 19:41:45.875182 PROGRESS: Channel   0:	 0.05 FDR: 7,202; 0.01 FDR: 6,495; 0.001 FDR: 3,631
+1 day, 19:41:45.875302 PROGRESS: 
+1 day, 19:41:45.875360 PROGRESS: Protein Summary:
+1 day, 19:41:45.879395 PROGRESS: Channel   0:	 0.05 FDR: 3,874; 0.01 FDR: 3,586; 0.001 FDR: 2,290
+1 day, 19:41:45.879501 PROGRESS: =========================================================================
+1 day, 19:41:45.901818 INFO: fragments_df_filtered: 5000
+1 day, 19:41:45.921316 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:41:46.551514 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:41:47.200429 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:41:47.829257 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:41:48.244609 INFO: calibration group: precursor, predicting mz
+1 day, 19:41:48.247584 INFO: calibration group: precursor, predicting rt
+1 day, 19:41:48.257007 INFO: calibration group: precursor, predicting mobility
+1 day, 19:41:48.259404 INFO: calibration group: fragment, predicting mz
+1 day, 19:41:48.278752 INFO: === checking if optimization conditions were reached ===
+1 day, 19:41:48.278950 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:41:48.284098 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 176.2320.
+1 day, 19:41:48.284156 INFO: ==============================================
+1 day, 19:41:48.284274 INFO: Starting optimization step 1.
+1 day, 19:41:48.284356 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:41:48.284438 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:41:48.289820 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:41:48.289884 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:41:48.289940 INFO: FWHM in RT is 2.92 seconds, sigma is 0.64
+1 day, 19:41:48.289969 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.07
+1 day, 19:41:48.291312 INFO: Starting candidate selection
+1 day, 19:41:56.327924 INFO: Starting candidate scoring
+1 day, 19:41:57.327756 INFO: Finished candidate processing
+1 day, 19:41:57.327877 INFO: Collecting candidate features
+1 day, 19:41:57.404020 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30285)
+1 day, 19:41:57.408447 INFO: Collecting fragment features
+1 day, 19:41:57.427694 INFO: Finished candidate scoring
+1 day, 19:41:57.443672 PROGRESS: === Extracted 30285 precursors and 325869 fragments ===
+1 day, 19:41:57.444122 INFO: performing precursor FDR with 47 features
+1 day, 19:41:57.444165 INFO: Decoy channel: -1
+1 day, 19:41:57.444196 INFO: Competetive: True
+1 day, 19:41:57.453020 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:41:57.457517 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 19:41:58.896163 INFO: Test AUC: 0.835
+1 day, 19:41:58.896307 INFO: Train AUC: 0.838
+1 day, 19:41:58.896344 INFO: AUC difference: 0.34%
+1 day, 19:41:58.983686 INFO: Resetting torch num_threads to 100
+1 day, 19:41:58.985170 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:41:58.986793 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:41:58.986907 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:41:58.986984 PROGRESS: Target precursors: 7,720 (96.50%)
+1 day, 19:41:58.987051 PROGRESS: Decoy precursors: 280 (3.50%)
+1 day, 19:41:58.987114 PROGRESS: 
+1 day, 19:41:58.987172 PROGRESS: Precursor Summary:
+1 day, 19:41:58.990207 PROGRESS: Channel   0:	 0.05 FDR: 7,720; 0.01 FDR: 7,241; 0.001 FDR: 5,649
+1 day, 19:41:58.990343 PROGRESS: 
+1 day, 19:41:58.990431 PROGRESS: Protein Summary:
+1 day, 19:41:58.995008 PROGRESS: Channel   0:	 0.05 FDR: 4,106; 0.01 FDR: 3,891; 0.001 FDR: 3,252
+1 day, 19:41:58.995133 PROGRESS: =========================================================================
+1 day, 19:41:59.019713 INFO: fragments_df_filtered: 5000
+1 day, 19:41:59.036084 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:41:59.790320 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:00.578723 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:01.335074 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:01.751364 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:01.754375 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:01.763700 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:01.766077 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:01.784478 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:01.784664 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:42:01.790835 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 50.1898.
+1 day, 19:42:01.790899 INFO: ==============================================
+1 day, 19:42:01.791013 INFO: Starting optimization step 2.
+1 day, 19:42:01.791085 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:01.791152 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:01.798500 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:01.798574 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:01.798622 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 19:42:01.798651 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.98
+1 day, 19:42:01.802398 INFO: Starting candidate selection
+1 day, 19:42:04.758746 INFO: Starting candidate scoring
+1 day, 19:42:05.785676 INFO: Finished candidate processing
+1 day, 19:42:05.785799 INFO: Collecting candidate features
+1 day, 19:42:05.833769 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30262)
+1 day, 19:42:05.840887 INFO: Collecting fragment features
+1 day, 19:42:05.859812 INFO: Finished candidate scoring
+1 day, 19:42:05.874477 PROGRESS: === Extracted 30262 precursors and 323112 fragments ===
+1 day, 19:42:05.874892 INFO: performing precursor FDR with 47 features
+1 day, 19:42:05.874931 INFO: Decoy channel: -1
+1 day, 19:42:05.874955 INFO: Competetive: True
+1 day, 19:42:05.883732 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:05.888016 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 19:42:06.269154 INFO: Test AUC: 0.845
+1 day, 19:42:06.269297 INFO: Train AUC: 0.857
+1 day, 19:42:06.269327 INFO: AUC difference: 1.34%
+1 day, 19:42:07.903768 INFO: Resetting torch num_threads to 100
+1 day, 19:42:07.905308 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:42:07.906988 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:07.907098 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:07.907163 PROGRESS: Target precursors: 7,814 (97.67%)
+1 day, 19:42:07.907216 PROGRESS: Decoy precursors: 186 (2.33%)
+1 day, 19:42:07.907277 PROGRESS: 
+1 day, 19:42:07.907325 PROGRESS: Precursor Summary:
+1 day, 19:42:07.910503 PROGRESS: Channel   0:	 0.05 FDR: 7,814; 0.01 FDR: 7,588; 0.001 FDR: 6,489
+1 day, 19:42:07.910632 PROGRESS: 
+1 day, 19:42:07.910702 PROGRESS: Protein Summary:
+1 day, 19:42:07.915290 PROGRESS: Channel   0:	 0.05 FDR: 4,134; 0.01 FDR: 4,038; 0.001 FDR: 3,618
+1 day, 19:42:07.915413 PROGRESS: =========================================================================
+1 day, 19:42:07.940642 INFO: fragments_df_filtered: 5000
+1 day, 19:42:07.956919 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:08.775994 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:09.628216 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:10.451949 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:10.867976 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:10.871054 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:10.880609 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:10.883016 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:10.901489 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:10.901677 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:42:10.908208 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 19.5672.
+1 day, 19:42:10.908283 INFO: ==============================================
+1 day, 19:42:10.908401 INFO: Starting optimization step 3.
+1 day, 19:42:10.908481 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:10.908555 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:10.915754 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:10.915836 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:10.915882 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 19:42:10.915910 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.94
+1 day, 19:42:10.919929 INFO: Starting candidate selection
+1 day, 19:42:12.740326 INFO: Starting candidate scoring
+1 day, 19:42:13.709095 INFO: Finished candidate processing
+1 day, 19:42:13.709220 INFO: Collecting candidate features
+1 day, 19:42:13.758085 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 30198)
+1 day, 19:42:13.758351 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30198)
+1 day, 19:42:13.762537 INFO: Collecting fragment features
+1 day, 19:42:13.781522 INFO: Finished candidate scoring
+1 day, 19:42:13.797224 PROGRESS: === Extracted 30198 precursors and 320007 fragments ===
+1 day, 19:42:13.797620 INFO: performing precursor FDR with 47 features
+1 day, 19:42:13.797659 INFO: Decoy channel: -1
+1 day, 19:42:13.797684 INFO: Competetive: True
+1 day, 19:42:13.806230 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:13.811341 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:42:13.811441 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 19:42:14.209168 INFO: Test AUC: 0.872
+1 day, 19:42:14.209304 INFO: Train AUC: 0.872
+1 day, 19:42:14.209335 INFO: AUC difference: 0.02%
+1 day, 19:42:14.294576 INFO: Resetting torch num_threads to 100
+1 day, 19:42:14.296073 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:42:14.297721 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:14.297827 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:14.297889 PROGRESS: Target precursors: 7,857 (98.21%)
+1 day, 19:42:14.297956 PROGRESS: Decoy precursors: 143 (1.79%)
+1 day, 19:42:14.298769 PROGRESS: 
+1 day, 19:42:14.298830 PROGRESS: Precursor Summary:
+1 day, 19:42:14.302098 PROGRESS: Channel   0:	 0.05 FDR: 7,857; 0.01 FDR: 7,757; 0.001 FDR: 7,013
+1 day, 19:42:14.302217 PROGRESS: 
+1 day, 19:42:14.302275 PROGRESS: Protein Summary:
+1 day, 19:42:14.306951 PROGRESS: Channel   0:	 0.05 FDR: 4,162; 0.01 FDR: 4,128; 0.001 FDR: 3,816
+1 day, 19:42:14.307073 PROGRESS: =========================================================================
+1 day, 19:42:14.333327 INFO: fragments_df_filtered: 5000
+1 day, 19:42:14.349055 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:15.135782 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:15.935036 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:16.725132 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:17.078802 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:17.081889 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:17.091235 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:17.093626 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:17.112250 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:17.112433 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 19:42:17.119213 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 14.5289.
+1 day, 19:42:17.119288 INFO: ==============================================
+1 day, 19:42:17.119401 INFO: Starting optimization step 4.
+1 day, 19:42:17.119478 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:17.119550 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:17.126266 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:17.126341 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:17.126386 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 19:42:17.126414 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.92
+1 day, 19:42:17.129827 INFO: Starting candidate selection
+1 day, 19:42:18.670579 INFO: Starting candidate scoring
+1 day, 19:42:19.639460 INFO: Finished candidate processing
+1 day, 19:42:19.639576 INFO: Collecting candidate features
+1 day, 19:42:19.710280 WARNING: intensity_correlation has 5 NaNs ( 0.02 % out of 30122)
+1 day, 19:42:19.710619 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30122)
+1 day, 19:42:19.718204 INFO: Collecting fragment features
+1 day, 19:42:19.737421 INFO: Finished candidate scoring
+1 day, 19:42:19.753445 PROGRESS: === Extracted 30122 precursors and 317682 fragments ===
+1 day, 19:42:19.753889 INFO: performing precursor FDR with 47 features
+1 day, 19:42:19.753927 INFO: Decoy channel: -1
+1 day, 19:42:19.753951 INFO: Competetive: True
+1 day, 19:42:19.763218 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:19.767586 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 19:42:20.217735 INFO: Test AUC: 0.888
+1 day, 19:42:20.217883 INFO: Train AUC: 0.884
+1 day, 19:42:20.217915 INFO: AUC difference: 0.49%
+1 day, 19:42:20.304935 INFO: Resetting torch num_threads to 100
+1 day, 19:42:20.306346 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:42:20.307945 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:20.308058 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:20.308122 PROGRESS: Target precursors: 7,850 (98.12%)
+1 day, 19:42:20.308175 PROGRESS: Decoy precursors: 150 (1.88%)
+1 day, 19:42:20.308225 PROGRESS: 
+1 day, 19:42:20.308274 PROGRESS: Precursor Summary:
+1 day, 19:42:20.311372 PROGRESS: Channel   0:	 0.05 FDR: 7,850; 0.01 FDR: 7,743; 0.001 FDR: 6,345
+1 day, 19:42:20.311502 PROGRESS: 
+1 day, 19:42:20.311562 PROGRESS: Protein Summary:
+1 day, 19:42:20.316279 PROGRESS: Channel   0:	 0.05 FDR: 4,165; 0.01 FDR: 4,127; 0.001 FDR: 3,540
+1 day, 19:42:20.316416 PROGRESS: =========================================================================
+1 day, 19:42:20.343120 INFO: fragments_df_filtered: 5000
+1 day, 19:42:20.360592 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:21.148325 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:21.957660 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:22.744326 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:23.094815 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:23.097889 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:23.107347 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:23.109686 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:23.127714 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:23.127897 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 19:42:23.133835 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 11.3656.
+1 day, 19:42:23.133895 INFO: ==============================================
+1 day, 19:42:23.133989 INFO: Starting optimization step 5.
+1 day, 19:42:23.134055 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:23.134115 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:23.138410 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:23.138472 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:23.138509 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 19:42:23.138532 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:42:23.139597 INFO: Starting candidate selection
+1 day, 19:42:24.734654 INFO: Starting candidate scoring
+1 day, 19:42:25.720496 INFO: Finished candidate processing
+1 day, 19:42:25.720615 INFO: Collecting candidate features
+1 day, 19:42:25.800834 WARNING: intensity_correlation has 11 NaNs ( 0.04 % out of 30171)
+1 day, 19:42:25.801132 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30171)
+1 day, 19:42:25.805420 INFO: Collecting fragment features
+1 day, 19:42:25.828035 INFO: Finished candidate scoring
+1 day, 19:42:25.849022 PROGRESS: === Extracted 30171 precursors and 318142 fragments ===
+1 day, 19:42:25.849514 INFO: performing precursor FDR with 47 features
+1 day, 19:42:25.849555 INFO: Decoy channel: -1
+1 day, 19:42:25.849586 INFO: Competetive: True
+1 day, 19:42:25.859356 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:25.864816 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:42:25.864929 WARNING: dropped 11 decoy PSMs due to missing features
+1 day, 19:42:26.170657 INFO: Test AUC: 0.882
+1 day, 19:42:26.170802 INFO: Train AUC: 0.885
+1 day, 19:42:26.170840 INFO: AUC difference: 0.31%
+1 day, 19:42:26.258622 INFO: Resetting torch num_threads to 100
+1 day, 19:42:26.260131 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:42:26.261759 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:26.261880 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:26.261960 PROGRESS: Target precursors: 7,867 (98.34%)
+1 day, 19:42:26.262030 PROGRESS: Decoy precursors: 133 (1.66%)
+1 day, 19:42:26.262100 PROGRESS: 
+1 day, 19:42:26.262163 PROGRESS: Precursor Summary:
+1 day, 19:42:26.265332 PROGRESS: Channel   0:	 0.05 FDR: 7,867; 0.01 FDR: 7,764; 0.001 FDR: 6,399
+1 day, 19:42:26.265467 PROGRESS: 
+1 day, 19:42:26.265542 PROGRESS: Protein Summary:
+1 day, 19:42:26.270424 PROGRESS: Channel   0:	 0.05 FDR: 4,169; 0.01 FDR: 4,134; 0.001 FDR: 3,571
+1 day, 19:42:26.270552 PROGRESS: =========================================================================
+1 day, 19:42:26.295121 INFO: fragments_df_filtered: 5000
+1 day, 19:42:26.311617 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:27.169955 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:28.023480 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:28.813138 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:29.169035 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:29.173253 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:29.183628 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:29.186080 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:29.204790 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:29.204998 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 19:42:29.211413 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 11.9054.
+1 day, 19:42:29.211483 INFO: ==============================================
+1 day, 19:42:29.211609 INFO: Starting optimization step 6.
+1 day, 19:42:29.211688 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:29.211773 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:29.222203 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:29.222267 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:29.222325 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:42:29.222349 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:42:29.229433 INFO: Starting candidate selection
+1 day, 19:42:30.757660 INFO: Starting candidate scoring
+1 day, 19:42:31.738934 INFO: Finished candidate processing
+1 day, 19:42:31.739055 INFO: Collecting candidate features
+1 day, 19:42:31.793514 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30157)
+1 day, 19:42:31.793775 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30157)
+1 day, 19:42:31.797925 INFO: Collecting fragment features
+1 day, 19:42:31.820253 INFO: Finished candidate scoring
+1 day, 19:42:31.834632 PROGRESS: === Extracted 30157 precursors and 317969 fragments ===
+1 day, 19:42:31.835062 INFO: performing precursor FDR with 47 features
+1 day, 19:42:31.835100 INFO: Decoy channel: -1
+1 day, 19:42:31.835124 INFO: Competetive: True
+1 day, 19:42:31.845967 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:31.851455 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:42:31.851558 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:42:32.139905 INFO: Test AUC: 0.882
+1 day, 19:42:32.141176 INFO: Train AUC: 0.885
+1 day, 19:42:32.141220 INFO: AUC difference: 0.35%
+1 day, 19:42:32.228518 INFO: Resetting torch num_threads to 100
+1 day, 19:42:32.230026 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:42:32.231746 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:32.231844 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:32.231908 PROGRESS: Target precursors: 7,860 (98.25%)
+1 day, 19:42:32.231962 PROGRESS: Decoy precursors: 140 (1.75%)
+1 day, 19:42:32.232011 PROGRESS: 
+1 day, 19:42:32.232059 PROGRESS: Precursor Summary:
+1 day, 19:42:32.235307 PROGRESS: Channel   0:	 0.05 FDR: 7,860; 0.01 FDR: 7,752; 0.001 FDR: 6,113
+1 day, 19:42:32.235432 PROGRESS: 
+1 day, 19:42:32.235492 PROGRESS: Protein Summary:
+1 day, 19:42:32.240248 PROGRESS: Channel   0:	 0.05 FDR: 4,169; 0.01 FDR: 4,135; 0.001 FDR: 3,449
+1 day, 19:42:32.240370 PROGRESS: =========================================================================
+1 day, 19:42:32.266997 INFO: fragments_df_filtered: 5000
+1 day, 19:42:32.285062 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:33.136139 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:33.998034 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:34.849710 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:35.265747 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:35.268758 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:35.277963 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:35.280371 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:35.299192 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:35.299399 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 19:42:35.300804 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 11.3656 found after 7 searches.
+1 day, 19:42:35.300861 INFO: ==============================================
+1 day, 19:42:35.300977 PROGRESS: Optimization finished for rt_error.
+1 day, 19:42:35.321972 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:35.325354 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:35.335258 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:35.337986 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:35.391200 INFO: Starting optimization step 0.
+1 day, 19:42:35.391418 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:35.391498 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:35.398538 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:35.398617 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:35.398662 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:42:35.398691 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:42:35.407545 INFO: Starting candidate selection
+1 day, 19:42:36.942238 INFO: Starting candidate scoring
+1 day, 19:42:37.919724 INFO: Finished candidate processing
+1 day, 19:42:37.919894 INFO: Collecting candidate features
+1 day, 19:42:37.968817 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30181)
+1 day, 19:42:37.969100 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30181)
+1 day, 19:42:37.973373 INFO: Collecting fragment features
+1 day, 19:42:37.993489 INFO: Finished candidate scoring
+1 day, 19:42:38.007921 PROGRESS: === Extracted 30181 precursors and 318203 fragments ===
+1 day, 19:42:38.008316 INFO: performing precursor FDR with 47 features
+1 day, 19:42:38.008354 INFO: Decoy channel: -1
+1 day, 19:42:38.008378 INFO: Competetive: True
+1 day, 19:42:38.017182 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:38.022164 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:42:38.022259 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:42:38.395575 INFO: Test AUC: 0.891
+1 day, 19:42:38.395715 INFO: Train AUC: 0.891
+1 day, 19:42:38.395746 INFO: AUC difference: 0.01%
+1 day, 19:42:38.483232 INFO: Resetting torch num_threads to 100
+1 day, 19:42:38.484701 INFO: === FDR correction performed with classifier version 8 ===
+1 day, 19:42:38.486369 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:38.486468 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:42:38.486531 PROGRESS: Target precursors: 7,874 (98.42%)
+1 day, 19:42:38.486584 PROGRESS: Decoy precursors: 126 (1.57%)
+1 day, 19:42:38.486632 PROGRESS: 
+1 day, 19:42:38.486679 PROGRESS: Precursor Summary:
+1 day, 19:42:38.489883 PROGRESS: Channel   0:	 0.05 FDR: 7,874; 0.01 FDR: 7,782; 0.001 FDR: 7,199
+1 day, 19:42:38.490000 PROGRESS: 
+1 day, 19:42:38.490060 PROGRESS: Protein Summary:
+1 day, 19:42:38.494982 PROGRESS: Channel   0:	 0.05 FDR: 4,169; 0.01 FDR: 4,144; 0.001 FDR: 3,910
+1 day, 19:42:38.495093 PROGRESS: =========================================================================
+1 day, 19:42:38.522864 INFO: fragments_df_filtered: 5000
+1 day, 19:42:38.538447 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:39.331352 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:40.136283 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:40.928056 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:41.278484 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:41.282384 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:41.292520 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:41.295842 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:41.314322 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:41.314500 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:42:41.317693 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0571.
+1 day, 19:42:41.317756 INFO: ==============================================
+1 day, 19:42:41.317864 INFO: Starting optimization step 1.
+1 day, 19:42:41.317942 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:41.318012 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:41.325859 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:41.325930 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:41.325975 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:42:41.326003 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:42:41.327193 INFO: Starting candidate selection
+1 day, 19:42:42.645951 INFO: Starting candidate scoring
+1 day, 19:42:43.590587 INFO: Finished candidate processing
+1 day, 19:42:43.590709 INFO: Collecting candidate features
+1 day, 19:42:43.638951 WARNING: intensity_correlation has 15 NaNs ( 0.05 % out of 30097)
+1 day, 19:42:43.639315 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30097)
+1 day, 19:42:43.646214 INFO: Collecting fragment features
+1 day, 19:42:43.665369 INFO: Finished candidate scoring
+1 day, 19:42:43.679556 PROGRESS: === Extracted 30097 precursors and 314231 fragments ===
+1 day, 19:42:43.680018 INFO: performing precursor FDR with 47 features
+1 day, 19:42:43.680060 INFO: Decoy channel: -1
+1 day, 19:42:43.680093 INFO: Competetive: True
+1 day, 19:42:43.688628 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:43.694063 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:42:43.694175 WARNING: dropped 15 decoy PSMs due to missing features
+1 day, 19:42:43.959950 INFO: Test AUC: 0.890
+1 day, 19:42:43.960091 INFO: Train AUC: 0.894
+1 day, 19:42:43.960126 INFO: AUC difference: 0.38%
+1 day, 19:42:44.047823 INFO: Resetting torch num_threads to 100
+1 day, 19:42:44.049359 INFO: === FDR correction performed with classifier version 8 ===
+1 day, 19:42:44.051055 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:44.051181 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:42:44.051264 PROGRESS: Target precursors: 7,887 (98.61%)
+1 day, 19:42:44.051339 PROGRESS: Decoy precursors: 111 (1.39%)
+1 day, 19:42:44.051399 PROGRESS: 
+1 day, 19:42:44.051457 PROGRESS: Precursor Summary:
+1 day, 19:42:44.054774 PROGRESS: Channel   0:	 0.05 FDR: 7,887; 0.01 FDR: 7,823; 0.001 FDR: 7,397
+1 day, 19:42:44.054905 PROGRESS: 
+1 day, 19:42:44.054986 PROGRESS: Protein Summary:
+1 day, 19:42:44.060019 PROGRESS: Channel   0:	 0.05 FDR: 4,174; 0.01 FDR: 4,158; 0.001 FDR: 3,985
+1 day, 19:42:44.060161 PROGRESS: =========================================================================
+1 day, 19:42:44.086037 INFO: fragments_df_filtered: 5000
+1 day, 19:42:44.101622 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:44.966923 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:45.844879 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:46.708963 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:47.128704 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:47.131669 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:47.140852 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:47.143155 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:47.161361 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:47.161548 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:42:47.164199 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0509.
+1 day, 19:42:47.164254 INFO: ==============================================
+1 day, 19:42:47.164387 INFO: Starting optimization step 2.
+1 day, 19:42:47.164474 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:42:47.164549 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:42:47.170072 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:47.170137 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:47.170184 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:42:47.170212 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:42:47.171291 INFO: Starting candidate selection
+1 day, 19:42:48.519310 INFO: Starting candidate scoring
+1 day, 19:42:49.483796 INFO: Finished candidate processing
+1 day, 19:42:49.483917 INFO: Collecting candidate features
+1 day, 19:42:49.531811 WARNING: intensity_correlation has 15 NaNs ( 0.05 % out of 30078)
+1 day, 19:42:49.532132 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30078)
+1 day, 19:42:49.538951 INFO: Collecting fragment features
+1 day, 19:42:49.557559 INFO: Finished candidate scoring
+1 day, 19:42:49.571160 PROGRESS: === Extracted 30078 precursors and 312617 fragments ===
+1 day, 19:42:49.571553 INFO: performing precursor FDR with 47 features
+1 day, 19:42:49.571591 INFO: Decoy channel: -1
+1 day, 19:42:49.571615 INFO: Competetive: True
+1 day, 19:42:49.579835 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:42:49.584921 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:42:49.585035 WARNING: dropped 15 decoy PSMs due to missing features
+1 day, 19:42:49.860184 INFO: Test AUC: 0.887
+1 day, 19:42:49.860326 INFO: Train AUC: 0.892
+1 day, 19:42:49.860355 INFO: AUC difference: 0.64%
+1 day, 19:42:49.948790 INFO: Resetting torch num_threads to 100
+1 day, 19:42:49.950224 INFO: === FDR correction performed with classifier version 8 ===
+1 day, 19:42:49.951818 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:42:49.951916 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:42:49.951976 PROGRESS: Target precursors: 7,880 (98.52%)
+1 day, 19:42:49.952029 PROGRESS: Decoy precursors: 118 (1.48%)
+1 day, 19:42:49.952076 PROGRESS: 
+1 day, 19:42:49.952122 PROGRESS: Precursor Summary:
+1 day, 19:42:49.955212 PROGRESS: Channel   0:	 0.05 FDR: 7,880; 0.01 FDR: 7,814; 0.001 FDR: 7,357
+1 day, 19:42:49.955333 PROGRESS: 
+1 day, 19:42:49.955390 PROGRESS: Protein Summary:
+1 day, 19:42:49.960104 PROGRESS: Channel   0:	 0.05 FDR: 4,173; 0.01 FDR: 4,156; 0.001 FDR: 3,975
+1 day, 19:42:49.960222 PROGRESS: =========================================================================
+1 day, 19:42:49.985463 INFO: fragments_df_filtered: 5000
+1 day, 19:42:50.000900 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:42:50.866476 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:42:51.743545 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:42:52.601643 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:42:53.017951 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:53.020919 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:53.030201 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:53.032537 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:53.051016 INFO: === checking if optimization conditions were reached ===
+1 day, 19:42:53.051177 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:42:53.052061 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0571 found after 3 searches.
+1 day, 19:42:53.052109 INFO: ==============================================
+1 day, 19:42:53.052198 PROGRESS: Optimization finished for mobility_error.
+1 day, 19:42:53.067881 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:53.070791 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:53.079907 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:53.082272 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:53.125777 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 19:42:53.125959 PROGRESS: ==============================================
+1 day, 19:42:53.126055 PROGRESS: ms2_error      : 15.0000
+1 day, 19:42:53.126128 PROGRESS: ms1_error      : 10.0000
+1 day, 19:42:53.126185 PROGRESS: rt_error       : 11.3656
+1 day, 19:42:53.126233 PROGRESS: mobility_error : 0.0571
+1 day, 19:42:53.126279 PROGRESS: ==============================================
+1 day, 19:42:53.127512 INFO: calibration group: precursor, predicting mz
+1 day, 19:42:53.146537 INFO: calibration group: precursor, predicting rt
+1 day, 19:42:53.235409 INFO: calibration group: precursor, predicting mobility
+1 day, 19:42:53.255649 INFO: calibration group: fragment, predicting mz
+1 day, 19:42:53.473689 PROGRESS: Extracting batch of 162861 precursors
+1 day, 19:42:53.521444 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:42:53.521596 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:42:53.521645 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:42:53.521669 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:42:53.522585 INFO: Starting candidate selection
+1 day, 19:43:02.578666 INFO: Applying score cutoff of 25.36326449584961
+1 day, 19:43:02.584977 INFO: Removed 20746 precursors with score below cutoff
+1 day, 19:43:02.901639 INFO: Starting candidate scoring
+1 day, 19:43:11.563314 INFO: Finished candidate processing
+1 day, 19:43:11.563492 INFO: Collecting candidate features
+1 day, 19:43:12.074491 WARNING: intensity_correlation has 10 NaNs ( 0.00 % out of 289026)
+1 day, 19:43:12.091479 INFO: Collecting fragment features
+1 day, 19:43:12.266765 INFO: Finished candidate scoring
+1 day, 19:43:12.463909 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 19:43:12.464751 INFO: performing precursor FDR with 47 features
+1 day, 19:43:12.464786 INFO: Decoy channel: -1
+1 day, 19:43:12.464809 INFO: Competetive: True
+1 day, 19:43:12.569192 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:43:12.620833 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:43:12.620992 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 19:43:12.621057 WARNING: FDR calculation for 153262 target and 135754 decoy PSMs
+1 day, 19:43:12.621086 WARNING: FDR calculation may be inaccurate as there is more than 10% difference in the number of target and decoy PSMs
+1 day, 19:43:17.630882 INFO: Test AUC: 0.905
+1 day, 19:43:17.631024 INFO: Train AUC: 0.907
+1 day, 19:43:17.631056 INFO: AUC difference: 0.21%
+1 day, 19:43:17.732209 INFO: Resetting torch num_threads to 100
+1 day, 19:43:17.755119 INFO: Removing fragments below FDR threshold
+1 day, 19:43:17.810823 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:43:17.811107 PROGRESS: Total precursors accumulated: 81,604
+1 day, 19:43:17.811177 PROGRESS: Target precursors: 80,797 (99.01%)
+1 day, 19:43:17.811245 PROGRESS: Decoy precursors: 807 (0.99%)
+1 day, 19:43:17.811299 PROGRESS: 
+1 day, 19:43:17.811347 PROGRESS: Precursor Summary:
+1 day, 19:43:17.854199 PROGRESS: Channel   0:	 0.05 FDR: 80,797; 0.01 FDR: 80,797; 0.001 FDR: 78,233
+1 day, 19:43:17.854528 PROGRESS: 
+1 day, 19:43:17.854595 PROGRESS: Protein Summary:
+1 day, 19:43:17.918529 PROGRESS: Channel   0:	 0.05 FDR: 8,247; 0.01 FDR: 8,247; 0.001 FDR: 8,212
+1 day, 19:43:17.918815 PROGRESS: =========================================================================
+1 day, 19:43:18.615366 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 19:43:18.663681 PROGRESS: Loading raw file 2/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:43:18.663864 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 19:43:18.663948 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:43:18.664663 INFO: Initializing RawFileManager
+1 day, 19:43:18.664791 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:18.664853 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:18.664895 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:18.869838 INFO: Reading 39,128 frames with 2,860,596,893 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.625040 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d...
+1 day, 19:43:25.629816 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.635442 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.635767 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.636282 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.637977 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.657277 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:25.657516 INFO: Indexing quadrupole dimension
+1 day, 19:43:26.162271 INFO: Transposing detector events
+1 day, 19:43:35.051303 INFO: Finished transposing data
+1 day, 19:43:35.078511 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d
+1 day, 19:43:35.079328 INFO: RT (min)            : 0.0 - 70.0
+1 day, 19:43:35.079371 INFO: RT duration (sec)   : 4199.8
+1 day, 19:43:35.079399 INFO: RT duration (min)   : 70.0
+1 day, 19:43:35.079426 INFO: Cycle len (scans)   : 9
+1 day, 19:43:35.079448 INFO: Cycle len (sec)     : 0.97
+1 day, 19:43:35.079467 INFO: Number of cycles    : 4347
+1 day, 19:43:35.079486 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 19:43:35.158923 INFO: Initializing CalibrationManager
+1 day, 19:43:35.159286 INFO: Loading calibration config
+1 day, 19:43:35.160158 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 19:43:35.160252 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 19:43:35.160349 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 19:43:35.160541 INFO: Initializing OptimizationManager
+1 day, 19:43:35.160659 INFO: initial parameter: ms1_error = 30
+1 day, 19:43:35.160717 INFO: initial parameter: ms2_error = 30
+1 day, 19:43:35.160787 INFO: initial parameter: rt_error = 2099.894844
+1 day, 19:43:35.160838 INFO: initial parameter: mobility_error = 0.1
+1 day, 19:43:35.160888 INFO: initial parameter: column_type = library
+1 day, 19:43:35.160932 INFO: initial parameter: num_candidates = 1
+1 day, 19:43:35.160978 INFO: initial parameter: classifier_version = -1
+1 day, 19:43:35.161034 INFO: initial parameter: fwhm_rt = 5
+1 day, 19:43:35.161093 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 19:43:35.161141 INFO: initial parameter: score_cutoff = 0
+1 day, 19:43:35.161208 INFO: Initializing TimingManager
+1 day, 19:43:35.161269 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:43:35.161427 INFO: FDRManager not loaded from disk.
+1 day, 19:43:35.161455 INFO: Initializing FDRManager
+1 day, 19:43:35.161494 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 19:43:35.193842 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 19:43:35.234039 PROGRESS: Starting initial search for precursors.
+1 day, 19:43:35.254699 INFO: Starting optimization step 0.
+1 day, 19:43:35.254951 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:43:35.255054 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:43:35.258892 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:43:35.258952 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:43:35.259000 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 19:43:35.259024 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 19:43:35.260126 INFO: Starting candidate selection
+1 day, 19:45:01.549274 INFO: Starting candidate scoring
+1 day, 19:45:02.623966 INFO: Finished candidate processing
+1 day, 19:45:02.624081 INFO: Collecting candidate features
+1 day, 19:45:02.660699 INFO: Collecting fragment features
+1 day, 19:45:02.676514 INFO: Finished candidate scoring
+1 day, 19:45:02.684964 PROGRESS: === Extracted 15885 precursors and 175846 fragments ===
+1 day, 19:45:02.685401 INFO: performing precursor FDR with 47 features
+1 day, 19:45:02.685443 INFO: Decoy channel: -1
+1 day, 19:45:02.685468 INFO: Competetive: True
+1 day, 19:45:02.690395 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:45:02.822764 INFO: Test AUC: 0.821
+1 day, 19:45:02.822888 INFO: Train AUC: 0.828
+1 day, 19:45:02.822918 INFO: AUC difference: 0.86%
+1 day, 19:45:02.906199 INFO: Resetting torch num_threads to 100
+1 day, 19:45:02.907225 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 19:45:02.908670 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:45:02.908772 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:45:02.908833 PROGRESS: Target precursors: 6,637 (82.96%)
+1 day, 19:45:02.908886 PROGRESS: Decoy precursors: 1,363 (17.04%)
+1 day, 19:45:02.908932 PROGRESS: 
+1 day, 19:45:02.908978 PROGRESS: Precursor Summary:
+1 day, 19:45:02.911263 PROGRESS: Channel   0:	 0.05 FDR: 5,247; 0.01 FDR: 3,919; 0.001 FDR: 2,205
+1 day, 19:45:02.911367 PROGRESS: 
+1 day, 19:45:02.911425 PROGRESS: Protein Summary:
+1 day, 19:45:02.914271 PROGRESS: Channel   0:	 0.05 FDR: 3,079; 0.01 FDR: 2,457; 0.001 FDR: 1,540
+1 day, 19:45:02.914372 PROGRESS: =========================================================================
+1 day, 19:45:02.923214 INFO: fragments_df_filtered: 5000
+1 day, 19:45:02.939944 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:45:03.240901 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:45:03.548913 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:45:03.846838 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:45:04.264689 INFO: calibration group: precursor, predicting mz
+1 day, 19:45:04.267421 INFO: calibration group: precursor, predicting rt
+1 day, 19:45:04.277182 INFO: calibration group: precursor, predicting mobility
+1 day, 19:45:04.279437 INFO: calibration group: fragment, predicting mz
+1 day, 19:45:04.299105 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 19:45:04.299302 INFO: Starting optimization step 1.
+1 day, 19:45:04.299387 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:45:04.299463 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:45:04.304954 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:45:04.305056 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:45:04.305110 INFO: FWHM in RT is 3.24 seconds, sigma is 0.71
+1 day, 19:45:04.305143 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.13
+1 day, 19:45:04.306312 INFO: Starting candidate selection
+1 day, 19:46:40.406615 INFO: Starting candidate scoring
+1 day, 19:46:42.439935 INFO: Finished candidate processing
+1 day, 19:46:42.440048 INFO: Collecting candidate features
+1 day, 19:46:42.496647 INFO: Collecting fragment features
+1 day, 19:46:42.516400 INFO: Finished candidate scoring
+1 day, 19:46:42.533114 PROGRESS: === Extracted 30469 precursors and 337367 fragments ===
+1 day, 19:46:42.533591 INFO: performing precursor FDR with 47 features
+1 day, 19:46:42.533633 INFO: Decoy channel: -1
+1 day, 19:46:42.533659 INFO: Competetive: True
+1 day, 19:46:42.544627 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:46:42.930736 INFO: Test AUC: 0.749
+1 day, 19:46:42.930855 INFO: Train AUC: 0.746
+1 day, 19:46:42.930887 INFO: AUC difference: 0.43%
+1 day, 19:46:43.019552 INFO: Resetting torch num_threads to 100
+1 day, 19:46:43.020799 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 19:46:43.022444 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:46:43.022553 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:46:43.022614 PROGRESS: Target precursors: 7,020 (87.75%)
+1 day, 19:46:43.022672 PROGRESS: Decoy precursors: 980 (12.25%)
+1 day, 19:46:43.022725 PROGRESS: 
+1 day, 19:46:43.022801 PROGRESS: Precursor Summary:
+1 day, 19:46:43.025235 PROGRESS: Channel   0:	 0.05 FDR: 6,085; 0.01 FDR: 5,072; 0.001 FDR: 3,205
+1 day, 19:46:43.025355 PROGRESS: 
+1 day, 19:46:43.025425 PROGRESS: Protein Summary:
+1 day, 19:46:43.028938 PROGRESS: Channel   0:	 0.05 FDR: 3,422; 0.01 FDR: 2,990; 0.001 FDR: 2,105
+1 day, 19:46:43.029063 PROGRESS: =========================================================================
+1 day, 19:46:43.047981 INFO: fragments_df_filtered: 5000
+1 day, 19:46:43.066697 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:46:43.496310 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:46:43.936011 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:46:44.359269 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:46:44.778126 INFO: calibration group: precursor, predicting mz
+1 day, 19:46:44.780864 INFO: calibration group: precursor, predicting rt
+1 day, 19:46:44.790557 INFO: calibration group: precursor, predicting mobility
+1 day, 19:46:44.792830 INFO: calibration group: fragment, predicting mz
+1 day, 19:46:44.811310 INFO: === checking if optimization conditions were reached ===
+1 day, 19:46:44.813137 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 19:46:44.814749 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 19:46:44.814799 INFO: ==============================================
+1 day, 19:46:44.814896 INFO: Starting optimization step 2.
+1 day, 19:46:44.814965 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:46:44.815031 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:46:44.819182 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:46:44.819248 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:46:44.819289 INFO: FWHM in RT is 3.22 seconds, sigma is 0.71
+1 day, 19:46:44.819313 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 4.99
+1 day, 19:46:44.820331 INFO: Starting candidate selection
+1 day, 19:48:10.388332 INFO: Starting candidate scoring
+1 day, 19:48:11.501992 INFO: Finished candidate processing
+1 day, 19:48:11.502133 INFO: Collecting candidate features
+1 day, 19:48:11.557697 INFO: Collecting fragment features
+1 day, 19:48:11.580420 INFO: Finished candidate scoring
+1 day, 19:48:11.593581 PROGRESS: === Extracted 30551 precursors and 333891 fragments ===
+1 day, 19:48:11.594040 INFO: performing precursor FDR with 47 features
+1 day, 19:48:11.594082 INFO: Decoy channel: -1
+1 day, 19:48:11.594122 INFO: Competetive: True
+1 day, 19:48:11.605048 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:48:11.880777 INFO: Test AUC: 0.791
+1 day, 19:48:11.880900 INFO: Train AUC: 0.798
+1 day, 19:48:11.880931 INFO: AUC difference: 0.86%
+1 day, 19:48:11.967194 INFO: Resetting torch num_threads to 100
+1 day, 19:48:11.968360 INFO: === FDR correction performed with classifier version 1 ===
+1 day, 19:48:11.969878 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:48:11.969980 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:48:11.970043 PROGRESS: Target precursors: 7,529 (94.11%)
+1 day, 19:48:11.970098 PROGRESS: Decoy precursors: 471 (5.89%)
+1 day, 19:48:11.970145 PROGRESS: 
+1 day, 19:48:11.970191 PROGRESS: Precursor Summary:
+1 day, 19:48:11.973081 PROGRESS: Channel   0:	 0.05 FDR: 7,342; 0.01 FDR: 6,741; 0.001 FDR: 5,426
+1 day, 19:48:11.973198 PROGRESS: 
+1 day, 19:48:11.973256 PROGRESS: Protein Summary:
+1 day, 19:48:11.977252 PROGRESS: Channel   0:	 0.05 FDR: 3,961; 0.01 FDR: 3,713; 0.001 FDR: 3,172
+1 day, 19:48:11.977363 PROGRESS: =========================================================================
+1 day, 19:48:12.000386 INFO: fragments_df_filtered: 5000
+1 day, 19:48:12.018417 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:48:12.619684 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:48:13.249279 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:48:15.520206 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:48:15.872208 INFO: calibration group: precursor, predicting mz
+1 day, 19:48:15.875297 INFO: calibration group: precursor, predicting rt
+1 day, 19:48:15.884510 INFO: calibration group: precursor, predicting mobility
+1 day, 19:48:15.886845 INFO: calibration group: fragment, predicting mz
+1 day, 19:48:15.905740 INFO: === checking if optimization conditions were reached ===
+1 day, 19:48:15.907859 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 19:48:15.910247 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 19:48:15.910309 INFO: ==============================================
+1 day, 19:48:15.910440 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 19:48:15.930263 INFO: calibration group: precursor, predicting mz
+1 day, 19:48:15.933086 INFO: calibration group: precursor, predicting rt
+1 day, 19:48:15.942193 INFO: calibration group: precursor, predicting mobility
+1 day, 19:48:15.944474 INFO: calibration group: fragment, predicting mz
+1 day, 19:48:15.964288 INFO: Starting optimization step 0.
+1 day, 19:48:15.964442 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:48:15.964512 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:48:15.970640 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:48:15.970702 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:48:15.970745 INFO: FWHM in RT is 2.92 seconds, sigma is 0.64
+1 day, 19:48:15.970770 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.08
+1 day, 19:48:15.976480 INFO: Starting candidate selection
+1 day, 19:49:49.520582 INFO: Starting candidate scoring
+1 day, 19:49:50.618755 INFO: Finished candidate processing
+1 day, 19:49:50.618858 INFO: Collecting candidate features
+1 day, 19:49:50.673580 INFO: Collecting fragment features
+1 day, 19:49:50.697869 INFO: Finished candidate scoring
+1 day, 19:49:50.719559 PROGRESS: === Extracted 30471 precursors and 332702 fragments ===
+1 day, 19:49:50.720011 INFO: performing precursor FDR with 47 features
+1 day, 19:49:50.720050 INFO: Decoy channel: -1
+1 day, 19:49:50.720074 INFO: Competetive: True
+1 day, 19:49:50.730242 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:49:51.042014 INFO: Test AUC: 0.805
+1 day, 19:49:51.042144 INFO: Train AUC: 0.815
+1 day, 19:49:51.042173 INFO: AUC difference: 1.25%
+1 day, 19:49:51.129874 INFO: Resetting torch num_threads to 100
+1 day, 19:49:51.131039 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:49:51.132744 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:49:51.132864 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:49:51.132926 PROGRESS: Target precursors: 7,571 (94.64%)
+1 day, 19:49:51.132978 PROGRESS: Decoy precursors: 429 (5.36%)
+1 day, 19:49:51.133034 PROGRESS: 
+1 day, 19:49:51.133085 PROGRESS: Precursor Summary:
+1 day, 19:49:51.136004 PROGRESS: Channel   0:	 0.05 FDR: 7,493; 0.01 FDR: 6,909; 0.001 FDR: 6,177
+1 day, 19:49:51.136128 PROGRESS: 
+1 day, 19:49:51.136187 PROGRESS: Protein Summary:
+1 day, 19:49:51.140500 PROGRESS: Channel   0:	 0.05 FDR: 4,022; 0.01 FDR: 3,764; 0.001 FDR: 3,490
+1 day, 19:49:51.140617 PROGRESS: =========================================================================
+1 day, 19:49:51.164426 INFO: fragments_df_filtered: 5000
+1 day, 19:49:51.182726 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:49:51.878927 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:49:52.604583 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:49:53.300536 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:49:53.717909 INFO: calibration group: precursor, predicting mz
+1 day, 19:49:53.720790 INFO: calibration group: precursor, predicting rt
+1 day, 19:49:53.730187 INFO: calibration group: precursor, predicting mobility
+1 day, 19:49:53.732553 INFO: calibration group: fragment, predicting mz
+1 day, 19:49:53.751952 INFO: === checking if optimization conditions were reached ===
+1 day, 19:49:53.752134 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:49:53.757436 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 183.3551.
+1 day, 19:49:53.757493 INFO: ==============================================
+1 day, 19:49:53.757597 INFO: Starting optimization step 1.
+1 day, 19:49:53.757667 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:49:53.757731 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:49:53.762093 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:49:53.762151 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:49:53.762193 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 19:49:53.762217 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.03
+1 day, 19:49:53.763314 INFO: Starting candidate selection
+1 day, 19:50:02.124597 INFO: Starting candidate scoring
+1 day, 19:50:03.131865 INFO: Finished candidate processing
+1 day, 19:50:03.132017 INFO: Collecting candidate features
+1 day, 19:50:03.179639 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30354)
+1 day, 19:50:03.184124 INFO: Collecting fragment features
+1 day, 19:50:03.203523 INFO: Finished candidate scoring
+1 day, 19:50:03.218607 PROGRESS: === Extracted 30354 precursors and 326954 fragments ===
+1 day, 19:50:03.218980 INFO: performing precursor FDR with 47 features
+1 day, 19:50:03.219023 INFO: Decoy channel: -1
+1 day, 19:50:03.219050 INFO: Competetive: True
+1 day, 19:50:03.227369 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:03.231389 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 19:50:03.499982 INFO: Test AUC: 0.837
+1 day, 19:50:03.500114 INFO: Train AUC: 0.839
+1 day, 19:50:03.500145 INFO: AUC difference: 0.25%
+1 day, 19:50:03.587516 INFO: Resetting torch num_threads to 100
+1 day, 19:50:03.588699 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:03.590304 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:03.590408 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:03.590470 PROGRESS: Target precursors: 7,774 (97.17%)
+1 day, 19:50:03.590525 PROGRESS: Decoy precursors: 226 (2.83%)
+1 day, 19:50:03.590572 PROGRESS: 
+1 day, 19:50:03.590619 PROGRESS: Precursor Summary:
+1 day, 19:50:03.593584 PROGRESS: Channel   0:	 0.05 FDR: 7,774; 0.01 FDR: 7,508; 0.001 FDR: 6,559
+1 day, 19:50:03.593707 PROGRESS: 
+1 day, 19:50:03.593785 PROGRESS: Protein Summary:
+1 day, 19:50:03.598367 PROGRESS: Channel   0:	 0.05 FDR: 4,127; 0.01 FDR: 4,015; 0.001 FDR: 3,653
+1 day, 19:50:03.598492 PROGRESS: =========================================================================
+1 day, 19:50:03.623771 INFO: fragments_df_filtered: 5000
+1 day, 19:50:03.638350 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:04.442998 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:05.289361 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:06.094263 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:06.513697 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:06.516596 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:06.525851 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:06.528196 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:06.548970 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:06.549139 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:50:06.554739 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 55.4757.
+1 day, 19:50:06.554798 INFO: ==============================================
+1 day, 19:50:06.554890 INFO: Starting optimization step 2.
+1 day, 19:50:06.554955 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:06.555012 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:06.559033 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:06.559098 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:06.559137 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 19:50:06.559160 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.95
+1 day, 19:50:06.560194 INFO: Starting candidate selection
+1 day, 19:50:09.987046 INFO: Starting candidate scoring
+1 day, 19:50:10.981647 INFO: Finished candidate processing
+1 day, 19:50:10.981769 INFO: Collecting candidate features
+1 day, 19:50:11.032292 WARNING: intensity_correlation has 2 NaNs ( 0.01 % out of 30301)
+1 day, 19:50:11.039403 INFO: Collecting fragment features
+1 day, 19:50:11.061596 INFO: Finished candidate scoring
+1 day, 19:50:11.078134 PROGRESS: === Extracted 30301 precursors and 324028 fragments ===
+1 day, 19:50:11.078547 INFO: performing precursor FDR with 47 features
+1 day, 19:50:11.078587 INFO: Decoy channel: -1
+1 day, 19:50:11.078610 INFO: Competetive: True
+1 day, 19:50:11.088213 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:11.092233 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 19:50:11.368657 INFO: Test AUC: 0.854
+1 day, 19:50:11.368787 INFO: Train AUC: 0.853
+1 day, 19:50:11.368818 INFO: AUC difference: 0.12%
+1 day, 19:50:11.459030 INFO: Resetting torch num_threads to 100
+1 day, 19:50:11.460233 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:11.461823 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:11.461927 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:11.461987 PROGRESS: Target precursors: 7,849 (98.11%)
+1 day, 19:50:11.462040 PROGRESS: Decoy precursors: 151 (1.89%)
+1 day, 19:50:11.462086 PROGRESS: 
+1 day, 19:50:11.462133 PROGRESS: Precursor Summary:
+1 day, 19:50:11.465305 PROGRESS: Channel   0:	 0.05 FDR: 7,849; 0.01 FDR: 7,735; 0.001 FDR: 7,246
+1 day, 19:50:11.465427 PROGRESS: 
+1 day, 19:50:11.465486 PROGRESS: Protein Summary:
+1 day, 19:50:11.470068 PROGRESS: Channel   0:	 0.05 FDR: 4,161; 0.01 FDR: 4,116; 0.001 FDR: 3,929
+1 day, 19:50:11.470177 PROGRESS: =========================================================================
+1 day, 19:50:11.494809 INFO: fragments_df_filtered: 5000
+1 day, 19:50:11.510464 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:12.355693 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:13.243290 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:14.091320 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:14.514210 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:14.517559 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:14.527352 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:14.529684 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:14.551019 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:14.551195 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:50:14.557425 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 18.9435.
+1 day, 19:50:14.557489 INFO: ==============================================
+1 day, 19:50:14.557599 INFO: Starting optimization step 3.
+1 day, 19:50:14.557673 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:14.557742 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:14.562875 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:14.562942 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:14.562984 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 19:50:14.563007 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.92
+1 day, 19:50:14.577513 INFO: Starting candidate selection
+1 day, 19:50:16.517345 INFO: Starting candidate scoring
+1 day, 19:50:17.519821 INFO: Finished candidate processing
+1 day, 19:50:17.520020 INFO: Collecting candidate features
+1 day, 19:50:17.579215 WARNING: intensity_correlation has 5 NaNs ( 0.02 % out of 30268)
+1 day, 19:50:17.586422 INFO: Collecting fragment features
+1 day, 19:50:17.609660 INFO: Finished candidate scoring
+1 day, 19:50:17.623135 PROGRESS: === Extracted 30268 precursors and 320814 fragments ===
+1 day, 19:50:17.623511 INFO: performing precursor FDR with 47 features
+1 day, 19:50:17.623549 INFO: Decoy channel: -1
+1 day, 19:50:17.623573 INFO: Competetive: True
+1 day, 19:50:17.635108 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:17.640001 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:50:17.640091 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 19:50:17.912992 INFO: Test AUC: 0.872
+1 day, 19:50:17.913126 INFO: Train AUC: 0.869
+1 day, 19:50:17.913156 INFO: AUC difference: 0.36%
+1 day, 19:50:18.002370 INFO: Resetting torch num_threads to 100
+1 day, 19:50:18.003565 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:18.005040 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:18.005142 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:18.005204 PROGRESS: Target precursors: 7,895 (98.69%)
+1 day, 19:50:18.005258 PROGRESS: Decoy precursors: 105 (1.31%)
+1 day, 19:50:18.005316 PROGRESS: 
+1 day, 19:50:18.005366 PROGRESS: Precursor Summary:
+1 day, 19:50:18.008543 PROGRESS: Channel   0:	 0.05 FDR: 7,895; 0.01 FDR: 7,864; 0.001 FDR: 7,308
+1 day, 19:50:18.008664 PROGRESS: 
+1 day, 19:50:18.008723 PROGRESS: Protein Summary:
+1 day, 19:50:18.013309 PROGRESS: Channel   0:	 0.05 FDR: 4,178; 0.01 FDR: 4,173; 0.001 FDR: 3,960
+1 day, 19:50:18.013419 PROGRESS: =========================================================================
+1 day, 19:50:18.039157 INFO: fragments_df_filtered: 5000
+1 day, 19:50:18.055658 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:18.926891 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:19.809136 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:20.679964 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:21.098227 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:21.101094 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:21.110212 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:21.112535 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:21.131135 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:21.131292 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 19:50:21.137061 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 11.8288.
+1 day, 19:50:21.137122 INFO: ==============================================
+1 day, 19:50:21.137221 INFO: Starting optimization step 4.
+1 day, 19:50:21.137287 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:21.137344 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:21.141418 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:21.141480 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:21.141515 INFO: FWHM in RT is 2.89 seconds, sigma is 0.63
+1 day, 19:50:21.141537 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:50:21.142616 INFO: Starting candidate selection
+1 day, 19:50:22.768965 INFO: Starting candidate scoring
+1 day, 19:50:23.726295 INFO: Finished candidate processing
+1 day, 19:50:23.727926 INFO: Collecting candidate features
+1 day, 19:50:23.777644 WARNING: intensity_correlation has 6 NaNs ( 0.02 % out of 30182)
+1 day, 19:50:23.782053 INFO: Collecting fragment features
+1 day, 19:50:23.800537 INFO: Finished candidate scoring
+1 day, 19:50:23.813677 PROGRESS: === Extracted 30182 precursors and 318310 fragments ===
+1 day, 19:50:23.814052 INFO: performing precursor FDR with 47 features
+1 day, 19:50:23.814091 INFO: Decoy channel: -1
+1 day, 19:50:23.814114 INFO: Competetive: True
+1 day, 19:50:23.822991 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:23.827249 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 19:50:24.095430 INFO: Test AUC: 0.882
+1 day, 19:50:24.095557 INFO: Train AUC: 0.878
+1 day, 19:50:24.095587 INFO: AUC difference: 0.37%
+1 day, 19:50:24.181669 INFO: Resetting torch num_threads to 100
+1 day, 19:50:24.182837 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:24.184274 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:24.184372 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:24.184433 PROGRESS: Target precursors: 7,903 (98.79%)
+1 day, 19:50:24.184486 PROGRESS: Decoy precursors: 97 (1.21%)
+1 day, 19:50:24.184533 PROGRESS: 
+1 day, 19:50:24.184580 PROGRESS: Precursor Summary:
+1 day, 19:50:24.187727 PROGRESS: Channel   0:	 0.05 FDR: 7,903; 0.01 FDR: 7,876; 0.001 FDR: 7,556
+1 day, 19:50:24.187848 PROGRESS: 
+1 day, 19:50:24.187907 PROGRESS: Protein Summary:
+1 day, 19:50:24.192524 PROGRESS: Channel   0:	 0.05 FDR: 4,188; 0.01 FDR: 4,182; 0.001 FDR: 4,047
+1 day, 19:50:24.192642 PROGRESS: =========================================================================
+1 day, 19:50:24.217430 INFO: fragments_df_filtered: 5000
+1 day, 19:50:24.231861 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:25.039074 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:25.860068 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:26.668022 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:27.024596 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:27.027486 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:27.036606 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:27.038954 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:27.057880 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:27.058067 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 19:50:27.064511 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 9.6661.
+1 day, 19:50:27.064583 INFO: ==============================================
+1 day, 19:50:27.064691 INFO: Starting optimization step 5.
+1 day, 19:50:27.064766 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:27.064833 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:27.069938 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:27.070022 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:27.070065 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1 day, 19:50:27.070092 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.90
+1 day, 19:50:27.072074 INFO: Starting candidate selection
+1 day, 19:50:28.705667 INFO: Starting candidate scoring
+1 day, 19:50:29.676326 INFO: Finished candidate processing
+1 day, 19:50:29.676518 INFO: Collecting candidate features
+1 day, 19:50:29.726532 WARNING: intensity_correlation has 7 NaNs ( 0.02 % out of 30191)
+1 day, 19:50:29.733696 INFO: Collecting fragment features
+1 day, 19:50:29.751966 INFO: Finished candidate scoring
+1 day, 19:50:29.764927 PROGRESS: === Extracted 30191 precursors and 318183 fragments ===
+1 day, 19:50:29.765311 INFO: performing precursor FDR with 47 features
+1 day, 19:50:29.765350 INFO: Decoy channel: -1
+1 day, 19:50:29.765375 INFO: Competetive: True
+1 day, 19:50:29.773187 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:29.777179 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 19:50:30.042670 INFO: Test AUC: 0.877
+1 day, 19:50:30.042797 INFO: Train AUC: 0.878
+1 day, 19:50:30.042828 INFO: AUC difference: 0.15%
+1 day, 19:50:30.129590 INFO: Resetting torch num_threads to 100
+1 day, 19:50:30.130744 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:30.132206 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:30.132313 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:30.132380 PROGRESS: Target precursors: 7,878 (98.47%)
+1 day, 19:50:30.132434 PROGRESS: Decoy precursors: 122 (1.52%)
+1 day, 19:50:30.132483 PROGRESS: 
+1 day, 19:50:30.132531 PROGRESS: Precursor Summary:
+1 day, 19:50:30.135540 PROGRESS: Channel   0:	 0.05 FDR: 7,878; 0.01 FDR: 7,796; 0.001 FDR: 7,403
+1 day, 19:50:30.135666 PROGRESS: 
+1 day, 19:50:30.135727 PROGRESS: Protein Summary:
+1 day, 19:50:30.140280 PROGRESS: Channel   0:	 0.05 FDR: 4,175; 0.01 FDR: 4,153; 0.001 FDR: 3,984
+1 day, 19:50:30.140393 PROGRESS: =========================================================================
+1 day, 19:50:30.164766 INFO: fragments_df_filtered: 5000
+1 day, 19:50:30.179212 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:30.970525 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:31.773963 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:32.569216 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:32.920795 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:32.923536 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:32.932684 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:32.934953 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:32.952922 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:32.953101 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 19:50:32.959520 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 9.1265.
+1 day, 19:50:32.959592 INFO: ==============================================
+1 day, 19:50:32.959716 INFO: Starting optimization step 6.
+1 day, 19:50:32.959796 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:32.959868 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:32.965322 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:32.965396 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:32.965440 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1 day, 19:50:32.965469 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:50:32.967454 INFO: Starting candidate selection
+1 day, 19:50:34.611929 INFO: Starting candidate scoring
+1 day, 19:50:35.603914 INFO: Finished candidate processing
+1 day, 19:50:35.604100 INFO: Collecting candidate features
+1 day, 19:50:35.685384 WARNING: intensity_correlation has 10 NaNs ( 0.03 % out of 30182)
+1 day, 19:50:35.690003 INFO: Collecting fragment features
+1 day, 19:50:35.709013 INFO: Finished candidate scoring
+1 day, 19:50:35.724315 PROGRESS: === Extracted 30182 precursors and 318100 fragments ===
+1 day, 19:50:35.724795 INFO: performing precursor FDR with 47 features
+1 day, 19:50:35.724832 INFO: Decoy channel: -1
+1 day, 19:50:35.724855 INFO: Competetive: True
+1 day, 19:50:35.735358 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:35.741560 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:50:35.741689 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 19:50:36.176043 INFO: Test AUC: 0.875
+1 day, 19:50:36.176191 INFO: Train AUC: 0.878
+1 day, 19:50:36.176222 INFO: AUC difference: 0.36%
+1 day, 19:50:36.267646 INFO: Resetting torch num_threads to 100
+1 day, 19:50:36.269358 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:36.271047 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:36.271152 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:36.271213 PROGRESS: Target precursors: 7,864 (98.30%)
+1 day, 19:50:36.271269 PROGRESS: Decoy precursors: 136 (1.70%)
+1 day, 19:50:36.271317 PROGRESS: 
+1 day, 19:50:36.271368 PROGRESS: Precursor Summary:
+1 day, 19:50:36.274713 PROGRESS: Channel   0:	 0.05 FDR: 7,864; 0.01 FDR: 7,773; 0.001 FDR: 7,472
+1 day, 19:50:36.274847 PROGRESS: 
+1 day, 19:50:36.274904 PROGRESS: Protein Summary:
+1 day, 19:50:36.279759 PROGRESS: Channel   0:	 0.05 FDR: 4,175; 0.01 FDR: 4,143; 0.001 FDR: 4,016
+1 day, 19:50:36.279891 PROGRESS: =========================================================================
+1 day, 19:50:36.305817 INFO: fragments_df_filtered: 5000
+1 day, 19:50:36.324420 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:37.130960 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:37.934793 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:38.727971 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:39.082685 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:39.085861 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:39.095397 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:39.097803 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:39.116975 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:39.117156 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 19:50:39.123246 PROGRESS: ❌ rt_error       : optimization incomplete after 7 search(es). Will search with parameter 9.8691.
+1 day, 19:50:39.123312 INFO: ==============================================
+1 day, 19:50:39.123410 INFO: Starting optimization step 7.
+1 day, 19:50:39.123477 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:39.123540 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:39.129758 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:39.129834 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:39.129874 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 19:50:39.129895 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:50:39.131897 INFO: Starting candidate selection
+1 day, 19:50:40.788574 INFO: Starting candidate scoring
+1 day, 19:50:41.776919 INFO: Finished candidate processing
+1 day, 19:50:41.777040 INFO: Collecting candidate features
+1 day, 19:50:41.826284 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30189)
+1 day, 19:50:41.833348 INFO: Collecting fragment features
+1 day, 19:50:41.851540 INFO: Finished candidate scoring
+1 day, 19:50:41.864722 PROGRESS: === Extracted 30189 precursors and 318083 fragments ===
+1 day, 19:50:41.865113 INFO: performing precursor FDR with 47 features
+1 day, 19:50:41.865152 INFO: Decoy channel: -1
+1 day, 19:50:41.865177 INFO: Competetive: True
+1 day, 19:50:41.873084 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:41.878031 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:50:41.878134 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:50:42.143552 INFO: Test AUC: 0.874
+1 day, 19:50:42.143678 INFO: Train AUC: 0.879
+1 day, 19:50:42.143713 INFO: AUC difference: 0.56%
+1 day, 19:50:42.230063 INFO: Resetting torch num_threads to 100
+1 day, 19:50:42.231183 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:42.232625 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:42.232724 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:42.232789 PROGRESS: Target precursors: 7,875 (98.44%)
+1 day, 19:50:42.232845 PROGRESS: Decoy precursors: 125 (1.56%)
+1 day, 19:50:42.232894 PROGRESS: 
+1 day, 19:50:42.232944 PROGRESS: Precursor Summary:
+1 day, 19:50:42.235955 PROGRESS: Channel   0:	 0.05 FDR: 7,875; 0.01 FDR: 7,783; 0.001 FDR: 7,507
+1 day, 19:50:42.236080 PROGRESS: 
+1 day, 19:50:42.236141 PROGRESS: Protein Summary:
+1 day, 19:50:42.240685 PROGRESS: Channel   0:	 0.05 FDR: 4,179; 0.01 FDR: 4,150; 0.001 FDR: 4,031
+1 day, 19:50:42.240807 PROGRESS: =========================================================================
+1 day, 19:50:42.264311 INFO: fragments_df_filtered: 5000
+1 day, 19:50:42.278630 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:43.135367 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:44.006860 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:44.861576 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:45.278763 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:45.281594 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:45.290730 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:45.293083 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:45.312284 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:45.312454 PROGRESS: === Optimization of rt_error has been performed 8 time(s); minimum number is 2 ===
+1 day, 19:50:45.318868 PROGRESS: ❌ rt_error       : optimization incomplete after 8 search(es). Will search with parameter 10.1362.
+1 day, 19:50:45.318937 INFO: ==============================================
+1 day, 19:50:45.319047 INFO: Starting optimization step 8.
+1 day, 19:50:45.319126 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:45.319197 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:45.325912 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:45.325987 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:45.326030 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 19:50:45.326059 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:50:45.329316 INFO: Starting candidate selection
+1 day, 19:50:46.950712 INFO: Starting candidate scoring
+1 day, 19:50:47.931984 INFO: Finished candidate processing
+1 day, 19:50:47.932118 INFO: Collecting candidate features
+1 day, 19:50:47.986006 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30194)
+1 day, 19:50:47.990741 INFO: Collecting fragment features
+1 day, 19:50:48.010271 INFO: Finished candidate scoring
+1 day, 19:50:48.025697 PROGRESS: === Extracted 30194 precursors and 318227 fragments ===
+1 day, 19:50:48.026166 INFO: performing precursor FDR with 47 features
+1 day, 19:50:48.026205 INFO: Decoy channel: -1
+1 day, 19:50:48.026229 INFO: Competetive: True
+1 day, 19:50:48.036963 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:48.043071 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:50:48.043196 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 19:50:48.483577 INFO: Test AUC: 0.878
+1 day, 19:50:48.483737 INFO: Train AUC: 0.878
+1 day, 19:50:48.483767 INFO: AUC difference: 0.00%
+1 day, 19:50:48.575533 INFO: Resetting torch num_threads to 100
+1 day, 19:50:48.577220 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:50:48.578874 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:48.578983 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:48.579045 PROGRESS: Target precursors: 7,878 (98.47%)
+1 day, 19:50:48.579098 PROGRESS: Decoy precursors: 122 (1.52%)
+1 day, 19:50:48.579149 PROGRESS: 
+1 day, 19:50:48.579197 PROGRESS: Precursor Summary:
+1 day, 19:50:48.582463 PROGRESS: Channel   0:	 0.05 FDR: 7,878; 0.01 FDR: 7,783; 0.001 FDR: 7,485
+1 day, 19:50:48.582605 PROGRESS: 
+1 day, 19:50:48.582664 PROGRESS: Protein Summary:
+1 day, 19:50:48.587537 PROGRESS: Channel   0:	 0.05 FDR: 4,176; 0.01 FDR: 4,149; 0.001 FDR: 4,019
+1 day, 19:50:48.587651 PROGRESS: =========================================================================
+1 day, 19:50:48.614114 INFO: fragments_df_filtered: 5000
+1 day, 19:50:48.634739 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:49.428640 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:50.233302 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:51.077490 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:51.431404 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:51.435629 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:51.446175 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:51.449629 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:51.468088 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:51.468280 PROGRESS: === Optimization of rt_error has been performed 9 time(s); minimum number is 2 ===
+1 day, 19:50:51.469567 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 9.1265 found after 9 searches.
+1 day, 19:50:51.469622 INFO: ==============================================
+1 day, 19:50:51.469723 PROGRESS: Optimization finished for rt_error.
+1 day, 19:50:51.488660 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:51.491689 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:51.500975 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:51.503350 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:51.549114 INFO: Starting optimization step 0.
+1 day, 19:50:51.549327 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:51.549400 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:51.555964 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:51.556036 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:51.556075 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 19:50:51.556098 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:50:51.565057 INFO: Starting candidate selection
+1 day, 19:50:53.208586 INFO: Starting candidate scoring
+1 day, 19:50:54.195127 INFO: Finished candidate processing
+1 day, 19:50:54.195234 INFO: Collecting candidate features
+1 day, 19:50:54.243560 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30176)
+1 day, 19:50:54.247947 INFO: Collecting fragment features
+1 day, 19:50:54.266649 INFO: Finished candidate scoring
+1 day, 19:50:54.279831 PROGRESS: === Extracted 30176 precursors and 318081 fragments ===
+1 day, 19:50:54.280202 INFO: performing precursor FDR with 47 features
+1 day, 19:50:54.280240 INFO: Decoy channel: -1
+1 day, 19:50:54.280265 INFO: Competetive: True
+1 day, 19:50:54.288108 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:50:54.292889 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:50:54.292985 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 19:50:54.658222 INFO: Test AUC: 0.884
+1 day, 19:50:54.658345 INFO: Train AUC: 0.887
+1 day, 19:50:54.658374 INFO: AUC difference: 0.36%
+1 day, 19:50:54.744843 INFO: Resetting torch num_threads to 100
+1 day, 19:50:54.746023 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 19:50:54.747460 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:50:54.747568 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:50:54.747630 PROGRESS: Target precursors: 7,870 (98.38%)
+1 day, 19:50:54.747684 PROGRESS: Decoy precursors: 130 (1.62%)
+1 day, 19:50:54.747729 PROGRESS: 
+1 day, 19:50:54.747777 PROGRESS: Precursor Summary:
+1 day, 19:50:54.750779 PROGRESS: Channel   0:	 0.05 FDR: 7,870; 0.01 FDR: 7,773; 0.001 FDR: 7,500
+1 day, 19:50:54.750900 PROGRESS: 
+1 day, 19:50:54.750959 PROGRESS: Protein Summary:
+1 day, 19:50:54.755492 PROGRESS: Channel   0:	 0.05 FDR: 4,175; 0.01 FDR: 4,136; 0.001 FDR: 4,029
+1 day, 19:50:54.755608 PROGRESS: =========================================================================
+1 day, 19:50:54.780379 INFO: fragments_df_filtered: 5000
+1 day, 19:50:54.795511 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:50:55.646453 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:50:56.488163 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:50:57.275957 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:50:57.626155 INFO: calibration group: precursor, predicting mz
+1 day, 19:50:57.628988 INFO: calibration group: precursor, predicting rt
+1 day, 19:50:57.639149 INFO: calibration group: precursor, predicting mobility
+1 day, 19:50:57.641800 INFO: calibration group: fragment, predicting mz
+1 day, 19:50:57.660379 INFO: === checking if optimization conditions were reached ===
+1 day, 19:50:57.660548 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:50:57.663521 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0580.
+1 day, 19:50:57.663587 INFO: ==============================================
+1 day, 19:50:57.663694 INFO: Starting optimization step 1.
+1 day, 19:50:57.663767 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:50:57.663833 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:50:57.670792 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:50:57.670872 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:50:57.670915 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 19:50:57.670942 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:50:57.672138 INFO: Starting candidate selection
+1 day, 19:50:59.053768 INFO: Starting candidate scoring
+1 day, 19:51:00.035157 INFO: Finished candidate processing
+1 day, 19:51:00.036549 INFO: Collecting candidate features
+1 day, 19:51:00.086296 WARNING: intensity_correlation has 12 NaNs ( 0.04 % out of 30152)
+1 day, 19:51:00.093353 INFO: Collecting fragment features
+1 day, 19:51:00.112661 INFO: Finished candidate scoring
+1 day, 19:51:00.125255 PROGRESS: === Extracted 30152 precursors and 314870 fragments ===
+1 day, 19:51:00.125642 INFO: performing precursor FDR with 47 features
+1 day, 19:51:00.125685 INFO: Decoy channel: -1
+1 day, 19:51:00.125712 INFO: Competetive: True
+1 day, 19:51:00.134008 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:51:00.138681 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:51:00.138773 WARNING: dropped 10 decoy PSMs due to missing features
+1 day, 19:51:00.404924 INFO: Test AUC: 0.880
+1 day, 19:51:00.405058 INFO: Train AUC: 0.889
+1 day, 19:51:00.405090 INFO: AUC difference: 1.01%
+1 day, 19:51:00.490184 INFO: Resetting torch num_threads to 100
+1 day, 19:51:00.491295 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 19:51:00.492609 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:51:00.492705 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:51:00.492767 PROGRESS: Target precursors: 7,870 (98.40%)
+1 day, 19:51:00.492822 PROGRESS: Decoy precursors: 128 (1.60%)
+1 day, 19:51:00.492870 PROGRESS: 
+1 day, 19:51:00.492917 PROGRESS: Precursor Summary:
+1 day, 19:51:00.495884 PROGRESS: Channel   0:	 0.05 FDR: 7,870; 0.01 FDR: 7,773; 0.001 FDR: 7,557
+1 day, 19:51:00.495999 PROGRESS: 
+1 day, 19:51:00.496070 PROGRESS: Protein Summary:
+1 day, 19:51:00.500528 PROGRESS: Channel   0:	 0.05 FDR: 4,180; 0.01 FDR: 4,143; 0.001 FDR: 4,056
+1 day, 19:51:00.500633 PROGRESS: =========================================================================
+1 day, 19:51:00.525269 INFO: fragments_df_filtered: 5000
+1 day, 19:51:00.540111 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:51:01.328296 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:51:02.137085 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:51:02.928044 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:51:03.279823 INFO: calibration group: precursor, predicting mz
+1 day, 19:51:03.283716 INFO: calibration group: precursor, predicting rt
+1 day, 19:51:03.294012 INFO: calibration group: precursor, predicting mobility
+1 day, 19:51:03.297488 INFO: calibration group: fragment, predicting mz
+1 day, 19:51:03.315891 INFO: === checking if optimization conditions were reached ===
+1 day, 19:51:03.316069 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:51:03.319624 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0511.
+1 day, 19:51:03.319689 INFO: ==============================================
+1 day, 19:51:03.319797 INFO: Starting optimization step 2.
+1 day, 19:51:03.319880 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:51:03.319952 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:51:03.325833 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:51:03.325903 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:51:03.325947 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:51:03.325974 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.85
+1 day, 19:51:03.327065 INFO: Starting candidate selection
+1 day, 19:51:04.657076 INFO: Starting candidate scoring
+1 day, 19:51:05.649836 INFO: Finished candidate processing
+1 day, 19:51:05.649940 INFO: Collecting candidate features
+1 day, 19:51:05.697861 WARNING: intensity_correlation has 14 NaNs ( 0.05 % out of 30129)
+1 day, 19:51:05.702177 INFO: Collecting fragment features
+1 day, 19:51:05.720438 INFO: Finished candidate scoring
+1 day, 19:51:05.733235 PROGRESS: === Extracted 30129 precursors and 313341 fragments ===
+1 day, 19:51:05.733608 INFO: performing precursor FDR with 47 features
+1 day, 19:51:05.733646 INFO: Decoy channel: -1
+1 day, 19:51:05.733669 INFO: Competetive: True
+1 day, 19:51:05.741474 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:51:05.746376 WARNING: dropped 3 target PSMs due to missing features
+1 day, 19:51:05.746474 WARNING: dropped 11 decoy PSMs due to missing features
+1 day, 19:51:06.009642 INFO: Test AUC: 0.881
+1 day, 19:51:06.009767 INFO: Train AUC: 0.888
+1 day, 19:51:06.009797 INFO: AUC difference: 0.79%
+1 day, 19:51:06.094427 INFO: Resetting torch num_threads to 100
+1 day, 19:51:06.095534 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 19:51:06.096934 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:51:06.097046 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:51:06.097111 PROGRESS: Target precursors: 7,867 (98.36%)
+1 day, 19:51:06.097165 PROGRESS: Decoy precursors: 131 (1.64%)
+1 day, 19:51:06.097212 PROGRESS: 
+1 day, 19:51:06.097258 PROGRESS: Precursor Summary:
+1 day, 19:51:06.100744 PROGRESS: Channel   0:	 0.05 FDR: 7,867; 0.01 FDR: 7,764; 0.001 FDR: 7,527
+1 day, 19:51:06.100874 PROGRESS: 
+1 day, 19:51:06.100932 PROGRESS: Protein Summary:
+1 day, 19:51:06.105485 PROGRESS: Channel   0:	 0.05 FDR: 4,174; 0.01 FDR: 4,143; 0.001 FDR: 4,048
+1 day, 19:51:06.105604 PROGRESS: =========================================================================
+1 day, 19:51:06.129880 INFO: fragments_df_filtered: 5000
+1 day, 19:51:06.145095 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:51:06.942702 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:51:07.744137 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:51:08.527849 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:51:08.881593 INFO: calibration group: precursor, predicting mz
+1 day, 19:51:08.885730 INFO: calibration group: precursor, predicting rt
+1 day, 19:51:08.896113 INFO: calibration group: precursor, predicting mobility
+1 day, 19:51:08.899573 INFO: calibration group: fragment, predicting mz
+1 day, 19:51:08.918859 INFO: === checking if optimization conditions were reached ===
+1 day, 19:51:08.919032 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:51:08.919810 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0580 found after 3 searches.
+1 day, 19:51:08.919860 INFO: ==============================================
+1 day, 19:51:08.919948 PROGRESS: Optimization finished for mobility_error.
+1 day, 19:51:08.935481 INFO: calibration group: precursor, predicting mz
+1 day, 19:51:08.938257 INFO: calibration group: precursor, predicting rt
+1 day, 19:51:08.947403 INFO: calibration group: precursor, predicting mobility
+1 day, 19:51:08.949810 INFO: calibration group: fragment, predicting mz
+1 day, 19:51:08.994758 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 19:51:08.994928 PROGRESS: ==============================================
+1 day, 19:51:08.995004 PROGRESS: ms2_error      : 15.0000
+1 day, 19:51:08.995065 PROGRESS: ms1_error      : 10.0000
+1 day, 19:51:08.995116 PROGRESS: rt_error       : 9.1265
+1 day, 19:51:08.995170 PROGRESS: mobility_error : 0.0580
+1 day, 19:51:08.995217 PROGRESS: ==============================================
+1 day, 19:51:08.996144 INFO: calibration group: precursor, predicting mz
+1 day, 19:51:09.015337 INFO: calibration group: precursor, predicting rt
+1 day, 19:51:09.101366 INFO: calibration group: precursor, predicting mobility
+1 day, 19:51:09.121948 INFO: calibration group: fragment, predicting mz
+1 day, 19:51:09.350402 PROGRESS: Extracting batch of 162861 precursors
+1 day, 19:51:09.386825 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:51:09.386959 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:51:09.387006 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:51:09.387031 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.85
+1 day, 19:51:09.387826 INFO: Starting candidate selection
+1 day, 19:51:18.309169 INFO: Applying score cutoff of 26.016138496398927
+1 day, 19:51:18.314803 INFO: Removed 22862 precursors with score below cutoff
+1 day, 19:51:18.629242 INFO: Starting candidate scoring
+1 day, 19:51:27.342467 INFO: Finished candidate processing
+1 day, 19:51:27.342679 INFO: Collecting candidate features
+1 day, 19:51:27.951005 WARNING: intensity_correlation has 3 NaNs ( 0.00 % out of 286815)
+1 day, 19:51:27.971844 INFO: Collecting fragment features
+1 day, 19:51:28.172430 INFO: Finished candidate scoring
+1 day, 19:51:28.375979 INFO: === FDR correction performed with classifier version 13 ===
+1 day, 19:51:28.376985 INFO: performing precursor FDR with 47 features
+1 day, 19:51:28.377038 INFO: Decoy channel: -1
+1 day, 19:51:28.377070 INFO: Competetive: True
+1 day, 19:51:28.494842 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:51:28.545151 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:51:28.545320 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 19:51:28.545374 WARNING: FDR calculation for 152687 target and 134125 decoy PSMs
+1 day, 19:51:28.545409 WARNING: FDR calculation may be inaccurate as there is more than 10% difference in the number of target and decoy PSMs
+1 day, 19:51:34.485090 INFO: Test AUC: 0.902
+1 day, 19:51:34.485319 INFO: Train AUC: 0.906
+1 day, 19:51:34.485353 INFO: AUC difference: 0.41%
+1 day, 19:51:36.443337 INFO: Resetting torch num_threads to 100
+1 day, 19:51:36.463793 INFO: Removing fragments below FDR threshold
+1 day, 19:51:36.521595 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:51:36.521901 PROGRESS: Total precursors accumulated: 80,613
+1 day, 19:51:36.521970 PROGRESS: Target precursors: 79,815 (99.01%)
+1 day, 19:51:36.522025 PROGRESS: Decoy precursors: 798 (0.99%)
+1 day, 19:51:36.522078 PROGRESS: 
+1 day, 19:51:36.522126 PROGRESS: Precursor Summary:
+1 day, 19:51:36.568316 PROGRESS: Channel   0:	 0.05 FDR: 79,815; 0.01 FDR: 79,815; 0.001 FDR: 78,057
+1 day, 19:51:36.568643 PROGRESS: 
+1 day, 19:51:36.568710 PROGRESS: Protein Summary:
+1 day, 19:51:36.626976 PROGRESS: Channel   0:	 0.05 FDR: 8,243; 0.01 FDR: 8,243; 0.001 FDR: 8,214
+1 day, 19:51:36.627243 PROGRESS: =========================================================================
+1 day, 19:51:37.307483 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 19:51:37.350827 PROGRESS: Loading raw file 3/6: ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:51:37.350972 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 19:51:37.351050 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:51:37.351933 INFO: Initializing RawFileManager
+1 day, 19:51:37.352131 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:37.352176 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:37.352207 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:37.564970 INFO: Reading 39,128 frames with 2,897,842,446 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.490737 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d...
+1 day, 19:51:44.493387 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.496752 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.496971 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.497339 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.499176 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.514564 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:44.514833 INFO: Indexing quadrupole dimension
+1 day, 19:51:45.000812 INFO: Transposing detector events
+1 day, 19:51:55.370965 INFO: Finished transposing data
+1 day, 19:51:55.412190 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d
+1 day, 19:51:55.413164 INFO: RT (min)            : 0.0 - 70.0
+1 day, 19:51:55.413265 INFO: RT duration (sec)   : 4199.8
+1 day, 19:51:55.413325 INFO: RT duration (min)   : 70.0
+1 day, 19:51:55.413375 INFO: Cycle len (scans)   : 9
+1 day, 19:51:55.413422 INFO: Cycle len (sec)     : 0.97
+1 day, 19:51:55.413466 INFO: Number of cycles    : 4347
+1 day, 19:51:55.413510 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 19:51:55.445507 INFO: Initializing CalibrationManager
+1 day, 19:51:55.445873 INFO: Loading calibration config
+1 day, 19:51:55.446307 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 19:51:55.446411 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 19:51:55.446484 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 19:51:55.446606 INFO: Initializing OptimizationManager
+1 day, 19:51:55.446816 INFO: initial parameter: ms1_error = 30
+1 day, 19:51:55.446867 INFO: initial parameter: ms2_error = 30
+1 day, 19:51:55.446925 INFO: initial parameter: rt_error = 2099.8992935
+1 day, 19:51:55.446973 INFO: initial parameter: mobility_error = 0.1
+1 day, 19:51:55.447019 INFO: initial parameter: column_type = library
+1 day, 19:51:55.447065 INFO: initial parameter: num_candidates = 1
+1 day, 19:51:55.447109 INFO: initial parameter: classifier_version = -1
+1 day, 19:51:55.447150 INFO: initial parameter: fwhm_rt = 5
+1 day, 19:51:55.447193 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 19:51:55.447238 INFO: initial parameter: score_cutoff = 0
+1 day, 19:51:55.447293 INFO: Initializing TimingManager
+1 day, 19:51:55.447344 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:51:55.447410 INFO: FDRManager not loaded from disk.
+1 day, 19:51:55.447433 INFO: Initializing FDRManager
+1 day, 19:51:55.447461 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 19:51:55.478938 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 19:51:55.524686 PROGRESS: Starting initial search for precursors.
+1 day, 19:51:55.545438 INFO: Starting optimization step 0.
+1 day, 19:51:55.545687 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:51:55.545758 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:51:55.549128 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:51:55.549187 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:51:55.549218 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 19:51:55.549240 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 19:51:55.550279 INFO: Starting candidate selection
+1 day, 19:53:21.408617 INFO: Starting candidate scoring
+1 day, 19:53:22.496296 INFO: Finished candidate processing
+1 day, 19:53:22.496400 INFO: Collecting candidate features
+1 day, 19:53:22.538127 INFO: Collecting fragment features
+1 day, 19:53:22.555557 INFO: Finished candidate scoring
+1 day, 19:53:22.565518 PROGRESS: === Extracted 15886 precursors and 175807 fragments ===
+1 day, 19:53:22.565955 INFO: performing precursor FDR with 47 features
+1 day, 19:53:22.565994 INFO: Decoy channel: -1
+1 day, 19:53:22.566017 INFO: Competetive: True
+1 day, 19:53:22.572173 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:53:22.749400 INFO: Test AUC: 0.827
+1 day, 19:53:22.749505 INFO: Train AUC: 0.828
+1 day, 19:53:22.749535 INFO: AUC difference: 0.15%
+1 day, 19:53:22.836945 INFO: Resetting torch num_threads to 100
+1 day, 19:53:22.838094 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 19:53:22.839724 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:53:22.839846 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:53:22.839931 PROGRESS: Target precursors: 6,638 (82.97%)
+1 day, 19:53:22.839997 PROGRESS: Decoy precursors: 1,362 (17.03%)
+1 day, 19:53:22.840049 PROGRESS: 
+1 day, 19:53:22.840110 PROGRESS: Precursor Summary:
+1 day, 19:53:22.842792 PROGRESS: Channel   0:	 0.05 FDR: 5,248; 0.01 FDR: 3,683; 0.001 FDR: 1,694
+1 day, 19:53:22.842919 PROGRESS: 
+1 day, 19:53:22.842981 PROGRESS: Protein Summary:
+1 day, 19:53:22.845938 PROGRESS: Channel   0:	 0.05 FDR: 3,051; 0.01 FDR: 2,306; 0.001 FDR: 1,195
+1 day, 19:53:22.846070 PROGRESS: =========================================================================
+1 day, 19:53:22.854603 INFO: fragments_df_filtered: 5000
+1 day, 19:53:22.876797 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:53:23.156697 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:53:23.446328 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:53:23.722043 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:53:24.087529 INFO: calibration group: precursor, predicting mz
+1 day, 19:53:24.090389 INFO: calibration group: precursor, predicting rt
+1 day, 19:53:24.100187 INFO: calibration group: precursor, predicting mobility
+1 day, 19:53:24.102560 INFO: calibration group: fragment, predicting mz
+1 day, 19:53:24.121323 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 19:53:24.121510 INFO: Starting optimization step 1.
+1 day, 19:53:24.121594 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:53:24.121669 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:53:24.127301 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:53:24.127365 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:53:24.127414 INFO: FWHM in RT is 3.32 seconds, sigma is 0.73
+1 day, 19:53:24.127443 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.22
+1 day, 19:53:24.128702 INFO: Starting candidate selection
+1 day, 19:55:00.061119 INFO: Starting candidate scoring
+1 day, 19:55:02.074783 INFO: Finished candidate processing
+1 day, 19:55:02.074890 INFO: Collecting candidate features
+1 day, 19:55:02.133122 INFO: Collecting fragment features
+1 day, 19:55:02.154878 INFO: Finished candidate scoring
+1 day, 19:55:02.169922 PROGRESS: === Extracted 30475 precursors and 337252 fragments ===
+1 day, 19:55:02.170378 INFO: performing precursor FDR with 47 features
+1 day, 19:55:02.170418 INFO: Decoy channel: -1
+1 day, 19:55:02.170442 INFO: Competetive: True
+1 day, 19:55:02.181816 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:55:02.562007 INFO: Test AUC: 0.745
+1 day, 19:55:02.562133 INFO: Train AUC: 0.745
+1 day, 19:55:02.562162 INFO: AUC difference: 0.05%
+1 day, 19:55:02.652434 INFO: Resetting torch num_threads to 100
+1 day, 19:55:02.653721 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 19:55:02.655179 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:55:02.655288 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:55:02.655351 PROGRESS: Target precursors: 6,985 (87.31%)
+1 day, 19:55:02.655403 PROGRESS: Decoy precursors: 1,015 (12.69%)
+1 day, 19:55:02.655448 PROGRESS: 
+1 day, 19:55:02.655493 PROGRESS: Precursor Summary:
+1 day, 19:55:02.657863 PROGRESS: Channel   0:	 0.05 FDR: 5,907; 0.01 FDR: 4,585; 0.001 FDR: 2,430
+1 day, 19:55:02.657986 PROGRESS: 
+1 day, 19:55:02.658053 PROGRESS: Protein Summary:
+1 day, 19:55:02.661252 PROGRESS: Channel   0:	 0.05 FDR: 3,365; 0.01 FDR: 2,740; 0.001 FDR: 1,638
+1 day, 19:55:02.661367 PROGRESS: =========================================================================
+1 day, 19:55:02.678955 INFO: fragments_df_filtered: 5000
+1 day, 19:55:02.702290 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:55:03.073377 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:55:03.453094 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:55:03.822122 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:55:04.242718 INFO: calibration group: precursor, predicting mz
+1 day, 19:55:04.245491 INFO: calibration group: precursor, predicting rt
+1 day, 19:55:04.255255 INFO: calibration group: precursor, predicting mobility
+1 day, 19:55:04.257522 INFO: calibration group: fragment, predicting mz
+1 day, 19:55:04.275270 INFO: === checking if optimization conditions were reached ===
+1 day, 19:55:04.277071 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 19:55:04.278632 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 19:55:04.278683 INFO: ==============================================
+1 day, 19:55:04.278776 INFO: Starting optimization step 2.
+1 day, 19:55:04.278842 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:55:04.278906 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:55:04.282852 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:55:04.282914 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:55:04.282957 INFO: FWHM in RT is 3.21 seconds, sigma is 0.71
+1 day, 19:55:04.282982 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.03
+1 day, 19:55:04.284146 INFO: Starting candidate selection
+1 day, 19:56:31.967296 INFO: Starting candidate scoring
+1 day, 19:56:33.059349 INFO: Finished candidate processing
+1 day, 19:56:33.059452 INFO: Collecting candidate features
+1 day, 19:56:33.114378 INFO: Collecting fragment features
+1 day, 19:56:33.136556 INFO: Finished candidate scoring
+1 day, 19:56:33.151942 PROGRESS: === Extracted 30536 precursors and 333655 fragments ===
+1 day, 19:56:33.152391 INFO: performing precursor FDR with 47 features
+1 day, 19:56:33.152429 INFO: Decoy channel: -1
+1 day, 19:56:33.152452 INFO: Competetive: True
+1 day, 19:56:33.162849 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:56:33.475858 INFO: Test AUC: 0.792
+1 day, 19:56:33.475981 INFO: Train AUC: 0.794
+1 day, 19:56:33.476011 INFO: AUC difference: 0.30%
+1 day, 19:56:33.564693 INFO: Resetting torch num_threads to 100
+1 day, 19:56:33.565971 INFO: === FDR correction performed with classifier version 1 ===
+1 day, 19:56:33.567437 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:56:33.567557 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:56:33.567620 PROGRESS: Target precursors: 7,477 (93.46%)
+1 day, 19:56:33.567675 PROGRESS: Decoy precursors: 523 (6.54%)
+1 day, 19:56:33.567726 PROGRESS: 
+1 day, 19:56:33.567773 PROGRESS: Precursor Summary:
+1 day, 19:56:33.570680 PROGRESS: Channel   0:	 0.05 FDR: 7,243; 0.01 FDR: 6,660; 0.001 FDR: 5,341
+1 day, 19:56:33.570815 PROGRESS: 
+1 day, 19:56:33.570877 PROGRESS: Protein Summary:
+1 day, 19:56:33.574981 PROGRESS: Channel   0:	 0.05 FDR: 3,916; 0.01 FDR: 3,643; 0.001 FDR: 3,122
+1 day, 19:56:33.575106 PROGRESS: =========================================================================
+1 day, 19:56:33.597773 INFO: fragments_df_filtered: 5000
+1 day, 19:56:33.616789 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:56:34.275874 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:56:34.956814 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:56:35.610902 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:56:36.026573 INFO: calibration group: precursor, predicting mz
+1 day, 19:56:36.029413 INFO: calibration group: precursor, predicting rt
+1 day, 19:56:36.038828 INFO: calibration group: precursor, predicting mobility
+1 day, 19:56:36.041124 INFO: calibration group: fragment, predicting mz
+1 day, 19:56:36.060025 INFO: === checking if optimization conditions were reached ===
+1 day, 19:56:36.061767 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 19:56:36.063607 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 19:56:36.063658 INFO: ==============================================
+1 day, 19:56:36.063758 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 19:56:36.078198 INFO: calibration group: precursor, predicting mz
+1 day, 19:56:36.080988 INFO: calibration group: precursor, predicting rt
+1 day, 19:56:36.090153 INFO: calibration group: precursor, predicting mobility
+1 day, 19:56:36.092447 INFO: calibration group: fragment, predicting mz
+1 day, 19:56:36.112276 INFO: Starting optimization step 0.
+1 day, 19:56:36.112426 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:56:36.112500 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:56:36.116360 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:56:36.117711 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:56:36.117772 INFO: FWHM in RT is 2.92 seconds, sigma is 0.64
+1 day, 19:56:36.117798 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.07
+1 day, 19:56:36.126810 INFO: Starting candidate selection
+1 day, 19:58:01.277847 INFO: Starting candidate scoring
+1 day, 19:58:02.377483 INFO: Finished candidate processing
+1 day, 19:58:02.377587 INFO: Collecting candidate features
+1 day, 19:58:02.437191 INFO: Collecting fragment features
+1 day, 19:58:02.459579 INFO: Finished candidate scoring
+1 day, 19:58:02.473660 PROGRESS: === Extracted 30459 precursors and 332453 fragments ===
+1 day, 19:58:02.474121 INFO: performing precursor FDR with 47 features
+1 day, 19:58:02.474161 INFO: Decoy channel: -1
+1 day, 19:58:02.474184 INFO: Competetive: True
+1 day, 19:58:02.484531 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:02.856808 INFO: Test AUC: 0.797
+1 day, 19:58:02.856934 INFO: Train AUC: 0.808
+1 day, 19:58:02.856965 INFO: AUC difference: 1.40%
+1 day, 19:58:02.947270 INFO: Resetting torch num_threads to 100
+1 day, 19:58:02.948512 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:02.949950 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:02.950059 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:58:02.950125 PROGRESS: Target precursors: 7,506 (93.83%)
+1 day, 19:58:02.950179 PROGRESS: Decoy precursors: 494 (6.17%)
+1 day, 19:58:02.950229 PROGRESS: 
+1 day, 19:58:02.950277 PROGRESS: Precursor Summary:
+1 day, 19:58:02.953202 PROGRESS: Channel   0:	 0.05 FDR: 7,301; 0.01 FDR: 6,742; 0.001 FDR: 5,953
+1 day, 19:58:02.953329 PROGRESS: 
+1 day, 19:58:02.953389 PROGRESS: Protein Summary:
+1 day, 19:58:02.957594 PROGRESS: Channel   0:	 0.05 FDR: 3,949; 0.01 FDR: 3,687; 0.001 FDR: 3,381
+1 day, 19:58:02.957714 PROGRESS: =========================================================================
+1 day, 19:58:02.980383 INFO: fragments_df_filtered: 5000
+1 day, 19:58:02.999989 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:03.615565 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:04.249746 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:04.920560 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:05.338067 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:05.340897 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:05.350104 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:05.352399 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:05.371139 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:05.371307 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:58:05.376450 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 175.4556.
+1 day, 19:58:05.376512 INFO: ==============================================
+1 day, 19:58:05.376624 INFO: Starting optimization step 1.
+1 day, 19:58:05.376703 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:05.376781 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:05.381019 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:05.381099 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:05.381148 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 19:58:05.381178 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.04
+1 day, 19:58:05.382350 INFO: Starting candidate selection
+1 day, 19:58:13.707395 INFO: Starting candidate scoring
+1 day, 19:58:14.705848 INFO: Finished candidate processing
+1 day, 19:58:14.705954 INFO: Collecting candidate features
+1 day, 19:58:14.755768 WARNING: intensity_correlation has 3 NaNs ( 0.01 % out of 30390)
+1 day, 19:58:14.760307 INFO: Collecting fragment features
+1 day, 19:58:14.779109 INFO: Finished candidate scoring
+1 day, 19:58:14.793765 PROGRESS: === Extracted 30390 precursors and 327013 fragments ===
+1 day, 19:58:14.794137 INFO: performing precursor FDR with 47 features
+1 day, 19:58:14.794181 INFO: Decoy channel: -1
+1 day, 19:58:14.794209 INFO: Competetive: True
+1 day, 19:58:14.802740 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:14.806727 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 19:58:15.177042 INFO: Test AUC: 0.833
+1 day, 19:58:15.177171 INFO: Train AUC: 0.835
+1 day, 19:58:15.177205 INFO: AUC difference: 0.23%
+1 day, 19:58:15.266223 INFO: Resetting torch num_threads to 100
+1 day, 19:58:15.267396 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:15.268946 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:15.269054 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:58:15.269128 PROGRESS: Target precursors: 7,755 (96.94%)
+1 day, 19:58:15.269190 PROGRESS: Decoy precursors: 245 (3.06%)
+1 day, 19:58:15.269246 PROGRESS: 
+1 day, 19:58:15.269303 PROGRESS: Precursor Summary:
+1 day, 19:58:15.272305 PROGRESS: Channel   0:	 0.05 FDR: 7,755; 0.01 FDR: 7,452; 0.001 FDR: 6,354
+1 day, 19:58:15.272431 PROGRESS: 
+1 day, 19:58:15.272506 PROGRESS: Protein Summary:
+1 day, 19:58:15.276917 PROGRESS: Channel   0:	 0.05 FDR: 4,125; 0.01 FDR: 4,001; 0.001 FDR: 3,573
+1 day, 19:58:15.277045 PROGRESS: =========================================================================
+1 day, 19:58:15.303449 INFO: fragments_df_filtered: 5000
+1 day, 19:58:15.318419 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:16.112161 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:16.934922 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:17.727498 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:18.144411 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:18.147346 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:18.156600 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:18.158972 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:18.178075 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:18.178231 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:58:18.183799 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 49.7477.
+1 day, 19:58:18.183865 INFO: ==============================================
+1 day, 19:58:18.183967 INFO: Starting optimization step 2.
+1 day, 19:58:18.184041 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:18.184105 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:18.188192 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:18.188256 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:18.188296 INFO: FWHM in RT is 2.89 seconds, sigma is 0.63
+1 day, 19:58:18.188322 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 3.96
+1 day, 19:58:18.189599 INFO: Starting candidate selection
+1 day, 19:58:21.408197 INFO: Starting candidate scoring
+1 day, 19:58:22.393254 INFO: Finished candidate processing
+1 day, 19:58:22.393389 INFO: Collecting candidate features
+1 day, 19:58:22.454340 WARNING: intensity_correlation has 5 NaNs ( 0.02 % out of 30341)
+1 day, 19:58:22.465133 INFO: Collecting fragment features
+1 day, 19:58:22.485609 INFO: Finished candidate scoring
+1 day, 19:58:22.501759 PROGRESS: === Extracted 30341 precursors and 323951 fragments ===
+1 day, 19:58:22.502199 INFO: performing precursor FDR with 47 features
+1 day, 19:58:22.502235 INFO: Decoy channel: -1
+1 day, 19:58:22.502257 INFO: Competetive: True
+1 day, 19:58:22.512646 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:22.517538 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 19:58:22.955278 INFO: Test AUC: 0.856
+1 day, 19:58:22.955437 INFO: Train AUC: 0.852
+1 day, 19:58:22.955468 INFO: AUC difference: 0.45%
+1 day, 19:58:23.053991 INFO: Resetting torch num_threads to 100
+1 day, 19:58:23.055728 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:23.058464 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:23.058585 PROGRESS: Total precursors accumulated: 8,000
+1 day, 19:58:23.058652 PROGRESS: Target precursors: 7,846 (98.08%)
+1 day, 19:58:23.058709 PROGRESS: Decoy precursors: 154 (1.93%)
+1 day, 19:58:23.058757 PROGRESS: 
+1 day, 19:58:23.058803 PROGRESS: Precursor Summary:
+1 day, 19:58:23.062355 PROGRESS: Channel   0:	 0.05 FDR: 7,846; 0.01 FDR: 7,698; 0.001 FDR: 7,130
+1 day, 19:58:23.062485 PROGRESS: 
+1 day, 19:58:23.062542 PROGRESS: Protein Summary:
+1 day, 19:58:23.067459 PROGRESS: Channel   0:	 0.05 FDR: 4,158; 0.01 FDR: 4,103; 0.001 FDR: 3,867
+1 day, 19:58:23.067579 PROGRESS: =========================================================================
+1 day, 19:58:23.096482 INFO: fragments_df_filtered: 5000
+1 day, 19:58:23.115934 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:23.894653 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:24.709196 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:25.489088 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:25.844413 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:25.847649 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:25.857297 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:25.859727 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:25.879464 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:25.879652 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:58:25.886327 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 20.6882.
+1 day, 19:58:25.886405 INFO: ==============================================
+1 day, 19:58:25.886528 INFO: Starting optimization step 3.
+1 day, 19:58:25.886604 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:25.886673 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:25.895401 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:25.895480 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:25.895526 INFO: FWHM in RT is 2.88 seconds, sigma is 0.63
+1 day, 19:58:25.895554 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.92
+1 day, 19:58:25.901365 INFO: Starting candidate selection
+1 day, 19:58:27.806497 INFO: Starting candidate scoring
+1 day, 19:58:28.770272 INFO: Finished candidate processing
+1 day, 19:58:28.770379 INFO: Collecting candidate features
+1 day, 19:58:28.820620 WARNING: intensity_correlation has 5 NaNs ( 0.02 % out of 30278)
+1 day, 19:58:28.825135 INFO: Collecting fragment features
+1 day, 19:58:28.843929 INFO: Finished candidate scoring
+1 day, 19:58:28.857480 PROGRESS: === Extracted 30278 precursors and 320733 fragments ===
+1 day, 19:58:28.857858 INFO: performing precursor FDR with 47 features
+1 day, 19:58:28.857897 INFO: Decoy channel: -1
+1 day, 19:58:28.857921 INFO: Competetive: True
+1 day, 19:58:28.866240 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:28.870266 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 19:58:29.233773 INFO: Test AUC: 0.867
+1 day, 19:58:29.233900 INFO: Train AUC: 0.869
+1 day, 19:58:29.233930 INFO: AUC difference: 0.26%
+1 day, 19:58:29.322817 INFO: Resetting torch num_threads to 100
+1 day, 19:58:29.323966 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:29.325398 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:29.325498 PROGRESS: Total precursors accumulated: 7,999
+1 day, 19:58:29.325563 PROGRESS: Target precursors: 7,895 (98.70%)
+1 day, 19:58:29.325619 PROGRESS: Decoy precursors: 104 (1.30%)
+1 day, 19:58:29.325680 PROGRESS: 
+1 day, 19:58:29.325731 PROGRESS: Precursor Summary:
+1 day, 19:58:29.328780 PROGRESS: Channel   0:	 0.05 FDR: 7,895; 0.01 FDR: 7,834; 0.001 FDR: 7,383
+1 day, 19:58:29.328907 PROGRESS: 
+1 day, 19:58:29.328969 PROGRESS: Protein Summary:
+1 day, 19:58:29.333612 PROGRESS: Channel   0:	 0.05 FDR: 4,179; 0.01 FDR: 4,157; 0.001 FDR: 3,971
+1 day, 19:58:29.333732 PROGRESS: =========================================================================
+1 day, 19:58:29.359095 INFO: fragments_df_filtered: 5000
+1 day, 19:58:29.373825 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:30.171364 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:30.982795 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:31.787204 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:32.137752 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:32.140555 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:32.149903 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:32.152224 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:32.171060 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:32.171230 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 19:58:32.177677 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 12.8442.
+1 day, 19:58:32.177744 INFO: ==============================================
+1 day, 19:58:32.177853 INFO: Starting optimization step 4.
+1 day, 19:58:32.177930 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:32.177999 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:32.183678 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:32.183756 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:32.183799 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 19:58:32.183829 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.89
+1 day, 19:58:32.185934 INFO: Starting candidate selection
+1 day, 19:58:33.810374 INFO: Starting candidate scoring
+1 day, 19:58:34.814022 INFO: Finished candidate processing
+1 day, 19:58:34.814124 INFO: Collecting candidate features
+1 day, 19:58:34.864514 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30262)
+1 day, 19:58:34.868926 INFO: Collecting fragment features
+1 day, 19:58:34.887527 INFO: Finished candidate scoring
+1 day, 19:58:34.900395 PROGRESS: === Extracted 30262 precursors and 318638 fragments ===
+1 day, 19:58:34.900767 INFO: performing precursor FDR with 47 features
+1 day, 19:58:34.900805 INFO: Decoy channel: -1
+1 day, 19:58:34.900826 INFO: Competetive: True
+1 day, 19:58:34.908716 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:34.913656 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:58:34.913750 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 19:58:35.282551 INFO: Test AUC: 0.875
+1 day, 19:58:35.282677 INFO: Train AUC: 0.880
+1 day, 19:58:35.282707 INFO: AUC difference: 0.53%
+1 day, 19:58:35.372331 INFO: Resetting torch num_threads to 100
+1 day, 19:58:35.373495 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:35.374953 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:35.375048 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:58:35.375110 PROGRESS: Target precursors: 7,909 (98.89%)
+1 day, 19:58:35.375165 PROGRESS: Decoy precursors: 89 (1.11%)
+1 day, 19:58:35.375214 PROGRESS: 
+1 day, 19:58:35.375261 PROGRESS: Precursor Summary:
+1 day, 19:58:35.378261 PROGRESS: Channel   0:	 0.05 FDR: 7,909; 0.01 FDR: 7,891; 0.001 FDR: 7,456
+1 day, 19:58:35.378399 PROGRESS: 
+1 day, 19:58:35.378463 PROGRESS: Protein Summary:
+1 day, 19:58:35.383058 PROGRESS: Channel   0:	 0.05 FDR: 4,187; 0.01 FDR: 4,182; 0.001 FDR: 4,003
+1 day, 19:58:35.383176 PROGRESS: =========================================================================
+1 day, 19:58:35.408319 INFO: fragments_df_filtered: 5000
+1 day, 19:58:35.422666 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:36.236407 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:37.062000 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:37.876781 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:38.227744 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:38.230625 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:38.239822 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:38.242188 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:38.260725 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:38.260889 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 19:58:38.267398 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 11.3611.
+1 day, 19:58:38.267469 INFO: ==============================================
+1 day, 19:58:38.267585 INFO: Starting optimization step 5.
+1 day, 19:58:38.267661 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:38.267727 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:38.272724 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:38.272795 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:38.272839 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:58:38.272869 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:58:38.274074 INFO: Starting candidate selection
+1 day, 19:58:39.909180 INFO: Starting candidate scoring
+1 day, 19:58:40.891133 INFO: Finished candidate processing
+1 day, 19:58:40.891269 INFO: Collecting candidate features
+1 day, 19:58:40.943188 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30267)
+1 day, 19:58:40.943447 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30267)
+1 day, 19:58:40.947639 INFO: Collecting fragment features
+1 day, 19:58:40.967300 INFO: Finished candidate scoring
+1 day, 19:58:40.980199 PROGRESS: === Extracted 30267 precursors and 318665 fragments ===
+1 day, 19:58:40.980572 INFO: performing precursor FDR with 47 features
+1 day, 19:58:40.980611 INFO: Decoy channel: -1
+1 day, 19:58:40.980634 INFO: Competetive: True
+1 day, 19:58:40.989289 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:40.994228 WARNING: dropped 1 target PSMs due to missing features
+1 day, 19:58:40.994317 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 19:58:41.370378 INFO: Test AUC: 0.878
+1 day, 19:58:41.370503 INFO: Train AUC: 0.877
+1 day, 19:58:41.370534 INFO: AUC difference: 0.06%
+1 day, 19:58:41.459011 INFO: Resetting torch num_threads to 100
+1 day, 19:58:41.460188 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:41.461566 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:41.461675 PROGRESS: Total precursors accumulated: 7,999
+1 day, 19:58:41.461740 PROGRESS: Target precursors: 7,901 (98.77%)
+1 day, 19:58:41.461794 PROGRESS: Decoy precursors: 98 (1.23%)
+1 day, 19:58:41.461843 PROGRESS: 
+1 day, 19:58:41.461888 PROGRESS: Precursor Summary:
+1 day, 19:58:41.464840 PROGRESS: Channel   0:	 0.05 FDR: 7,901; 0.01 FDR: 7,861; 0.001 FDR: 7,512
+1 day, 19:58:41.464962 PROGRESS: 
+1 day, 19:58:41.465030 PROGRESS: Protein Summary:
+1 day, 19:58:41.469555 PROGRESS: Channel   0:	 0.05 FDR: 4,181; 0.01 FDR: 4,174; 0.001 FDR: 4,032
+1 day, 19:58:41.469665 PROGRESS: =========================================================================
+1 day, 19:58:41.493980 INFO: fragments_df_filtered: 5000
+1 day, 19:58:41.508430 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:42.349201 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:43.168699 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:43.973001 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:44.331483 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:44.334818 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:44.344295 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:44.346678 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:44.365927 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:44.366123 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 19:58:44.372714 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 10.7725.
+1 day, 19:58:44.372785 INFO: ==============================================
+1 day, 19:58:44.372912 INFO: Starting optimization step 6.
+1 day, 19:58:44.372999 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:44.373097 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:44.391311 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:44.391397 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:44.391447 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:58:44.391475 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:58:44.400517 INFO: Starting candidate selection
+1 day, 19:58:45.947974 INFO: Starting candidate scoring
+1 day, 19:58:46.930168 INFO: Finished candidate processing
+1 day, 19:58:46.930360 INFO: Collecting candidate features
+1 day, 19:58:46.991089 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30257)
+1 day, 19:58:46.991361 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30257)
+1 day, 19:58:46.995672 INFO: Collecting fragment features
+1 day, 19:58:47.019163 INFO: Finished candidate scoring
+1 day, 19:58:47.032768 PROGRESS: === Extracted 30257 precursors and 318548 fragments ===
+1 day, 19:58:47.033208 INFO: performing precursor FDR with 47 features
+1 day, 19:58:47.033250 INFO: Decoy channel: -1
+1 day, 19:58:47.033274 INFO: Competetive: True
+1 day, 19:58:47.044747 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:47.049845 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:58:47.049928 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:58:47.417100 INFO: Test AUC: 0.874
+1 day, 19:58:47.417222 INFO: Train AUC: 0.877
+1 day, 19:58:47.417253 INFO: AUC difference: 0.34%
+1 day, 19:58:47.506007 INFO: Resetting torch num_threads to 100
+1 day, 19:58:47.507157 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:47.508826 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:47.508925 PROGRESS: Total precursors accumulated: 7,999
+1 day, 19:58:47.508986 PROGRESS: Target precursors: 7,893 (98.67%)
+1 day, 19:58:47.509053 PROGRESS: Decoy precursors: 106 (1.33%)
+1 day, 19:58:47.509103 PROGRESS: 
+1 day, 19:58:47.509148 PROGRESS: Precursor Summary:
+1 day, 19:58:47.512136 PROGRESS: Channel   0:	 0.05 FDR: 7,893; 0.01 FDR: 7,843; 0.001 FDR: 7,356
+1 day, 19:58:47.512248 PROGRESS: 
+1 day, 19:58:47.512306 PROGRESS: Protein Summary:
+1 day, 19:58:47.516864 PROGRESS: Channel   0:	 0.05 FDR: 4,178; 0.01 FDR: 4,166; 0.001 FDR: 3,972
+1 day, 19:58:47.516983 PROGRESS: =========================================================================
+1 day, 19:58:47.542631 INFO: fragments_df_filtered: 5000
+1 day, 19:58:47.560756 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:48.361115 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:49.173265 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:49.974937 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:50.325652 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:50.328431 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:50.337554 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:50.339830 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:50.358408 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:50.358593 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 19:58:50.365105 PROGRESS: ❌ rt_error       : optimization incomplete after 7 search(es). Will search with parameter 10.4040.
+1 day, 19:58:50.365171 INFO: ==============================================
+1 day, 19:58:50.365283 INFO: Starting optimization step 7.
+1 day, 19:58:50.365362 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:50.365433 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:50.371683 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:50.371755 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:50.371807 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:58:50.371836 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:58:50.374623 INFO: Starting candidate selection
+1 day, 19:58:52.015654 INFO: Starting candidate scoring
+1 day, 19:58:53.014064 INFO: Finished candidate processing
+1 day, 19:58:53.014279 INFO: Collecting candidate features
+1 day, 19:58:53.065585 WARNING: intensity_correlation has 10 NaNs ( 0.03 % out of 30268)
+1 day, 19:58:53.065846 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30268)
+1 day, 19:58:53.070034 INFO: Collecting fragment features
+1 day, 19:58:53.089168 INFO: Finished candidate scoring
+1 day, 19:58:53.102064 PROGRESS: === Extracted 30268 precursors and 318622 fragments ===
+1 day, 19:58:53.102434 INFO: performing precursor FDR with 47 features
+1 day, 19:58:53.102472 INFO: Decoy channel: -1
+1 day, 19:58:53.102496 INFO: Competetive: True
+1 day, 19:58:53.110492 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:53.115137 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:58:53.115219 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 19:58:53.471301 INFO: Test AUC: 0.865
+1 day, 19:58:53.471426 INFO: Train AUC: 0.880
+1 day, 19:58:53.471456 INFO: AUC difference: 1.73%
+1 day, 19:58:53.558673 INFO: Resetting torch num_threads to 100
+1 day, 19:58:53.559837 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 19:58:53.561217 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:53.561317 PROGRESS: Total precursors accumulated: 7,999
+1 day, 19:58:53.561382 PROGRESS: Target precursors: 7,888 (98.61%)
+1 day, 19:58:53.561437 PROGRESS: Decoy precursors: 111 (1.39%)
+1 day, 19:58:53.561488 PROGRESS: 
+1 day, 19:58:53.561538 PROGRESS: Precursor Summary:
+1 day, 19:58:53.564656 PROGRESS: Channel   0:	 0.05 FDR: 7,888; 0.01 FDR: 7,842; 0.001 FDR: 7,437
+1 day, 19:58:53.564774 PROGRESS: 
+1 day, 19:58:53.564835 PROGRESS: Protein Summary:
+1 day, 19:58:53.569348 PROGRESS: Channel   0:	 0.05 FDR: 4,178; 0.01 FDR: 4,163; 0.001 FDR: 4,000
+1 day, 19:58:53.569461 PROGRESS: =========================================================================
+1 day, 19:58:53.593563 INFO: fragments_df_filtered: 5000
+1 day, 19:58:53.607920 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:58:54.409505 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:58:55.221259 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:58:56.020138 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:58:56.370557 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:56.373322 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:56.382484 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:56.384751 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:56.403079 INFO: === checking if optimization conditions were reached ===
+1 day, 19:58:56.403250 PROGRESS: === Optimization of rt_error has been performed 8 time(s); minimum number is 2 ===
+1 day, 19:58:56.404505 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 10.4040 found after 8 searches.
+1 day, 19:58:56.404562 INFO: ==============================================
+1 day, 19:58:56.404667 PROGRESS: Optimization finished for rt_error.
+1 day, 19:58:56.423105 INFO: calibration group: precursor, predicting mz
+1 day, 19:58:56.426297 INFO: calibration group: precursor, predicting rt
+1 day, 19:58:56.436043 INFO: calibration group: precursor, predicting mobility
+1 day, 19:58:56.438702 INFO: calibration group: fragment, predicting mz
+1 day, 19:58:56.490852 INFO: Starting optimization step 0.
+1 day, 19:58:56.491059 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:58:56.491140 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:58:56.496181 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:58:56.496258 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:58:56.496303 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:58:56.496332 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.87
+1 day, 19:58:56.505307 INFO: Starting candidate selection
+1 day, 19:58:58.111847 INFO: Starting candidate scoring
+1 day, 19:58:59.102549 INFO: Finished candidate processing
+1 day, 19:58:59.102681 INFO: Collecting candidate features
+1 day, 19:58:59.153313 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30264)
+1 day, 19:58:59.153669 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30264)
+1 day, 19:58:59.161174 INFO: Collecting fragment features
+1 day, 19:58:59.180229 INFO: Finished candidate scoring
+1 day, 19:58:59.193265 PROGRESS: === Extracted 30264 precursors and 318587 fragments ===
+1 day, 19:58:59.193647 INFO: performing precursor FDR with 47 features
+1 day, 19:58:59.193691 INFO: Decoy channel: -1
+1 day, 19:58:59.193720 INFO: Competetive: True
+1 day, 19:58:59.201457 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:58:59.206392 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:58:59.206496 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 19:58:59.553746 INFO: Test AUC: 0.881
+1 day, 19:58:59.553877 INFO: Train AUC: 0.887
+1 day, 19:58:59.553913 INFO: AUC difference: 0.70%
+1 day, 19:58:59.638649 INFO: Resetting torch num_threads to 100
+1 day, 19:58:59.639818 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 19:58:59.641243 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:58:59.641582 PROGRESS: Total precursors accumulated: 7,999
+1 day, 19:58:59.641656 PROGRESS: Target precursors: 7,881 (98.52%)
+1 day, 19:58:59.641715 PROGRESS: Decoy precursors: 118 (1.48%)
+1 day, 19:58:59.641772 PROGRESS: 
+1 day, 19:58:59.641826 PROGRESS: Precursor Summary:
+1 day, 19:58:59.644973 PROGRESS: Channel   0:	 0.05 FDR: 7,881; 0.01 FDR: 7,828; 0.001 FDR: 7,442
+1 day, 19:58:59.645100 PROGRESS: 
+1 day, 19:58:59.645166 PROGRESS: Protein Summary:
+1 day, 19:58:59.649653 PROGRESS: Channel   0:	 0.05 FDR: 4,177; 0.01 FDR: 4,163; 0.001 FDR: 4,001
+1 day, 19:58:59.649770 PROGRESS: =========================================================================
+1 day, 19:58:59.674903 INFO: fragments_df_filtered: 5000
+1 day, 19:58:59.689239 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:59:00.489396 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:59:01.299498 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:59:02.099787 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:59:02.449323 INFO: calibration group: precursor, predicting mz
+1 day, 19:59:02.452208 INFO: calibration group: precursor, predicting rt
+1 day, 19:59:02.461910 INFO: calibration group: precursor, predicting mobility
+1 day, 19:59:02.464270 INFO: calibration group: fragment, predicting mz
+1 day, 19:59:02.481983 INFO: === checking if optimization conditions were reached ===
+1 day, 19:59:02.482177 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 19:59:02.485187 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0580.
+1 day, 19:59:02.485251 INFO: ==============================================
+1 day, 19:59:02.485366 INFO: Starting optimization step 1.
+1 day, 19:59:02.485443 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:59:02.485512 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:59:02.491127 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:59:02.491197 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:59:02.491241 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:59:02.491269 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:59:02.492438 INFO: Starting candidate selection
+1 day, 19:59:03.858094 INFO: Starting candidate scoring
+1 day, 19:59:04.832772 INFO: Finished candidate processing
+1 day, 19:59:04.832910 INFO: Collecting candidate features
+1 day, 19:59:04.889349 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30211)
+1 day, 19:59:04.889632 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30211)
+1 day, 19:59:04.893979 INFO: Collecting fragment features
+1 day, 19:59:04.913708 INFO: Finished candidate scoring
+1 day, 19:59:04.928962 PROGRESS: === Extracted 30211 precursors and 314996 fragments ===
+1 day, 19:59:04.929422 INFO: performing precursor FDR with 47 features
+1 day, 19:59:04.929462 INFO: Decoy channel: -1
+1 day, 19:59:04.929493 INFO: Competetive: True
+1 day, 19:59:04.938923 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:59:04.944810 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:59:04.944927 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:59:05.379023 INFO: Test AUC: 0.894
+1 day, 19:59:05.379186 INFO: Train AUC: 0.883
+1 day, 19:59:05.379221 INFO: AUC difference: 1.27%
+1 day, 19:59:08.078281 INFO: Resetting torch num_threads to 100
+1 day, 19:59:08.080122 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 19:59:08.083010 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:59:08.083154 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:59:08.083220 PROGRESS: Target precursors: 7,883 (98.56%)
+1 day, 19:59:08.083274 PROGRESS: Decoy precursors: 115 (1.44%)
+1 day, 19:59:08.083321 PROGRESS: 
+1 day, 19:59:08.083368 PROGRESS: Precursor Summary:
+1 day, 19:59:08.087955 PROGRESS: Channel   0:	 0.05 FDR: 7,883; 0.01 FDR: 7,821; 0.001 FDR: 7,500
+1 day, 19:59:08.088117 PROGRESS: 
+1 day, 19:59:08.088181 PROGRESS: Protein Summary:
+1 day, 19:59:08.093364 PROGRESS: Channel   0:	 0.05 FDR: 4,178; 0.01 FDR: 4,153; 0.001 FDR: 4,024
+1 day, 19:59:08.093505 PROGRESS: =========================================================================
+1 day, 19:59:08.122195 INFO: fragments_df_filtered: 5000
+1 day, 19:59:08.142887 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:59:08.958417 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:59:09.773951 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:59:10.570837 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:59:10.921928 INFO: calibration group: precursor, predicting mz
+1 day, 19:59:10.924870 INFO: calibration group: precursor, predicting rt
+1 day, 19:59:10.934061 INFO: calibration group: precursor, predicting mobility
+1 day, 19:59:10.936408 INFO: calibration group: fragment, predicting mz
+1 day, 19:59:10.954587 INFO: === checking if optimization conditions were reached ===
+1 day, 19:59:10.954756 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 19:59:10.957288 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0514.
+1 day, 19:59:10.957345 INFO: ==============================================
+1 day, 19:59:10.957443 INFO: Starting optimization step 2.
+1 day, 19:59:10.957511 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 19:59:10.957570 PROGRESS: Extracting batch of 15886 precursors
+1 day, 19:59:10.961718 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:59:10.961780 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:59:10.961817 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 19:59:10.961839 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.86
+1 day, 19:59:10.970666 INFO: Starting candidate selection
+1 day, 19:59:12.338054 INFO: Starting candidate scoring
+1 day, 19:59:13.300756 INFO: Finished candidate processing
+1 day, 19:59:13.300897 INFO: Collecting candidate features
+1 day, 19:59:13.352106 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30160)
+1 day, 19:59:13.352387 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30160)
+1 day, 19:59:13.356585 INFO: Collecting fragment features
+1 day, 19:59:13.375623 INFO: Finished candidate scoring
+1 day, 19:59:13.391952 PROGRESS: === Extracted 30160 precursors and 313842 fragments ===
+1 day, 19:59:13.392342 INFO: performing precursor FDR with 47 features
+1 day, 19:59:13.392385 INFO: Decoy channel: -1
+1 day, 19:59:13.392411 INFO: Competetive: True
+1 day, 19:59:13.401197 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:59:13.406194 WARNING: dropped 2 target PSMs due to missing features
+1 day, 19:59:13.406295 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 19:59:13.769227 INFO: Test AUC: 0.886
+1 day, 19:59:13.769354 INFO: Train AUC: 0.885
+1 day, 19:59:13.769385 INFO: AUC difference: 0.09%
+1 day, 19:59:13.854196 INFO: Resetting torch num_threads to 100
+1 day, 19:59:13.855421 INFO: === FDR correction performed with classifier version 10 ===
+1 day, 19:59:13.856911 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:59:13.857012 PROGRESS: Total precursors accumulated: 7,998
+1 day, 19:59:13.857088 PROGRESS: Target precursors: 7,883 (98.56%)
+1 day, 19:59:13.857141 PROGRESS: Decoy precursors: 115 (1.44%)
+1 day, 19:59:13.857191 PROGRESS: 
+1 day, 19:59:13.857236 PROGRESS: Precursor Summary:
+1 day, 19:59:13.860381 PROGRESS: Channel   0:	 0.05 FDR: 7,883; 0.01 FDR: 7,814; 0.001 FDR: 7,562
+1 day, 19:59:13.860505 PROGRESS: 
+1 day, 19:59:13.860566 PROGRESS: Protein Summary:
+1 day, 19:59:13.865277 PROGRESS: Channel   0:	 0.05 FDR: 4,177; 0.01 FDR: 4,148; 0.001 FDR: 4,049
+1 day, 19:59:13.865388 PROGRESS: =========================================================================
+1 day, 19:59:13.889693 INFO: fragments_df_filtered: 5000
+1 day, 19:59:13.904287 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 19:59:14.702199 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 19:59:15.512161 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 19:59:16.305140 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 19:59:16.655405 INFO: calibration group: precursor, predicting mz
+1 day, 19:59:16.658410 INFO: calibration group: precursor, predicting rt
+1 day, 19:59:16.667726 INFO: calibration group: precursor, predicting mobility
+1 day, 19:59:16.670104 INFO: calibration group: fragment, predicting mz
+1 day, 19:59:16.689315 INFO: === checking if optimization conditions were reached ===
+1 day, 19:59:16.689479 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 19:59:16.690249 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.1000 found after 3 searches.
+1 day, 19:59:16.690300 INFO: ==============================================
+1 day, 19:59:16.690389 PROGRESS: Optimization finished for mobility_error.
+1 day, 19:59:16.704903 INFO: calibration group: precursor, predicting mz
+1 day, 19:59:16.707772 INFO: calibration group: precursor, predicting rt
+1 day, 19:59:16.717537 INFO: calibration group: precursor, predicting mobility
+1 day, 19:59:16.719895 INFO: calibration group: fragment, predicting mz
+1 day, 19:59:16.763330 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 19:59:16.763501 PROGRESS: ==============================================
+1 day, 19:59:16.763572 PROGRESS: ms2_error      : 15.0000
+1 day, 19:59:16.763632 PROGRESS: ms1_error      : 10.0000
+1 day, 19:59:16.763685 PROGRESS: rt_error       : 10.4040
+1 day, 19:59:16.763736 PROGRESS: mobility_error : 0.1000
+1 day, 19:59:16.763785 PROGRESS: ==============================================
+1 day, 19:59:16.764616 INFO: calibration group: precursor, predicting mz
+1 day, 19:59:16.783977 INFO: calibration group: precursor, predicting rt
+1 day, 19:59:16.873203 INFO: calibration group: precursor, predicting mobility
+1 day, 19:59:16.893977 INFO: calibration group: fragment, predicting mz
+1 day, 19:59:17.129651 PROGRESS: Extracting batch of 162861 precursors
+1 day, 19:59:17.167723 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 19:59:17.167853 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 19:59:17.167900 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 19:59:17.167926 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 19:59:17.168805 INFO: Starting candidate selection
+1 day, 19:59:28.478506 INFO: Applying score cutoff of 28.377387195587158
+1 day, 19:59:28.484571 INFO: Removed 24541 precursors with score below cutoff
+1 day, 19:59:28.819656 INFO: Starting candidate scoring
+1 day, 19:59:37.597186 INFO: Finished candidate processing
+1 day, 19:59:37.597289 INFO: Collecting candidate features
+1 day, 19:59:38.074690 INFO: Collecting fragment features
+1 day, 19:59:38.264215 INFO: Finished candidate scoring
+1 day, 19:59:38.418637 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 19:59:38.420095 INFO: performing precursor FDR with 47 features
+1 day, 19:59:38.420146 INFO: Decoy channel: -1
+1 day, 19:59:38.420173 INFO: Competetive: True
+1 day, 19:59:38.519426 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 19:59:38.550274 WARNING: FDR calculation for 152364 target and 133215 decoy PSMs
+1 day, 19:59:38.550415 WARNING: FDR calculation may be inaccurate as there is more than 10% difference in the number of target and decoy PSMs
+1 day, 19:59:43.370150 INFO: Test AUC: 0.899
+1 day, 19:59:43.370280 INFO: Train AUC: 0.901
+1 day, 19:59:43.370312 INFO: AUC difference: 0.24%
+1 day, 19:59:43.473480 INFO: Resetting torch num_threads to 100
+1 day, 19:59:43.491549 INFO: Removing fragments below FDR threshold
+1 day, 19:59:43.544333 PROGRESS: ============================= Precursor FDR =============================
+1 day, 19:59:43.544658 PROGRESS: Total precursors accumulated: 80,959
+1 day, 19:59:43.544728 PROGRESS: Target precursors: 80,158 (99.01%)
+1 day, 19:59:43.544784 PROGRESS: Decoy precursors: 801 (0.99%)
+1 day, 19:59:43.544836 PROGRESS: 
+1 day, 19:59:43.544885 PROGRESS: Precursor Summary:
+1 day, 19:59:43.580607 PROGRESS: Channel   0:	 0.05 FDR: 80,158; 0.01 FDR: 80,158; 0.001 FDR: 77,623
+1 day, 19:59:43.580943 PROGRESS: 
+1 day, 19:59:43.581011 PROGRESS: Protein Summary:
+1 day, 19:59:43.631490 PROGRESS: Channel   0:	 0.05 FDR: 8,244; 0.01 FDR: 8,244; 0.001 FDR: 8,212
+1 day, 19:59:43.631799 PROGRESS: =========================================================================
+1 day, 19:59:44.306578 INFO: Finished workflow for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 19:59:44.347911 PROGRESS: Loading raw file 4/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 19:59:44.348063 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 19:59:44.348140 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 19:59:44.349014 INFO: Initializing RawFileManager
+1 day, 19:59:44.349124 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:44.349168 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:44.349196 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:44.561163 INFO: Reading 39,128 frames with 2,751,035,867 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.943853 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d...
+1 day, 19:59:51.946622 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.951318 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.951611 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.952056 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.953850 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.976537 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 19:59:51.976875 INFO: Indexing quadrupole dimension
+1 day, 19:59:52.444649 INFO: Transposing detector events
+1 day, 20:00:02.186134 INFO: Finished transposing data
+1 day, 20:00:02.222182 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d
+1 day, 20:00:02.223200 INFO: RT (min)            : 0.0 - 70.0
+1 day, 20:00:02.223295 INFO: RT duration (sec)   : 4199.8
+1 day, 20:00:02.223355 INFO: RT duration (min)   : 70.0
+1 day, 20:00:02.223408 INFO: Cycle len (scans)   : 9
+1 day, 20:00:02.223454 INFO: Cycle len (sec)     : 0.97
+1 day, 20:00:02.223502 INFO: Number of cycles    : 4347
+1 day, 20:00:02.223549 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 20:00:02.279989 INFO: Initializing CalibrationManager
+1 day, 20:00:02.280354 INFO: Loading calibration config
+1 day, 20:00:02.281045 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 20:00:02.281147 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 20:00:02.281245 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 20:00:02.281401 INFO: Initializing OptimizationManager
+1 day, 20:00:02.281529 INFO: initial parameter: ms1_error = 30
+1 day, 20:00:02.281588 INFO: initial parameter: ms2_error = 30
+1 day, 20:00:02.281656 INFO: initial parameter: rt_error = 2099.891532
+1 day, 20:00:02.281709 INFO: initial parameter: mobility_error = 0.1
+1 day, 20:00:02.281756 INFO: initial parameter: column_type = library
+1 day, 20:00:02.281802 INFO: initial parameter: num_candidates = 1
+1 day, 20:00:02.281850 INFO: initial parameter: classifier_version = -1
+1 day, 20:00:02.281894 INFO: initial parameter: fwhm_rt = 5
+1 day, 20:00:02.281939 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 20:00:02.281981 INFO: initial parameter: score_cutoff = 0
+1 day, 20:00:02.282045 INFO: Initializing TimingManager
+1 day, 20:00:02.282104 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 20:00:02.282203 INFO: FDRManager not loaded from disk.
+1 day, 20:00:02.282228 INFO: Initializing FDRManager
+1 day, 20:00:02.282264 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 20:00:02.311843 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 20:00:02.357666 PROGRESS: Starting initial search for precursors.
+1 day, 20:00:02.375884 INFO: Starting optimization step 0.
+1 day, 20:00:02.376139 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:00:02.376237 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:00:02.379470 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:00:02.379524 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:00:02.379562 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 20:00:02.379586 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 20:00:02.381478 INFO: Starting candidate selection
+1 day, 20:01:28.330160 INFO: Starting candidate scoring
+1 day, 20:01:29.362635 INFO: Finished candidate processing
+1 day, 20:01:29.362775 INFO: Collecting candidate features
+1 day, 20:01:29.400160 INFO: Collecting fragment features
+1 day, 20:01:29.417243 INFO: Finished candidate scoring
+1 day, 20:01:29.427420 PROGRESS: === Extracted 15885 precursors and 175826 fragments ===
+1 day, 20:01:29.427866 INFO: performing precursor FDR with 47 features
+1 day, 20:01:29.427903 INFO: Decoy channel: -1
+1 day, 20:01:29.427926 INFO: Competetive: True
+1 day, 20:01:29.433092 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:01:29.605303 INFO: Test AUC: 0.807
+1 day, 20:01:29.605424 INFO: Train AUC: 0.818
+1 day, 20:01:29.605455 INFO: AUC difference: 1.38%
+1 day, 20:01:29.695739 INFO: Resetting torch num_threads to 100
+1 day, 20:01:29.696883 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 20:01:29.698864 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:01:29.698994 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:01:29.699056 PROGRESS: Target precursors: 6,641 (83.01%)
+1 day, 20:01:29.699108 PROGRESS: Decoy precursors: 1,359 (16.99%)
+1 day, 20:01:29.699154 PROGRESS: 
+1 day, 20:01:29.699200 PROGRESS: Precursor Summary:
+1 day, 20:01:29.701892 PROGRESS: Channel   0:	 0.05 FDR: 5,213; 0.01 FDR: 4,351; 0.001 FDR: 3,271
+1 day, 20:01:29.702033 PROGRESS: 
+1 day, 20:01:29.702091 PROGRESS: Protein Summary:
+1 day, 20:01:29.705432 PROGRESS: Channel   0:	 0.05 FDR: 3,052; 0.01 FDR: 2,653; 0.001 FDR: 2,116
+1 day, 20:01:29.705554 PROGRESS: =========================================================================
+1 day, 20:01:29.715020 INFO: fragments_df_filtered: 5000
+1 day, 20:01:29.732028 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:01:30.011580 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:01:30.361932 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:01:30.640403 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:01:30.997299 INFO: calibration group: precursor, predicting mz
+1 day, 20:01:31.000178 INFO: calibration group: precursor, predicting rt
+1 day, 20:01:31.009896 INFO: calibration group: precursor, predicting mobility
+1 day, 20:01:31.012281 INFO: calibration group: fragment, predicting mz
+1 day, 20:01:31.031434 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 20:01:31.031606 INFO: Starting optimization step 1.
+1 day, 20:01:31.031688 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:01:31.031754 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:01:31.035961 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:01:31.036022 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:01:31.036065 INFO: FWHM in RT is 3.25 seconds, sigma is 0.72
+1 day, 20:01:31.036088 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.08
+1 day, 20:01:31.044882 INFO: Starting candidate selection
+1 day, 20:03:07.042625 INFO: Starting candidate scoring
+1 day, 20:03:08.955820 INFO: Finished candidate processing
+1 day, 20:03:08.955994 INFO: Collecting candidate features
+1 day, 20:03:09.033324 INFO: Collecting fragment features
+1 day, 20:03:09.058792 INFO: Finished candidate scoring
+1 day, 20:03:09.079005 PROGRESS: === Extracted 30459 precursors and 336997 fragments ===
+1 day, 20:03:09.079506 INFO: performing precursor FDR with 47 features
+1 day, 20:03:09.079546 INFO: Decoy channel: -1
+1 day, 20:03:09.079571 INFO: Competetive: True
+1 day, 20:03:09.093698 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:03:09.455479 INFO: Test AUC: 0.756
+1 day, 20:03:09.455605 INFO: Train AUC: 0.749
+1 day, 20:03:09.455639 INFO: AUC difference: 0.92%
+1 day, 20:03:09.546839 INFO: Resetting torch num_threads to 100
+1 day, 20:03:09.548114 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 20:03:09.549660 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:03:09.549778 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:03:09.549848 PROGRESS: Target precursors: 6,837 (85.46%)
+1 day, 20:03:09.549908 PROGRESS: Decoy precursors: 1,163 (14.54%)
+1 day, 20:03:09.549962 PROGRESS: 
+1 day, 20:03:09.550017 PROGRESS: Precursor Summary:
+1 day, 20:03:09.550961 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 20:03:09.551062 PROGRESS: 
+1 day, 20:03:09.551134 PROGRESS: Protein Summary:
+1 day, 20:03:09.552145 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1 day, 20:03:09.552240 PROGRESS: =========================================================================
+1 day, 20:03:09.585230 INFO: calibration group: precursor, predicting mz
+1 day, 20:03:09.590431 INFO: calibration group: precursor, predicting rt
+1 day, 20:03:09.607512 INFO: calibration group: precursor, predicting mobility
+1 day, 20:03:09.611775 INFO: calibration group: fragment, predicting mz
+1 day, 20:03:09.650427 INFO: === skipping optimization until target number of precursors are found ===
+1 day, 20:03:09.650735 INFO: Starting optimization step 2.
+1 day, 20:03:09.650829 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1 day, 20:03:09.650912 PROGRESS: Extracting batch of 31769 precursors
+1 day, 20:03:09.662281 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:03:09.662392 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:03:09.662450 INFO: FWHM in RT is 3.25 seconds, sigma is 0.72
+1 day, 20:03:09.662480 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.08
+1 day, 20:03:09.671640 INFO: Starting candidate selection
+1 day, 20:06:15.330148 INFO: Starting candidate scoring
+1 day, 20:06:18.760807 INFO: Finished candidate processing
+1 day, 20:06:18.761175 INFO: Collecting candidate features
+1 day, 20:06:18.900922 INFO: Collecting fragment features
+1 day, 20:06:18.945728 INFO: Finished candidate scoring
+1 day, 20:06:19.002616 PROGRESS: === Extracted 91375 precursors and 1013371 fragments ===
+1 day, 20:06:19.016812 INFO: performing precursor FDR with 47 features
+1 day, 20:06:19.016952 INFO: Decoy channel: -1
+1 day, 20:06:19.016978 INFO: Competetive: True
+1 day, 20:06:19.055216 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:06:20.615819 INFO: Test AUC: 0.771
+1 day, 20:06:20.615959 INFO: Train AUC: 0.768
+1 day, 20:06:20.615989 INFO: AUC difference: 0.38%
+1 day, 20:06:20.718529 INFO: Resetting torch num_threads to 100
+1 day, 20:06:20.722324 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 20:06:20.726370 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:06:20.726541 PROGRESS: Total precursors accumulated: 24,000
+1 day, 20:06:20.726617 PROGRESS: Target precursors: 21,427 (89.28%)
+1 day, 20:06:20.726669 PROGRESS: Decoy precursors: 2,573 (10.72%)
+1 day, 20:06:20.726720 PROGRESS: 
+1 day, 20:06:20.726769 PROGRESS: Precursor Summary:
+1 day, 20:06:20.733182 PROGRESS: Channel   0:	 0.05 FDR: 18,636; 0.01 FDR: 16,806; 0.001 FDR: 13,683
+1 day, 20:06:20.733375 PROGRESS: 
+1 day, 20:06:20.733437 PROGRESS: Protein Summary:
+1 day, 20:06:20.742935 PROGRESS: Channel   0:	 0.05 FDR: 5,823; 0.01 FDR: 5,439; 0.001 FDR: 4,809
+1 day, 20:06:20.743134 PROGRESS: =========================================================================
+1 day, 20:06:20.814917 INFO: fragments_df_filtered: 5000
+1 day, 20:06:20.838714 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:06:24.383943 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:06:28.036377 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:06:31.575169 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:06:31.933180 INFO: calibration group: precursor, predicting mz
+1 day, 20:06:31.936194 INFO: calibration group: precursor, predicting rt
+1 day, 20:06:31.945434 INFO: calibration group: precursor, predicting mobility
+1 day, 20:06:31.947805 INFO: calibration group: fragment, predicting mz
+1 day, 20:06:31.967588 INFO: === checking if optimization conditions were reached ===
+1 day, 20:06:31.969481 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 20:06:31.973064 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 20:06:31.973119 INFO: ==============================================
+1 day, 20:06:31.973236 INFO: Starting optimization step 3.
+1 day, 20:06:31.973305 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:06:31.973369 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:06:31.978120 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:06:31.978187 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:06:31.978228 INFO: FWHM in RT is 3.24 seconds, sigma is 0.71
+1 day, 20:06:31.978251 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 4.92
+1 day, 20:06:31.979156 INFO: Starting candidate selection
+1 day, 20:07:58.836591 INFO: Starting candidate scoring
+1 day, 20:07:59.881614 INFO: Finished candidate processing
+1 day, 20:07:59.881724 INFO: Collecting candidate features
+1 day, 20:07:59.939421 INFO: Collecting fragment features
+1 day, 20:07:59.960424 INFO: Finished candidate scoring
+1 day, 20:07:59.975824 PROGRESS: === Extracted 30520 precursors and 333204 fragments ===
+1 day, 20:07:59.976279 INFO: performing precursor FDR with 47 features
+1 day, 20:07:59.976318 INFO: Decoy channel: -1
+1 day, 20:07:59.976341 INFO: Competetive: True
+1 day, 20:07:59.987932 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:08:00.377360 INFO: Test AUC: 0.799
+1 day, 20:08:00.377485 INFO: Train AUC: 0.803
+1 day, 20:08:00.377516 INFO: AUC difference: 0.42%
+1 day, 20:08:00.471248 INFO: Resetting torch num_threads to 100
+1 day, 20:08:00.472632 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:08:00.474164 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:08:00.474270 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:08:00.474332 PROGRESS: Target precursors: 7,538 (94.23%)
+1 day, 20:08:00.474385 PROGRESS: Decoy precursors: 462 (5.78%)
+1 day, 20:08:00.474432 PROGRESS: 
+1 day, 20:08:00.474478 PROGRESS: Precursor Summary:
+1 day, 20:08:00.477587 PROGRESS: Channel   0:	 0.05 FDR: 7,374; 0.01 FDR: 6,870; 0.001 FDR: 5,724
+1 day, 20:08:00.477716 PROGRESS: 
+1 day, 20:08:00.477780 PROGRESS: Protein Summary:
+1 day, 20:08:00.482237 PROGRESS: Channel   0:	 0.05 FDR: 3,987; 0.01 FDR: 3,768; 0.001 FDR: 3,263
+1 day, 20:08:00.482355 PROGRESS: =========================================================================
+1 day, 20:08:00.506926 INFO: fragments_df_filtered: 5000
+1 day, 20:08:00.527401 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:08:01.153907 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:08:01.810647 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:08:02.440107 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:08:02.797113 INFO: calibration group: precursor, predicting mz
+1 day, 20:08:02.800164 INFO: calibration group: precursor, predicting rt
+1 day, 20:08:02.809905 INFO: calibration group: precursor, predicting mobility
+1 day, 20:08:02.812366 INFO: calibration group: fragment, predicting mz
+1 day, 20:08:02.832389 INFO: === checking if optimization conditions were reached ===
+1 day, 20:08:02.834550 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 20:08:02.836766 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 20:08:02.836824 INFO: ==============================================
+1 day, 20:08:02.836958 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 20:08:02.857334 INFO: calibration group: precursor, predicting mz
+1 day, 20:08:02.860611 INFO: calibration group: precursor, predicting rt
+1 day, 20:08:02.870553 INFO: calibration group: precursor, predicting mobility
+1 day, 20:08:02.873289 INFO: calibration group: fragment, predicting mz
+1 day, 20:08:02.895175 INFO: Starting optimization step 0.
+1 day, 20:08:02.895365 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:08:02.895459 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:08:02.901907 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:08:02.901990 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:08:02.902041 INFO: FWHM in RT is 2.93 seconds, sigma is 0.64
+1 day, 20:08:02.902071 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.06
+1 day, 20:08:02.910975 INFO: Starting candidate selection
+1 day, 20:09:33.681853 INFO: Starting candidate scoring
+1 day, 20:09:34.752291 INFO: Finished candidate processing
+1 day, 20:09:34.752396 INFO: Collecting candidate features
+1 day, 20:09:34.813552 INFO: Collecting fragment features
+1 day, 20:09:34.839872 INFO: Finished candidate scoring
+1 day, 20:09:34.853594 PROGRESS: === Extracted 30467 precursors and 332256 fragments ===
+1 day, 20:09:34.854062 INFO: performing precursor FDR with 47 features
+1 day, 20:09:34.854103 INFO: Decoy channel: -1
+1 day, 20:09:34.854126 INFO: Competetive: True
+1 day, 20:09:34.868194 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:09:35.247925 INFO: Test AUC: 0.812
+1 day, 20:09:35.248049 INFO: Train AUC: 0.816
+1 day, 20:09:35.248080 INFO: AUC difference: 0.51%
+1 day, 20:09:35.340574 INFO: Resetting torch num_threads to 100
+1 day, 20:09:35.341785 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:09:35.343178 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:09:35.343289 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:09:35.343355 PROGRESS: Target precursors: 7,574 (94.67%)
+1 day, 20:09:35.343410 PROGRESS: Decoy precursors: 426 (5.33%)
+1 day, 20:09:35.343458 PROGRESS: 
+1 day, 20:09:35.343503 PROGRESS: Precursor Summary:
+1 day, 20:09:35.346471 PROGRESS: Channel   0:	 0.05 FDR: 7,517; 0.01 FDR: 6,938; 0.001 FDR: 5,720
+1 day, 20:09:35.346604 PROGRESS: 
+1 day, 20:09:35.346663 PROGRESS: Protein Summary:
+1 day, 20:09:35.350828 PROGRESS: Channel   0:	 0.05 FDR: 4,027; 0.01 FDR: 3,784; 0.001 FDR: 3,275
+1 day, 20:09:35.350946 PROGRESS: =========================================================================
+1 day, 20:09:35.373839 INFO: fragments_df_filtered: 5000
+1 day, 20:09:35.393106 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:09:36.041880 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:09:36.713943 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:09:37.352704 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:09:37.708659 INFO: calibration group: precursor, predicting mz
+1 day, 20:09:37.711629 INFO: calibration group: precursor, predicting rt
+1 day, 20:09:37.721303 INFO: calibration group: precursor, predicting mobility
+1 day, 20:09:37.723769 INFO: calibration group: fragment, predicting mz
+1 day, 20:09:37.744513 INFO: === checking if optimization conditions were reached ===
+1 day, 20:09:37.744687 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:09:37.750167 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 296.3653.
+1 day, 20:09:37.750226 INFO: ==============================================
+1 day, 20:09:37.750331 INFO: Starting optimization step 1.
+1 day, 20:09:37.750402 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:09:37.750467 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:09:37.754809 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:09:37.754869 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:09:37.754925 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:09:37.754951 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.02
+1 day, 20:09:37.756071 INFO: Starting candidate selection
+1 day, 20:09:51.160058 INFO: Starting candidate scoring
+1 day, 20:09:52.141514 INFO: Finished candidate processing
+1 day, 20:09:52.141650 INFO: Collecting candidate features
+1 day, 20:09:52.203640 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30387)
+1 day, 20:09:52.212644 INFO: Collecting fragment features
+1 day, 20:09:52.234589 INFO: Finished candidate scoring
+1 day, 20:09:52.250532 PROGRESS: === Extracted 30387 precursors and 328022 fragments ===
+1 day, 20:09:52.250996 INFO: performing precursor FDR with 47 features
+1 day, 20:09:52.251036 INFO: Decoy channel: -1
+1 day, 20:09:52.251059 INFO: Competetive: True
+1 day, 20:09:52.261807 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:09:52.266671 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 20:09:52.710986 INFO: Test AUC: 0.832
+1 day, 20:09:52.711151 INFO: Train AUC: 0.838
+1 day, 20:09:52.711181 INFO: AUC difference: 0.65%
+1 day, 20:09:52.803566 INFO: Resetting torch num_threads to 100
+1 day, 20:09:52.805215 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:09:52.806791 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:09:52.806890 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:09:52.806963 PROGRESS: Target precursors: 7,743 (96.79%)
+1 day, 20:09:52.807026 PROGRESS: Decoy precursors: 257 (3.21%)
+1 day, 20:09:52.807074 PROGRESS: 
+1 day, 20:09:52.807121 PROGRESS: Precursor Summary:
+1 day, 20:09:52.810422 PROGRESS: Channel   0:	 0.05 FDR: 7,743; 0.01 FDR: 7,449; 0.001 FDR: 6,830
+1 day, 20:09:52.810544 PROGRESS: 
+1 day, 20:09:52.810604 PROGRESS: Protein Summary:
+1 day, 20:09:52.815252 PROGRESS: Channel   0:	 0.05 FDR: 4,124; 0.01 FDR: 3,996; 0.001 FDR: 3,758
+1 day, 20:09:52.815374 PROGRESS: =========================================================================
+1 day, 20:09:52.844832 INFO: fragments_df_filtered: 5000
+1 day, 20:09:52.863660 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:09:53.611606 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:09:54.448205 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:09:55.243237 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:09:55.662258 INFO: calibration group: precursor, predicting mz
+1 day, 20:09:55.665657 INFO: calibration group: precursor, predicting rt
+1 day, 20:09:55.675492 INFO: calibration group: precursor, predicting mobility
+1 day, 20:09:55.677948 INFO: calibration group: fragment, predicting mz
+1 day, 20:09:55.698656 INFO: === checking if optimization conditions were reached ===
+1 day, 20:09:55.698841 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:09:55.704812 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 119.0359.
+1 day, 20:09:55.704877 INFO: ==============================================
+1 day, 20:09:55.704978 INFO: Starting optimization step 2.
+1 day, 20:09:55.705074 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:09:55.705140 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:09:55.712078 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:09:55.712156 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:09:55.712196 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 20:09:55.712222 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.92
+1 day, 20:09:55.714914 INFO: Starting candidate selection
+1 day, 20:10:01.485990 INFO: Starting candidate scoring
+1 day, 20:10:03.228136 INFO: Finished candidate processing
+1 day, 20:10:03.228232 INFO: Collecting candidate features
+1 day, 20:10:03.281601 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30340)
+1 day, 20:10:03.281942 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 30340)
+1 day, 20:10:03.289091 INFO: Collecting fragment features
+1 day, 20:10:03.307910 INFO: Finished candidate scoring
+1 day, 20:10:03.322294 PROGRESS: === Extracted 30340 precursors and 325010 fragments ===
+1 day, 20:10:03.322660 INFO: performing precursor FDR with 47 features
+1 day, 20:10:03.322696 INFO: Decoy channel: -1
+1 day, 20:10:03.322718 INFO: Competetive: True
+1 day, 20:10:03.331284 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:03.335526 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 20:10:03.712118 INFO: Test AUC: 0.851
+1 day, 20:10:03.712246 INFO: Train AUC: 0.854
+1 day, 20:10:03.712276 INFO: AUC difference: 0.38%
+1 day, 20:10:03.802174 INFO: Resetting torch num_threads to 100
+1 day, 20:10:03.803356 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:03.804734 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:03.804826 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:03.804888 PROGRESS: Target precursors: 7,830 (97.88%)
+1 day, 20:10:03.804939 PROGRESS: Decoy precursors: 170 (2.12%)
+1 day, 20:10:03.804988 PROGRESS: 
+1 day, 20:10:03.805046 PROGRESS: Precursor Summary:
+1 day, 20:10:03.808034 PROGRESS: Channel   0:	 0.05 FDR: 7,830; 0.01 FDR: 7,730; 0.001 FDR: 7,248
+1 day, 20:10:03.808150 PROGRESS: 
+1 day, 20:10:03.808208 PROGRESS: Protein Summary:
+1 day, 20:10:03.812725 PROGRESS: Channel   0:	 0.05 FDR: 4,162; 0.01 FDR: 4,121; 0.001 FDR: 3,933
+1 day, 20:10:03.812832 PROGRESS: =========================================================================
+1 day, 20:10:03.838376 INFO: fragments_df_filtered: 5000
+1 day, 20:10:03.853396 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:04.699908 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:05.589101 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:06.436806 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:06.855260 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:06.858160 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:06.867768 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:06.870201 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:06.889843 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:06.890068 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:10:06.896651 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 50.3024.
+1 day, 20:10:06.896723 INFO: ==============================================
+1 day, 20:10:06.896832 INFO: Starting optimization step 3.
+1 day, 20:10:06.896907 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:06.896975 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:06.903065 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:06.903132 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:06.903174 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 20:10:06.903203 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.88
+1 day, 20:10:06.905602 INFO: Starting candidate selection
+1 day, 20:10:10.121567 INFO: Starting candidate scoring
+1 day, 20:10:11.051330 INFO: Finished candidate processing
+1 day, 20:10:11.051486 INFO: Collecting candidate features
+1 day, 20:10:11.100952 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30298)
+1 day, 20:10:11.105432 INFO: Collecting fragment features
+1 day, 20:10:11.123535 INFO: Finished candidate scoring
+1 day, 20:10:11.136469 PROGRESS: === Extracted 30298 precursors and 322651 fragments ===
+1 day, 20:10:11.136860 INFO: performing precursor FDR with 47 features
+1 day, 20:10:11.136897 INFO: Decoy channel: -1
+1 day, 20:10:11.136919 INFO: Competetive: True
+1 day, 20:10:11.145159 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:11.149156 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 20:10:11.529068 INFO: Test AUC: 0.854
+1 day, 20:10:11.529190 INFO: Train AUC: 0.865
+1 day, 20:10:11.529221 INFO: AUC difference: 1.18%
+1 day, 20:10:11.618023 INFO: Resetting torch num_threads to 100
+1 day, 20:10:11.619187 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:11.620585 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:11.620684 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:11.620747 PROGRESS: Target precursors: 7,904 (98.80%)
+1 day, 20:10:11.620799 PROGRESS: Decoy precursors: 96 (1.20%)
+1 day, 20:10:11.620848 PROGRESS: 
+1 day, 20:10:11.620894 PROGRESS: Precursor Summary:
+1 day, 20:10:11.623916 PROGRESS: Channel   0:	 0.05 FDR: 7,904; 0.01 FDR: 7,869; 0.001 FDR: 7,566
+1 day, 20:10:11.624037 PROGRESS: 
+1 day, 20:10:11.624099 PROGRESS: Protein Summary:
+1 day, 20:10:11.628678 PROGRESS: Channel   0:	 0.05 FDR: 4,188; 0.01 FDR: 4,175; 0.001 FDR: 4,056
+1 day, 20:10:11.628790 PROGRESS: =========================================================================
+1 day, 20:10:11.653700 INFO: fragments_df_filtered: 5000
+1 day, 20:10:11.668119 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:12.534714 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:13.387869 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:14.211335 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:14.564512 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:14.567439 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:14.577190 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:14.579604 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:14.600419 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:14.600587 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 20:10:14.607230 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 26.4911.
+1 day, 20:10:14.607302 INFO: ==============================================
+1 day, 20:10:14.607414 INFO: Starting optimization step 4.
+1 day, 20:10:14.607492 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:14.607562 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:14.613604 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:14.613676 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:14.613720 INFO: FWHM in RT is 2.89 seconds, sigma is 0.63
+1 day, 20:10:14.613748 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.86
+1 day, 20:10:14.616330 INFO: Starting candidate selection
+1 day, 20:10:16.910006 INFO: Starting candidate scoring
+1 day, 20:10:17.833960 INFO: Finished candidate processing
+1 day, 20:10:17.834091 INFO: Collecting candidate features
+1 day, 20:10:17.885040 WARNING: intensity_correlation has 7 NaNs ( 0.02 % out of 30257)
+1 day, 20:10:17.892233 INFO: Collecting fragment features
+1 day, 20:10:17.910696 INFO: Finished candidate scoring
+1 day, 20:10:17.923475 PROGRESS: === Extracted 30257 precursors and 320268 fragments ===
+1 day, 20:10:17.923845 INFO: performing precursor FDR with 47 features
+1 day, 20:10:17.923885 INFO: Decoy channel: -1
+1 day, 20:10:17.923912 INFO: Competetive: True
+1 day, 20:10:17.931786 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:17.936522 WARNING: dropped 1 target PSMs due to missing features
+1 day, 20:10:17.936605 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 20:10:18.315534 INFO: Test AUC: 0.871
+1 day, 20:10:18.315661 INFO: Train AUC: 0.871
+1 day, 20:10:18.315691 INFO: AUC difference: 0.02%
+1 day, 20:10:18.416094 INFO: Resetting torch num_threads to 100
+1 day, 20:10:18.417331 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:18.418740 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:18.418845 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:18.418908 PROGRESS: Target precursors: 7,927 (99.09%)
+1 day, 20:10:18.418962 PROGRESS: Decoy precursors: 73 (0.91%)
+1 day, 20:10:18.419008 PROGRESS: 
+1 day, 20:10:18.419053 PROGRESS: Precursor Summary:
+1 day, 20:10:18.422045 PROGRESS: Channel   0:	 0.05 FDR: 7,927; 0.01 FDR: 7,927; 0.001 FDR: 7,738
+1 day, 20:10:18.422169 PROGRESS: 
+1 day, 20:10:18.422229 PROGRESS: Protein Summary:
+1 day, 20:10:18.426823 PROGRESS: Channel   0:	 0.05 FDR: 4,194; 0.01 FDR: 4,194; 0.001 FDR: 4,125
+1 day, 20:10:18.426941 PROGRESS: =========================================================================
+1 day, 20:10:18.452089 INFO: fragments_df_filtered: 5000
+1 day, 20:10:18.466449 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:19.284271 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:20.130194 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:20.951383 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:21.303484 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:21.306361 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:21.315903 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:21.318260 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:21.336580 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:21.336760 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 20:10:21.343377 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 16.3476.
+1 day, 20:10:21.343444 INFO: ==============================================
+1 day, 20:10:21.343552 INFO: Starting optimization step 5.
+1 day, 20:10:21.343627 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:21.343693 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:21.349687 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:21.349757 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:21.349800 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:10:21.349827 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.85
+1 day, 20:10:21.352230 INFO: Starting candidate selection
+1 day, 20:10:23.217619 INFO: Starting candidate scoring
+1 day, 20:10:24.139600 INFO: Finished candidate processing
+1 day, 20:10:24.139703 INFO: Collecting candidate features
+1 day, 20:10:24.212894 WARNING: intensity_correlation has 6 NaNs ( 0.02 % out of 30227)
+1 day, 20:10:24.218201 INFO: Collecting fragment features
+1 day, 20:10:24.236228 INFO: Finished candidate scoring
+1 day, 20:10:24.248613 PROGRESS: === Extracted 30227 precursors and 319071 fragments ===
+1 day, 20:10:24.248981 INFO: performing precursor FDR with 47 features
+1 day, 20:10:24.249019 INFO: Decoy channel: -1
+1 day, 20:10:24.249057 INFO: Competetive: True
+1 day, 20:10:24.256967 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:24.260943 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 20:10:24.634434 INFO: Test AUC: 0.876
+1 day, 20:10:24.634560 INFO: Train AUC: 0.880
+1 day, 20:10:24.634590 INFO: AUC difference: 0.50%
+1 day, 20:10:24.720528 INFO: Resetting torch num_threads to 100
+1 day, 20:10:24.721714 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:24.723062 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:24.723163 PROGRESS: Total precursors accumulated: 7,999
+1 day, 20:10:24.723225 PROGRESS: Target precursors: 7,935 (99.20%)
+1 day, 20:10:24.723277 PROGRESS: Decoy precursors: 64 (0.80%)
+1 day, 20:10:24.723324 PROGRESS: 
+1 day, 20:10:24.723371 PROGRESS: Precursor Summary:
+1 day, 20:10:24.726362 PROGRESS: Channel   0:	 0.05 FDR: 7,935; 0.01 FDR: 7,935; 0.001 FDR: 7,802
+1 day, 20:10:24.726477 PROGRESS: 
+1 day, 20:10:24.726534 PROGRESS: Protein Summary:
+1 day, 20:10:24.731109 PROGRESS: Channel   0:	 0.05 FDR: 4,199; 0.01 FDR: 4,199; 0.001 FDR: 4,144
+1 day, 20:10:24.731224 PROGRESS: =========================================================================
+1 day, 20:10:24.756187 INFO: fragments_df_filtered: 5000
+1 day, 20:10:24.770384 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:25.588043 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:26.425530 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:27.249322 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:27.599456 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:27.602319 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:27.611917 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:27.614380 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:27.633947 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:27.634122 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 20:10:27.640705 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 13.1899.
+1 day, 20:10:27.640774 INFO: ==============================================
+1 day, 20:10:27.640890 INFO: Starting optimization step 6.
+1 day, 20:10:27.640969 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:27.641052 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:27.646009 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:27.646079 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:27.646122 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:10:27.646152 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:10:27.647696 INFO: Starting candidate selection
+1 day, 20:10:29.217949 INFO: Starting candidate scoring
+1 day, 20:10:30.139586 INFO: Finished candidate processing
+1 day, 20:10:30.139689 INFO: Collecting candidate features
+1 day, 20:10:30.189836 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30184)
+1 day, 20:10:30.198141 INFO: Collecting fragment features
+1 day, 20:10:30.216049 INFO: Finished candidate scoring
+1 day, 20:10:30.228493 PROGRESS: === Extracted 30184 precursors and 317070 fragments ===
+1 day, 20:10:30.228862 INFO: performing precursor FDR with 47 features
+1 day, 20:10:30.228900 INFO: Decoy channel: -1
+1 day, 20:10:30.228925 INFO: Competetive: True
+1 day, 20:10:30.237056 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:30.240993 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 20:10:30.626424 INFO: Test AUC: 0.891
+1 day, 20:10:30.626548 INFO: Train AUC: 0.885
+1 day, 20:10:30.626579 INFO: AUC difference: 0.70%
+1 day, 20:10:30.712810 INFO: Resetting torch num_threads to 100
+1 day, 20:10:30.713917 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:30.715273 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:30.715369 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:30.715429 PROGRESS: Target precursors: 7,941 (99.26%)
+1 day, 20:10:30.715483 PROGRESS: Decoy precursors: 59 (0.74%)
+1 day, 20:10:30.715540 PROGRESS: 
+1 day, 20:10:30.715590 PROGRESS: Precursor Summary:
+1 day, 20:10:30.718597 PROGRESS: Channel   0:	 0.05 FDR: 7,941; 0.01 FDR: 7,941; 0.001 FDR: 7,742
+1 day, 20:10:30.718722 PROGRESS: 
+1 day, 20:10:30.718786 PROGRESS: Protein Summary:
+1 day, 20:10:30.723451 PROGRESS: Channel   0:	 0.05 FDR: 4,196; 0.01 FDR: 4,196; 0.001 FDR: 4,122
+1 day, 20:10:30.723565 PROGRESS: =========================================================================
+1 day, 20:10:30.748899 INFO: fragments_df_filtered: 5000
+1 day, 20:10:30.763085 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:31.658442 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:32.552308 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:33.375257 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:33.728811 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:33.731779 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:33.741434 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:33.743890 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:33.762721 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:33.762867 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 20:10:33.768956 PROGRESS: ❌ rt_error       : optimization incomplete after 7 search(es). Will search with parameter 10.6216.
+1 day, 20:10:33.769018 INFO: ==============================================
+1 day, 20:10:33.769127 INFO: Starting optimization step 7.
+1 day, 20:10:33.769196 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:33.769264 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:33.773728 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:33.773787 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:33.773825 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:10:33.773850 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.83
+1 day, 20:10:33.774806 INFO: Starting candidate selection
+1 day, 20:10:35.371916 INFO: Starting candidate scoring
+1 day, 20:10:36.299673 INFO: Finished candidate processing
+1 day, 20:10:36.300782 INFO: Collecting candidate features
+1 day, 20:10:36.350917 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30191)
+1 day, 20:10:36.358044 INFO: Collecting fragment features
+1 day, 20:10:36.376036 INFO: Finished candidate scoring
+1 day, 20:10:36.388384 PROGRESS: === Extracted 30191 precursors and 317226 fragments ===
+1 day, 20:10:36.388762 INFO: performing precursor FDR with 47 features
+1 day, 20:10:36.388800 INFO: Decoy channel: -1
+1 day, 20:10:36.388824 INFO: Competetive: True
+1 day, 20:10:36.396903 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:36.400840 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 20:10:36.769491 INFO: Test AUC: 0.889
+1 day, 20:10:36.769612 INFO: Train AUC: 0.890
+1 day, 20:10:36.769642 INFO: AUC difference: 0.17%
+1 day, 20:10:36.856005 INFO: Resetting torch num_threads to 100
+1 day, 20:10:36.857162 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:36.858589 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:36.858684 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:36.858745 PROGRESS: Target precursors: 7,947 (99.34%)
+1 day, 20:10:36.858796 PROGRESS: Decoy precursors: 53 (0.66%)
+1 day, 20:10:36.858846 PROGRESS: 
+1 day, 20:10:36.858891 PROGRESS: Precursor Summary:
+1 day, 20:10:36.861884 PROGRESS: Channel   0:	 0.05 FDR: 7,947; 0.01 FDR: 7,947; 0.001 FDR: 7,619
+1 day, 20:10:36.862004 PROGRESS: 
+1 day, 20:10:36.862064 PROGRESS: Protein Summary:
+1 day, 20:10:36.866600 PROGRESS: Channel   0:	 0.05 FDR: 4,197; 0.01 FDR: 4,197; 0.001 FDR: 4,072
+1 day, 20:10:36.866713 PROGRESS: =========================================================================
+1 day, 20:10:36.891561 INFO: fragments_df_filtered: 5000
+1 day, 20:10:36.905816 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:37.792427 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:38.630800 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:42.067949 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:42.426286 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:42.429572 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:42.439661 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:42.442081 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:42.461078 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:42.461242 PROGRESS: === Optimization of rt_error has been performed 8 time(s); minimum number is 2 ===
+1 day, 20:10:42.467555 PROGRESS: ❌ rt_error       : optimization incomplete after 8 search(es). Will search with parameter 11.1908.
+1 day, 20:10:42.467630 INFO: ==============================================
+1 day, 20:10:42.467737 INFO: Starting optimization step 8.
+1 day, 20:10:42.467805 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:42.467868 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:42.472342 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:42.472406 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:42.472442 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:10:42.472466 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.81
+1 day, 20:10:42.473508 INFO: Starting candidate selection
+1 day, 20:10:44.089671 INFO: Starting candidate scoring
+1 day, 20:10:45.006548 INFO: Finished candidate processing
+1 day, 20:10:45.006743 INFO: Collecting candidate features
+1 day, 20:10:45.057618 WARNING: intensity_correlation has 10 NaNs ( 0.03 % out of 30186)
+1 day, 20:10:45.061972 INFO: Collecting fragment features
+1 day, 20:10:45.081537 INFO: Finished candidate scoring
+1 day, 20:10:45.097539 PROGRESS: === Extracted 30186 precursors and 317173 fragments ===
+1 day, 20:10:45.097909 INFO: performing precursor FDR with 47 features
+1 day, 20:10:45.097947 INFO: Decoy channel: -1
+1 day, 20:10:45.097970 INFO: Competetive: True
+1 day, 20:10:45.106620 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:45.110676 WARNING: dropped 10 decoy PSMs due to missing features
+1 day, 20:10:45.470014 INFO: Test AUC: 0.890
+1 day, 20:10:45.470137 INFO: Train AUC: 0.891
+1 day, 20:10:45.470166 INFO: AUC difference: 0.20%
+1 day, 20:10:45.555347 INFO: Resetting torch num_threads to 100
+1 day, 20:10:45.556580 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:45.558123 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:45.558234 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:45.558303 PROGRESS: Target precursors: 7,949 (99.36%)
+1 day, 20:10:45.558358 PROGRESS: Decoy precursors: 51 (0.64%)
+1 day, 20:10:45.558409 PROGRESS: 
+1 day, 20:10:45.558457 PROGRESS: Precursor Summary:
+1 day, 20:10:45.561565 PROGRESS: Channel   0:	 0.05 FDR: 7,949; 0.01 FDR: 7,949; 0.001 FDR: 7,648
+1 day, 20:10:45.561694 PROGRESS: 
+1 day, 20:10:45.561755 PROGRESS: Protein Summary:
+1 day, 20:10:45.566473 PROGRESS: Channel   0:	 0.05 FDR: 4,200; 0.01 FDR: 4,200; 0.001 FDR: 4,082
+1 day, 20:10:45.566595 PROGRESS: =========================================================================
+1 day, 20:10:45.591290 INFO: fragments_df_filtered: 5000
+1 day, 20:10:45.605979 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:46.494137 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:47.396274 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:48.287997 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:48.704198 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:48.707144 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:48.716743 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:48.719129 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:48.737985 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:48.738147 PROGRESS: === Optimization of rt_error has been performed 9 time(s); minimum number is 2 ===
+1 day, 20:10:48.744311 PROGRESS: ❌ rt_error       : optimization incomplete after 9 search(es). Will search with parameter 11.2067.
+1 day, 20:10:48.744370 INFO: ==============================================
+1 day, 20:10:48.744465 INFO: Starting optimization step 9.
+1 day, 20:10:48.744532 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:48.744591 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:48.748970 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:48.749047 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:48.749087 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:10:48.749120 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:10:48.750012 INFO: Starting candidate selection
+1 day, 20:10:50.352818 INFO: Starting candidate scoring
+1 day, 20:10:51.261425 INFO: Finished candidate processing
+1 day, 20:10:51.261617 INFO: Collecting candidate features
+1 day, 20:10:51.322427 WARNING: intensity_correlation has 9 NaNs ( 0.03 % out of 30183)
+1 day, 20:10:51.326985 INFO: Collecting fragment features
+1 day, 20:10:51.344386 INFO: Finished candidate scoring
+1 day, 20:10:51.359729 PROGRESS: === Extracted 30183 precursors and 317133 fragments ===
+1 day, 20:10:51.360109 INFO: performing precursor FDR with 47 features
+1 day, 20:10:51.360147 INFO: Decoy channel: -1
+1 day, 20:10:51.360171 INFO: Competetive: True
+1 day, 20:10:51.368283 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:51.372351 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 20:10:51.731597 INFO: Test AUC: 0.893
+1 day, 20:10:51.731741 INFO: Train AUC: 0.891
+1 day, 20:10:51.731772 INFO: AUC difference: 0.30%
+1 day, 20:10:51.817366 INFO: Resetting torch num_threads to 100
+1 day, 20:10:51.818587 INFO: === FDR correction performed with classifier version 3 ===
+1 day, 20:10:51.819972 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:51.820068 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:51.820132 PROGRESS: Target precursors: 7,949 (99.36%)
+1 day, 20:10:51.820185 PROGRESS: Decoy precursors: 51 (0.64%)
+1 day, 20:10:51.820237 PROGRESS: 
+1 day, 20:10:51.820286 PROGRESS: Precursor Summary:
+1 day, 20:10:51.823333 PROGRESS: Channel   0:	 0.05 FDR: 7,949; 0.01 FDR: 7,949; 0.001 FDR: 7,677
+1 day, 20:10:51.823457 PROGRESS: 
+1 day, 20:10:51.823518 PROGRESS: Protein Summary:
+1 day, 20:10:51.828175 PROGRESS: Channel   0:	 0.05 FDR: 4,201; 0.01 FDR: 4,201; 0.001 FDR: 4,095
+1 day, 20:10:51.828296 PROGRESS: =========================================================================
+1 day, 20:10:51.853918 INFO: fragments_df_filtered: 5000
+1 day, 20:10:51.868542 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:52.755543 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:53.634881 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:10:54.456467 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:10:54.808156 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:54.811445 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:54.821220 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:54.823649 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:54.843061 INFO: === checking if optimization conditions were reached ===
+1 day, 20:10:54.843224 PROGRESS: === Optimization of rt_error has been performed 10 time(s); minimum number is 2 ===
+1 day, 20:10:54.844294 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 10.6216 found after 10 searches.
+1 day, 20:10:54.844349 INFO: ==============================================
+1 day, 20:10:54.844442 PROGRESS: Optimization finished for rt_error.
+1 day, 20:10:54.860938 INFO: calibration group: precursor, predicting mz
+1 day, 20:10:54.863880 INFO: calibration group: precursor, predicting rt
+1 day, 20:10:54.873394 INFO: calibration group: precursor, predicting mobility
+1 day, 20:10:54.875822 INFO: calibration group: fragment, predicting mz
+1 day, 20:10:54.920324 INFO: Starting optimization step 0.
+1 day, 20:10:54.920498 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:10:54.920569 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:10:54.925103 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:10:54.925166 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:10:54.925203 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:10:54.925227 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.81
+1 day, 20:10:54.926163 INFO: Starting candidate selection
+1 day, 20:10:56.556741 INFO: Starting candidate scoring
+1 day, 20:10:57.478440 INFO: Finished candidate processing
+1 day, 20:10:57.478556 INFO: Collecting candidate features
+1 day, 20:10:57.536896 WARNING: intensity_correlation has 10 NaNs ( 0.03 % out of 30180)
+1 day, 20:10:57.542326 INFO: Collecting fragment features
+1 day, 20:10:57.569472 INFO: Finished candidate scoring
+1 day, 20:10:57.585742 PROGRESS: === Extracted 30180 precursors and 317038 fragments ===
+1 day, 20:10:57.586154 INFO: performing precursor FDR with 47 features
+1 day, 20:10:57.586192 INFO: Decoy channel: -1
+1 day, 20:10:57.586216 INFO: Competetive: True
+1 day, 20:10:57.599572 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:10:57.603794 WARNING: dropped 10 decoy PSMs due to missing features
+1 day, 20:10:57.971177 INFO: Test AUC: 0.898
+1 day, 20:10:57.971297 INFO: Train AUC: 0.900
+1 day, 20:10:57.971327 INFO: AUC difference: 0.26%
+1 day, 20:10:58.061506 INFO: Resetting torch num_threads to 100
+1 day, 20:10:58.062756 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 20:10:58.064243 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:10:58.064345 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:10:58.064406 PROGRESS: Target precursors: 7,953 (99.41%)
+1 day, 20:10:58.064460 PROGRESS: Decoy precursors: 47 (0.59%)
+1 day, 20:10:58.064508 PROGRESS: 
+1 day, 20:10:58.064554 PROGRESS: Precursor Summary:
+1 day, 20:10:58.067792 PROGRESS: Channel   0:	 0.05 FDR: 7,953; 0.01 FDR: 7,953; 0.001 FDR: 7,766
+1 day, 20:10:58.067919 PROGRESS: 
+1 day, 20:10:58.067978 PROGRESS: Protein Summary:
+1 day, 20:10:58.076361 PROGRESS: Channel   0:	 0.05 FDR: 4,199; 0.01 FDR: 4,199; 0.001 FDR: 4,127
+1 day, 20:10:58.076662 PROGRESS: =========================================================================
+1 day, 20:10:58.106336 INFO: fragments_df_filtered: 5000
+1 day, 20:10:58.125233 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:10:59.020820 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:10:59.869413 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:11:00.694675 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:11:01.048439 INFO: calibration group: precursor, predicting mz
+1 day, 20:11:01.051438 INFO: calibration group: precursor, predicting rt
+1 day, 20:11:01.061160 INFO: calibration group: precursor, predicting mobility
+1 day, 20:11:01.063572 INFO: calibration group: fragment, predicting mz
+1 day, 20:11:01.083861 INFO: === checking if optimization conditions were reached ===
+1 day, 20:11:01.084064 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:11:01.087065 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0600.
+1 day, 20:11:01.087131 INFO: ==============================================
+1 day, 20:11:01.087242 INFO: Starting optimization step 1.
+1 day, 20:11:01.087323 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:11:01.087398 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:11:01.093472 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:11:01.093547 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:11:01.093596 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:11:01.093627 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:11:01.100365 INFO: Starting candidate selection
+1 day, 20:11:02.483902 INFO: Starting candidate scoring
+1 day, 20:11:03.393177 INFO: Finished candidate processing
+1 day, 20:11:03.393382 INFO: Collecting candidate features
+1 day, 20:11:03.478110 WARNING: intensity_correlation has 12 NaNs ( 0.04 % out of 30129)
+1 day, 20:11:03.482787 INFO: Collecting fragment features
+1 day, 20:11:03.504670 INFO: Finished candidate scoring
+1 day, 20:11:03.521961 PROGRESS: === Extracted 30129 precursors and 314144 fragments ===
+1 day, 20:11:03.522412 INFO: performing precursor FDR with 47 features
+1 day, 20:11:03.522460 INFO: Decoy channel: -1
+1 day, 20:11:03.522501 INFO: Competetive: True
+1 day, 20:11:03.535456 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:11:03.540405 WARNING: dropped 12 decoy PSMs due to missing features
+1 day, 20:11:03.998979 INFO: Test AUC: 0.895
+1 day, 20:11:03.999141 INFO: Train AUC: 0.901
+1 day, 20:11:03.999173 INFO: AUC difference: 0.71%
+1 day, 20:11:04.091208 INFO: Resetting torch num_threads to 100
+1 day, 20:11:04.092936 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 20:11:04.094618 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:11:04.094735 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:11:04.094808 PROGRESS: Target precursors: 7,958 (99.50%)
+1 day, 20:11:04.094872 PROGRESS: Decoy precursors: 40 (0.50%)
+1 day, 20:11:04.094929 PROGRESS: 
+1 day, 20:11:04.094982 PROGRESS: Precursor Summary:
+1 day, 20:11:04.098362 PROGRESS: Channel   0:	 0.05 FDR: 7,958; 0.01 FDR: 7,958; 0.001 FDR: 7,797
+1 day, 20:11:04.098504 PROGRESS: 
+1 day, 20:11:04.098573 PROGRESS: Protein Summary:
+1 day, 20:11:04.103609 PROGRESS: Channel   0:	 0.05 FDR: 4,205; 0.01 FDR: 4,205; 0.001 FDR: 4,143
+1 day, 20:11:04.103735 PROGRESS: =========================================================================
+1 day, 20:11:04.129955 INFO: fragments_df_filtered: 5000
+1 day, 20:11:04.149862 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:11:04.976893 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:11:05.886707 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:11:06.780040 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:11:07.200039 INFO: calibration group: precursor, predicting mz
+1 day, 20:11:07.203277 INFO: calibration group: precursor, predicting rt
+1 day, 20:11:07.213192 INFO: calibration group: precursor, predicting mobility
+1 day, 20:11:07.215621 INFO: calibration group: fragment, predicting mz
+1 day, 20:11:07.235104 INFO: === checking if optimization conditions were reached ===
+1 day, 20:11:07.235306 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:11:07.238498 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0542.
+1 day, 20:11:07.238565 INFO: ==============================================
+1 day, 20:11:07.238689 INFO: Starting optimization step 2.
+1 day, 20:11:07.238770 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:11:07.238844 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:11:07.245998 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:11:07.246078 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:11:07.246125 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:11:07.246154 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:11:07.247301 INFO: Starting candidate selection
+1 day, 20:11:08.610744 INFO: Starting candidate scoring
+1 day, 20:11:09.529863 INFO: Finished candidate processing
+1 day, 20:11:09.529965 INFO: Collecting candidate features
+1 day, 20:11:09.590934 WARNING: intensity_correlation has 13 NaNs ( 0.04 % out of 30109)
+1 day, 20:11:09.598114 INFO: Collecting fragment features
+1 day, 20:11:09.620300 INFO: Finished candidate scoring
+1 day, 20:11:09.634356 PROGRESS: === Extracted 30109 precursors and 312978 fragments ===
+1 day, 20:11:09.634725 INFO: performing precursor FDR with 47 features
+1 day, 20:11:09.634764 INFO: Decoy channel: -1
+1 day, 20:11:09.634789 INFO: Competetive: True
+1 day, 20:11:09.642900 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:11:09.646880 WARNING: dropped 13 decoy PSMs due to missing features
+1 day, 20:11:10.010388 INFO: Test AUC: 0.899
+1 day, 20:11:10.010514 INFO: Train AUC: 0.899
+1 day, 20:11:10.010545 INFO: AUC difference: 0.02%
+1 day, 20:11:10.099850 INFO: Resetting torch num_threads to 100
+1 day, 20:11:10.101109 INFO: === FDR correction performed with classifier version 11 ===
+1 day, 20:11:10.102618 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:11:10.102729 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:11:10.102792 PROGRESS: Target precursors: 7,955 (99.46%)
+1 day, 20:11:10.102847 PROGRESS: Decoy precursors: 43 (0.54%)
+1 day, 20:11:10.102899 PROGRESS: 
+1 day, 20:11:10.102947 PROGRESS: Precursor Summary:
+1 day, 20:11:10.106191 PROGRESS: Channel   0:	 0.05 FDR: 7,955; 0.01 FDR: 7,955; 0.001 FDR: 7,719
+1 day, 20:11:10.106322 PROGRESS: 
+1 day, 20:11:10.106383 PROGRESS: Protein Summary:
+1 day, 20:11:10.111140 PROGRESS: Channel   0:	 0.05 FDR: 4,203; 0.01 FDR: 4,203; 0.001 FDR: 4,111
+1 day, 20:11:10.111258 PROGRESS: =========================================================================
+1 day, 20:11:10.135921 INFO: fragments_df_filtered: 5000
+1 day, 20:11:10.150520 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:11:10.976816 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:11:11.815116 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:11:12.641378 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:11:12.991558 INFO: calibration group: precursor, predicting mz
+1 day, 20:11:12.994526 INFO: calibration group: precursor, predicting rt
+1 day, 20:11:13.004234 INFO: calibration group: precursor, predicting mobility
+1 day, 20:11:13.006685 INFO: calibration group: fragment, predicting mz
+1 day, 20:11:13.025825 INFO: === checking if optimization conditions were reached ===
+1 day, 20:11:13.025996 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:11:13.026961 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0600 found after 3 searches.
+1 day, 20:11:13.027018 INFO: ==============================================
+1 day, 20:11:13.027122 PROGRESS: Optimization finished for mobility_error.
+1 day, 20:11:13.046700 INFO: calibration group: precursor, predicting mz
+1 day, 20:11:13.049977 INFO: calibration group: precursor, predicting rt
+1 day, 20:11:13.059964 INFO: calibration group: precursor, predicting mobility
+1 day, 20:11:13.062697 INFO: calibration group: fragment, predicting mz
+1 day, 20:11:13.114914 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 20:11:13.115117 PROGRESS: ==============================================
+1 day, 20:11:13.115201 PROGRESS: ms2_error      : 15.0000
+1 day, 20:11:13.115286 PROGRESS: ms1_error      : 10.0000
+1 day, 20:11:13.115353 PROGRESS: rt_error       : 10.6216
+1 day, 20:11:13.115410 PROGRESS: mobility_error : 0.0600
+1 day, 20:11:13.115464 PROGRESS: ==============================================
+1 day, 20:11:13.117102 INFO: calibration group: precursor, predicting mz
+1 day, 20:11:13.138653 INFO: calibration group: precursor, predicting rt
+1 day, 20:11:13.232577 INFO: calibration group: precursor, predicting mobility
+1 day, 20:11:13.255337 INFO: calibration group: fragment, predicting mz
+1 day, 20:11:13.487196 PROGRESS: Extracting batch of 162861 precursors
+1 day, 20:11:13.532449 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:11:13.532582 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:11:13.532628 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:11:13.532653 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:11:13.533431 INFO: Starting candidate selection
+1 day, 20:11:22.577647 INFO: Applying score cutoff of 19.506486516952513
+1 day, 20:11:22.585441 INFO: Removed 8424 precursors with score below cutoff
+1 day, 20:11:22.900509 INFO: Starting candidate scoring
+1 day, 20:11:31.443998 INFO: Finished candidate processing
+1 day, 20:11:31.444103 INFO: Collecting candidate features
+1 day, 20:11:31.936143 WARNING: intensity_correlation has 24 NaNs ( 0.01 % out of 301317)
+1 day, 20:11:31.949656 INFO: Collecting fragment features
+1 day, 20:11:32.154980 INFO: Finished candidate scoring
+1 day, 20:11:32.309503 INFO: === FDR correction performed with classifier version 15 ===
+1 day, 20:11:32.310489 INFO: performing precursor FDR with 47 features
+1 day, 20:11:32.310536 INFO: Decoy channel: -1
+1 day, 20:11:32.310561 INFO: Competetive: True
+1 day, 20:11:32.395037 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:11:32.438454 WARNING: dropped 1 target PSMs due to missing features
+1 day, 20:11:32.438591 WARNING: dropped 23 decoy PSMs due to missing features
+1 day, 20:11:37.651629 INFO: Test AUC: 0.911
+1 day, 20:11:37.651755 INFO: Train AUC: 0.915
+1 day, 20:11:37.651787 INFO: AUC difference: 0.46%
+1 day, 20:11:37.756048 INFO: Resetting torch num_threads to 100
+1 day, 20:11:37.769036 INFO: Removing fragments below FDR threshold
+1 day, 20:11:37.822397 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:11:37.822670 PROGRESS: Total precursors accumulated: 81,941
+1 day, 20:11:37.822738 PROGRESS: Target precursors: 81,465 (99.42%)
+1 day, 20:11:37.822803 PROGRESS: Decoy precursors: 476 (0.58%)
+1 day, 20:11:37.822852 PROGRESS: 
+1 day, 20:11:37.822897 PROGRESS: Precursor Summary:
+1 day, 20:11:37.858388 PROGRESS: Channel   0:	 0.05 FDR: 81,465; 0.01 FDR: 81,465; 0.001 FDR: 80,430
+1 day, 20:11:37.858730 PROGRESS: 
+1 day, 20:11:37.858798 PROGRESS: Protein Summary:
+1 day, 20:11:37.906696 PROGRESS: Channel   0:	 0.05 FDR: 8,249; 0.01 FDR: 8,249; 0.001 FDR: 8,241
+1 day, 20:11:37.906977 PROGRESS: =========================================================================
+1 day, 20:11:38.585119 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 20:11:38.628867 PROGRESS: Loading raw file 5/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:11:38.629058 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 20:11:38.629139 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:11:38.629936 INFO: Initializing RawFileManager
+1 day, 20:11:38.630054 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:38.630107 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:38.630165 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:38.841612 INFO: Reading 39,128 frames with 2,766,418,119 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.860468 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d...
+1 day, 20:11:45.862052 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.864497 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.864719 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.865213 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.866647 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.880411 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:45.880798 INFO: Indexing quadrupole dimension
+1 day, 20:11:46.346634 INFO: Transposing detector events
+1 day, 20:11:54.989460 INFO: Finished transposing data
+1 day, 20:11:55.015359 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d
+1 day, 20:11:55.017896 INFO: RT (min)            : 0.0 - 70.0
+1 day, 20:11:55.017944 INFO: RT duration (sec)   : 4199.9
+1 day, 20:11:55.017968 INFO: RT duration (min)   : 70.0
+1 day, 20:11:55.017991 INFO: Cycle len (scans)   : 9
+1 day, 20:11:55.018009 INFO: Cycle len (sec)     : 0.97
+1 day, 20:11:55.018029 INFO: Number of cycles    : 4347
+1 day, 20:11:55.018047 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 20:11:55.066081 INFO: Initializing CalibrationManager
+1 day, 20:11:55.066442 INFO: Loading calibration config
+1 day, 20:11:55.067205 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 20:11:55.067311 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 20:11:55.067411 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 20:11:55.067593 INFO: Initializing OptimizationManager
+1 day, 20:11:55.067723 INFO: initial parameter: ms1_error = 30
+1 day, 20:11:55.067789 INFO: initial parameter: ms2_error = 30
+1 day, 20:11:55.067857 INFO: initial parameter: rt_error = 2099.9331315
+1 day, 20:11:55.067909 INFO: initial parameter: mobility_error = 0.1
+1 day, 20:11:55.067958 INFO: initial parameter: column_type = library
+1 day, 20:11:55.068003 INFO: initial parameter: num_candidates = 1
+1 day, 20:11:55.068047 INFO: initial parameter: classifier_version = -1
+1 day, 20:11:55.068090 INFO: initial parameter: fwhm_rt = 5
+1 day, 20:11:55.068144 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 20:11:55.068190 INFO: initial parameter: score_cutoff = 0
+1 day, 20:11:55.068259 INFO: Initializing TimingManager
+1 day, 20:11:55.068320 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:11:55.068419 INFO: FDRManager not loaded from disk.
+1 day, 20:11:55.068446 INFO: Initializing FDRManager
+1 day, 20:11:55.068484 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 20:11:55.099908 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 20:11:55.140842 PROGRESS: Starting initial search for precursors.
+1 day, 20:11:55.162049 INFO: Starting optimization step 0.
+1 day, 20:11:55.162284 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:11:55.162364 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:11:55.166134 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:11:55.166190 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:11:55.166227 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 20:11:55.166250 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 20:11:55.167188 INFO: Starting candidate selection
+1 day, 20:13:20.395290 INFO: Starting candidate scoring
+1 day, 20:13:21.413963 INFO: Finished candidate processing
+1 day, 20:13:21.414071 INFO: Collecting candidate features
+1 day, 20:13:21.449005 INFO: Collecting fragment features
+1 day, 20:13:21.463222 INFO: Finished candidate scoring
+1 day, 20:13:21.472211 PROGRESS: === Extracted 15885 precursors and 175780 fragments ===
+1 day, 20:13:21.472651 INFO: performing precursor FDR with 47 features
+1 day, 20:13:21.472692 INFO: Decoy channel: -1
+1 day, 20:13:21.472726 INFO: Competetive: True
+1 day, 20:13:21.477400 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:13:21.638344 INFO: Test AUC: 0.828
+1 day, 20:13:21.638466 INFO: Train AUC: 0.827
+1 day, 20:13:21.638498 INFO: AUC difference: 0.05%
+1 day, 20:13:21.728357 INFO: Resetting torch num_threads to 100
+1 day, 20:13:21.730260 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 20:13:21.731756 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:13:21.731860 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:13:21.731924 PROGRESS: Target precursors: 6,634 (82.93%)
+1 day, 20:13:21.731976 PROGRESS: Decoy precursors: 1,366 (17.08%)
+1 day, 20:13:21.732021 PROGRESS: 
+1 day, 20:13:21.732066 PROGRESS: Precursor Summary:
+1 day, 20:13:21.734378 PROGRESS: Channel   0:	 0.05 FDR: 5,234; 0.01 FDR: 3,641; 0.001 FDR: 2,217
+1 day, 20:13:21.734491 PROGRESS: 
+1 day, 20:13:21.734554 PROGRESS: Protein Summary:
+1 day, 20:13:21.737489 PROGRESS: Channel   0:	 0.05 FDR: 3,026; 0.01 FDR: 2,280; 0.001 FDR: 1,482
+1 day, 20:13:21.737595 PROGRESS: =========================================================================
+1 day, 20:13:21.746327 INFO: fragments_df_filtered: 5000
+1 day, 20:13:21.764049 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:13:21.970504 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:13:22.189926 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:13:22.397737 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:13:22.751724 INFO: calibration group: precursor, predicting mz
+1 day, 20:13:22.754649 INFO: calibration group: precursor, predicting rt
+1 day, 20:13:22.764708 INFO: calibration group: precursor, predicting mobility
+1 day, 20:13:22.767194 INFO: calibration group: fragment, predicting mz
+1 day, 20:13:22.786798 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 20:13:22.787014 INFO: Starting optimization step 1.
+1 day, 20:13:22.787097 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:13:22.787170 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:13:22.792831 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:13:22.792902 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:13:22.792952 INFO: FWHM in RT is 3.32 seconds, sigma is 0.73
+1 day, 20:13:22.792981 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.28
+1 day, 20:13:22.794123 INFO: Starting candidate selection
+1 day, 20:14:56.823112 INFO: Starting candidate scoring
+1 day, 20:14:58.719117 INFO: Finished candidate processing
+1 day, 20:14:58.719227 INFO: Collecting candidate features
+1 day, 20:14:58.780572 INFO: Collecting fragment features
+1 day, 20:14:58.800712 INFO: Finished candidate scoring
+1 day, 20:14:58.814211 PROGRESS: === Extracted 30442 precursors and 336817 fragments ===
+1 day, 20:14:58.814667 INFO: performing precursor FDR with 47 features
+1 day, 20:14:58.814706 INFO: Decoy channel: -1
+1 day, 20:14:58.814731 INFO: Competetive: True
+1 day, 20:14:58.824710 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:14:59.193181 INFO: Test AUC: 0.716
+1 day, 20:14:59.193300 INFO: Train AUC: 0.726
+1 day, 20:14:59.193330 INFO: AUC difference: 1.26%
+1 day, 20:14:59.282863 INFO: Resetting torch num_threads to 100
+1 day, 20:14:59.284061 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 20:14:59.285677 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:14:59.285797 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:14:59.285861 PROGRESS: Target precursors: 7,204 (90.05%)
+1 day, 20:14:59.285914 PROGRESS: Decoy precursors: 796 (9.95%)
+1 day, 20:14:59.285961 PROGRESS: 
+1 day, 20:14:59.286008 PROGRESS: Precursor Summary:
+1 day, 20:14:59.288899 PROGRESS: Channel   0:	 0.05 FDR: 6,022; 0.01 FDR: 5,071; 0.001 FDR: 2,552
+1 day, 20:14:59.289019 PROGRESS: 
+1 day, 20:14:59.289103 PROGRESS: Protein Summary:
+1 day, 20:14:59.292352 PROGRESS: Channel   0:	 0.05 FDR: 3,392; 0.01 FDR: 2,949; 0.001 FDR: 1,703
+1 day, 20:14:59.292465 PROGRESS: =========================================================================
+1 day, 20:14:59.310642 INFO: fragments_df_filtered: 5000
+1 day, 20:14:59.329352 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:14:59.692460 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:15:00.076452 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:15:00.438072 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:15:00.787388 INFO: calibration group: precursor, predicting mz
+1 day, 20:15:00.790295 INFO: calibration group: precursor, predicting rt
+1 day, 20:15:00.800467 INFO: calibration group: precursor, predicting mobility
+1 day, 20:15:00.802912 INFO: calibration group: fragment, predicting mz
+1 day, 20:15:00.822855 INFO: === checking if optimization conditions were reached ===
+1 day, 20:15:00.824659 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 20:15:00.826431 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 20:15:00.826484 INFO: ==============================================
+1 day, 20:15:00.826578 INFO: Starting optimization step 2.
+1 day, 20:15:00.826646 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:15:00.826710 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:15:00.830683 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:15:00.830748 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:15:00.830790 INFO: FWHM in RT is 3.20 seconds, sigma is 0.70
+1 day, 20:15:00.830815 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 4.99
+1 day, 20:15:00.831806 INFO: Starting candidate selection
+1 day, 20:16:32.370714 INFO: Starting candidate scoring
+1 day, 20:16:33.410882 INFO: Finished candidate processing
+1 day, 20:16:33.410986 INFO: Collecting candidate features
+1 day, 20:16:33.473485 INFO: Collecting fragment features
+1 day, 20:16:33.493209 INFO: Finished candidate scoring
+1 day, 20:16:33.506716 PROGRESS: === Extracted 30467 precursors and 332826 fragments ===
+1 day, 20:16:33.507169 INFO: performing precursor FDR with 47 features
+1 day, 20:16:33.507209 INFO: Decoy channel: -1
+1 day, 20:16:33.507233 INFO: Competetive: True
+1 day, 20:16:33.517236 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:16:33.886764 INFO: Test AUC: 0.766
+1 day, 20:16:33.886883 INFO: Train AUC: 0.768
+1 day, 20:16:33.886912 INFO: AUC difference: 0.25%
+1 day, 20:16:33.976543 INFO: Resetting torch num_threads to 100
+1 day, 20:16:33.977786 INFO: === FDR correction performed with classifier version 1 ===
+1 day, 20:16:33.979367 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:16:33.979469 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:16:33.979534 PROGRESS: Target precursors: 7,811 (97.64%)
+1 day, 20:16:33.979587 PROGRESS: Decoy precursors: 189 (2.36%)
+1 day, 20:16:33.979637 PROGRESS: 
+1 day, 20:16:33.979685 PROGRESS: Precursor Summary:
+1 day, 20:16:33.982579 PROGRESS: Channel   0:	 0.05 FDR: 7,811; 0.01 FDR: 6,884; 0.001 FDR: 6,036
+1 day, 20:16:33.982710 PROGRESS: 
+1 day, 20:16:33.982770 PROGRESS: Protein Summary:
+1 day, 20:16:33.987083 PROGRESS: Channel   0:	 0.05 FDR: 4,139; 0.01 FDR: 3,742; 0.001 FDR: 3,388
+1 day, 20:16:33.987197 PROGRESS: =========================================================================
+1 day, 20:16:34.011002 INFO: fragments_df_filtered: 5000
+1 day, 20:16:34.029583 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:16:34.659708 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:16:35.315391 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:16:35.943562 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:16:36.295160 INFO: calibration group: precursor, predicting mz
+1 day, 20:16:36.298166 INFO: calibration group: precursor, predicting rt
+1 day, 20:16:36.307913 INFO: calibration group: precursor, predicting mobility
+1 day, 20:16:36.310404 INFO: calibration group: fragment, predicting mz
+1 day, 20:16:36.331019 INFO: === checking if optimization conditions were reached ===
+1 day, 20:16:36.333100 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 20:16:36.335276 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 20:16:36.335979 INFO: ==============================================
+1 day, 20:16:36.336105 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 20:16:36.355244 INFO: calibration group: precursor, predicting mz
+1 day, 20:16:36.358117 INFO: calibration group: precursor, predicting rt
+1 day, 20:16:36.367602 INFO: calibration group: precursor, predicting mobility
+1 day, 20:16:36.370033 INFO: calibration group: fragment, predicting mz
+1 day, 20:16:36.391255 INFO: Starting optimization step 0.
+1 day, 20:16:36.391415 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:16:36.391489 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:16:36.395633 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:16:36.395687 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:16:36.395730 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:16:36.395754 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.00
+1 day, 20:16:36.404801 INFO: Starting candidate selection
+1 day, 20:18:04.379953 INFO: Starting candidate scoring
+1 day, 20:18:05.418231 INFO: Finished candidate processing
+1 day, 20:18:05.418337 INFO: Collecting candidate features
+1 day, 20:18:05.483882 INFO: Collecting fragment features
+1 day, 20:18:05.507390 INFO: Finished candidate scoring
+1 day, 20:18:05.520710 PROGRESS: === Extracted 30455 precursors and 332185 fragments ===
+1 day, 20:18:05.521187 INFO: performing precursor FDR with 47 features
+1 day, 20:18:05.521228 INFO: Decoy channel: -1
+1 day, 20:18:05.521252 INFO: Competetive: True
+1 day, 20:18:05.531406 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:18:05.904896 INFO: Test AUC: 0.771
+1 day, 20:18:05.905020 INFO: Train AUC: 0.775
+1 day, 20:18:05.905061 INFO: AUC difference: 0.61%
+1 day, 20:18:05.994035 INFO: Resetting torch num_threads to 100
+1 day, 20:18:05.995247 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:18:05.996809 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:18:05.996904 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:18:05.996964 PROGRESS: Target precursors: 7,860 (98.25%)
+1 day, 20:18:05.997017 PROGRESS: Decoy precursors: 140 (1.75%)
+1 day, 20:18:05.997078 PROGRESS: 
+1 day, 20:18:05.997123 PROGRESS: Precursor Summary:
+1 day, 20:18:06.000030 PROGRESS: Channel   0:	 0.05 FDR: 7,860; 0.01 FDR: 7,846; 0.001 FDR: 6,248
+1 day, 20:18:06.000157 PROGRESS: 
+1 day, 20:18:06.000216 PROGRESS: Protein Summary:
+1 day, 20:18:06.004633 PROGRESS: Channel   0:	 0.05 FDR: 4,170; 0.01 FDR: 4,163; 0.001 FDR: 3,477
+1 day, 20:18:06.004749 PROGRESS: =========================================================================
+1 day, 20:18:06.030975 INFO: fragments_df_filtered: 5000
+1 day, 20:18:06.050930 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:18:06.866266 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:18:07.694966 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:18:08.498230 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:18:08.849941 INFO: calibration group: precursor, predicting mz
+1 day, 20:18:08.852873 INFO: calibration group: precursor, predicting rt
+1 day, 20:18:08.862497 INFO: calibration group: precursor, predicting mobility
+1 day, 20:18:08.864904 INFO: calibration group: fragment, predicting mz
+1 day, 20:18:08.885442 INFO: === checking if optimization conditions were reached ===
+1 day, 20:18:08.885618 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:18:08.891654 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 1031.1060.
+1 day, 20:18:08.891717 INFO: ==============================================
+1 day, 20:18:08.891826 INFO: Starting optimization step 1.
+1 day, 20:18:08.891904 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:18:08.891977 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:18:08.895847 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:18:08.895929 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:18:08.895980 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:18:08.896010 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:18:08.897184 INFO: Starting candidate selection
+1 day, 20:18:55.062660 INFO: Starting candidate scoring
+1 day, 20:18:56.099849 INFO: Finished candidate processing
+1 day, 20:18:56.099956 INFO: Collecting candidate features
+1 day, 20:18:56.154335 INFO: Collecting fragment features
+1 day, 20:18:56.173475 INFO: Finished candidate scoring
+1 day, 20:18:56.186566 PROGRESS: === Extracted 30422 precursors and 331751 fragments ===
+1 day, 20:18:56.186947 INFO: performing precursor FDR with 47 features
+1 day, 20:18:56.186988 INFO: Decoy channel: -1
+1 day, 20:18:56.187012 INFO: Competetive: True
+1 day, 20:18:56.196063 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:18:56.552006 INFO: Test AUC: 0.784
+1 day, 20:18:56.552129 INFO: Train AUC: 0.777
+1 day, 20:18:56.552159 INFO: AUC difference: 0.93%
+1 day, 20:18:56.639782 INFO: Resetting torch num_threads to 100
+1 day, 20:18:56.640914 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:18:56.643817 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:18:56.643928 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:18:56.643993 PROGRESS: Target precursors: 7,849 (98.11%)
+1 day, 20:18:56.644049 PROGRESS: Decoy precursors: 151 (1.89%)
+1 day, 20:18:56.644102 PROGRESS: 
+1 day, 20:18:56.644152 PROGRESS: Precursor Summary:
+1 day, 20:18:56.647092 PROGRESS: Channel   0:	 0.05 FDR: 7,849; 0.01 FDR: 7,836; 0.001 FDR: 6,190
+1 day, 20:18:56.647216 PROGRESS: 
+1 day, 20:18:56.647290 PROGRESS: Protein Summary:
+1 day, 20:18:56.651723 PROGRESS: Channel   0:	 0.05 FDR: 4,165; 0.01 FDR: 4,162; 0.001 FDR: 3,464
+1 day, 20:18:56.651838 PROGRESS: =========================================================================
+1 day, 20:18:56.678464 INFO: fragments_df_filtered: 5000
+1 day, 20:18:56.695603 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:18:57.505904 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:18:58.320225 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:18:59.120299 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:18:59.470637 INFO: calibration group: precursor, predicting mz
+1 day, 20:18:59.473593 INFO: calibration group: precursor, predicting rt
+1 day, 20:18:59.483239 INFO: calibration group: precursor, predicting mobility
+1 day, 20:18:59.485664 INFO: calibration group: fragment, predicting mz
+1 day, 20:18:59.505973 INFO: === checking if optimization conditions were reached ===
+1 day, 20:18:59.506166 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:18:59.512681 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 892.1751.
+1 day, 20:18:59.512756 INFO: ==============================================
+1 day, 20:18:59.512874 INFO: Starting optimization step 2.
+1 day, 20:18:59.512954 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:18:59.513022 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:18:59.518975 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:18:59.519042 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:18:59.519083 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:18:59.519111 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:18:59.521639 INFO: Starting candidate selection
+1 day, 20:19:37.383161 INFO: Starting candidate scoring
+1 day, 20:19:38.425485 INFO: Finished candidate processing
+1 day, 20:19:38.425593 INFO: Collecting candidate features
+1 day, 20:19:38.484386 INFO: Collecting fragment features
+1 day, 20:19:38.511376 INFO: Finished candidate scoring
+1 day, 20:19:38.524308 PROGRESS: === Extracted 30421 precursors and 331549 fragments ===
+1 day, 20:19:38.524765 INFO: performing precursor FDR with 47 features
+1 day, 20:19:38.524805 INFO: Decoy channel: -1
+1 day, 20:19:38.524831 INFO: Competetive: True
+1 day, 20:19:38.535328 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:19:38.910869 INFO: Test AUC: 0.778
+1 day, 20:19:38.910985 INFO: Train AUC: 0.780
+1 day, 20:19:38.911015 INFO: AUC difference: 0.25%
+1 day, 20:19:38.998903 INFO: Resetting torch num_threads to 100
+1 day, 20:19:39.000106 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:19:39.001497 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:19:39.001594 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:19:39.001659 PROGRESS: Target precursors: 7,851 (98.14%)
+1 day, 20:19:39.001713 PROGRESS: Decoy precursors: 149 (1.86%)
+1 day, 20:19:39.001763 PROGRESS: 
+1 day, 20:19:39.001812 PROGRESS: Precursor Summary:
+1 day, 20:19:39.004818 PROGRESS: Channel   0:	 0.05 FDR: 7,851; 0.01 FDR: 7,839; 0.001 FDR: 6,451
+1 day, 20:19:39.004933 PROGRESS: 
+1 day, 20:19:39.004994 PROGRESS: Protein Summary:
+1 day, 20:19:39.009426 PROGRESS: Channel   0:	 0.05 FDR: 4,165; 0.01 FDR: 4,163; 0.001 FDR: 3,557
+1 day, 20:19:39.009538 PROGRESS: =========================================================================
+1 day, 20:19:39.035773 INFO: fragments_df_filtered: 5000
+1 day, 20:19:39.054664 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:19:39.855802 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:19:40.674818 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:19:41.477209 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:19:41.827121 INFO: calibration group: precursor, predicting mz
+1 day, 20:19:41.830643 INFO: calibration group: precursor, predicting rt
+1 day, 20:19:41.840178 INFO: calibration group: precursor, predicting mobility
+1 day, 20:19:41.842575 INFO: calibration group: fragment, predicting mz
+1 day, 20:19:41.863837 INFO: === checking if optimization conditions were reached ===
+1 day, 20:19:41.864025 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:19:41.870741 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 787.8072.
+1 day, 20:19:41.870817 INFO: ==============================================
+1 day, 20:19:41.870938 INFO: Starting optimization step 3.
+1 day, 20:19:41.871020 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:19:41.871096 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:19:41.876959 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:19:41.877038 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:19:41.877089 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:19:41.877119 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:19:41.879806 INFO: Starting candidate selection
+1 day, 20:20:14.590038 INFO: Starting candidate scoring
+1 day, 20:20:15.664352 INFO: Finished candidate processing
+1 day, 20:20:15.664527 INFO: Collecting candidate features
+1 day, 20:20:15.749988 INFO: Collecting fragment features
+1 day, 20:20:15.772627 INFO: Finished candidate scoring
+1 day, 20:20:15.787442 PROGRESS: === Extracted 30387 precursors and 330998 fragments ===
+1 day, 20:20:15.787935 INFO: performing precursor FDR with 47 features
+1 day, 20:20:15.787975 INFO: Decoy channel: -1
+1 day, 20:20:15.788005 INFO: Competetive: True
+1 day, 20:20:15.798440 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:20:16.169790 INFO: Test AUC: 0.782
+1 day, 20:20:16.169915 INFO: Train AUC: 0.783
+1 day, 20:20:16.169951 INFO: AUC difference: 0.14%
+1 day, 20:20:16.258286 INFO: Resetting torch num_threads to 100
+1 day, 20:20:16.259639 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:20:16.261172 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:20:16.261279 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:20:16.261367 PROGRESS: Target precursors: 7,852 (98.15%)
+1 day, 20:20:16.261435 PROGRESS: Decoy precursors: 148 (1.85%)
+1 day, 20:20:16.261512 PROGRESS: 
+1 day, 20:20:16.261575 PROGRESS: Precursor Summary:
+1 day, 20:20:16.264586 PROGRESS: Channel   0:	 0.05 FDR: 7,852; 0.01 FDR: 7,840; 0.001 FDR: 6,365
+1 day, 20:20:16.264711 PROGRESS: 
+1 day, 20:20:16.264781 PROGRESS: Protein Summary:
+1 day, 20:20:16.269304 PROGRESS: Channel   0:	 0.05 FDR: 4,169; 0.01 FDR: 4,166; 0.001 FDR: 3,529
+1 day, 20:20:16.269431 PROGRESS: =========================================================================
+1 day, 20:20:16.295497 INFO: fragments_df_filtered: 5000
+1 day, 20:20:16.314757 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:20:17.117392 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:20:17.936183 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:20:18.739216 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:20:19.087530 INFO: calibration group: precursor, predicting mz
+1 day, 20:20:19.090554 INFO: calibration group: precursor, predicting rt
+1 day, 20:20:19.100259 INFO: calibration group: precursor, predicting mobility
+1 day, 20:20:19.102652 INFO: calibration group: fragment, predicting mz
+1 day, 20:20:19.123930 INFO: === checking if optimization conditions were reached ===
+1 day, 20:20:19.124136 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 20:20:19.130811 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 721.5405.
+1 day, 20:20:19.130879 INFO: ==============================================
+1 day, 20:20:19.130998 INFO: Starting optimization step 4.
+1 day, 20:20:19.131072 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:20:19.131144 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:20:19.136921 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:20:19.136987 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:20:19.137052 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:20:19.137083 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:20:19.139707 INFO: Starting candidate selection
+1 day, 20:20:51.438925 INFO: Starting candidate scoring
+1 day, 20:20:52.504460 INFO: Finished candidate processing
+1 day, 20:20:52.504640 INFO: Collecting candidate features
+1 day, 20:20:52.595088 INFO: Collecting fragment features
+1 day, 20:20:52.618803 INFO: Finished candidate scoring
+1 day, 20:20:52.634033 PROGRESS: === Extracted 30390 precursors and 330818 fragments ===
+1 day, 20:20:52.634513 INFO: performing precursor FDR with 47 features
+1 day, 20:20:52.634566 INFO: Decoy channel: -1
+1 day, 20:20:52.634592 INFO: Competetive: True
+1 day, 20:20:52.646818 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:20:53.023814 INFO: Test AUC: 0.784
+1 day, 20:20:53.023956 INFO: Train AUC: 0.783
+1 day, 20:20:53.023986 INFO: AUC difference: 0.06%
+1 day, 20:20:53.112687 INFO: Resetting torch num_threads to 100
+1 day, 20:20:53.114231 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:20:53.115688 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:20:53.115783 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:20:53.115846 PROGRESS: Target precursors: 7,845 (98.06%)
+1 day, 20:20:53.115899 PROGRESS: Decoy precursors: 155 (1.94%)
+1 day, 20:20:53.115948 PROGRESS: 
+1 day, 20:20:53.115993 PROGRESS: Precursor Summary:
+1 day, 20:20:53.119257 PROGRESS: Channel   0:	 0.05 FDR: 7,845; 0.01 FDR: 7,835; 0.001 FDR: 6,274
+1 day, 20:20:53.119375 PROGRESS: 
+1 day, 20:20:53.119434 PROGRESS: Protein Summary:
+1 day, 20:20:53.124041 PROGRESS: Channel   0:	 0.05 FDR: 4,164; 0.01 FDR: 4,162; 0.001 FDR: 3,479
+1 day, 20:20:53.124151 PROGRESS: =========================================================================
+1 day, 20:20:53.149960 INFO: fragments_df_filtered: 5000
+1 day, 20:20:53.170136 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:20:54.036679 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:20:54.918314 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:20:55.786643 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:20:56.203186 INFO: calibration group: precursor, predicting mz
+1 day, 20:20:56.206154 INFO: calibration group: precursor, predicting rt
+1 day, 20:20:56.215526 INFO: calibration group: precursor, predicting mobility
+1 day, 20:20:56.217909 INFO: calibration group: fragment, predicting mz
+1 day, 20:20:56.238745 INFO: === checking if optimization conditions were reached ===
+1 day, 20:20:56.238953 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 20:20:56.245613 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 669.2799.
+1 day, 20:20:56.245682 INFO: ==============================================
+1 day, 20:20:56.245800 INFO: Starting optimization step 5.
+1 day, 20:20:56.245878 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:20:56.245954 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:20:56.252149 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:20:56.252214 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:20:56.252263 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:20:56.252294 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:20:56.255611 INFO: Starting candidate selection
+1 day, 20:21:24.883166 INFO: Starting candidate scoring
+1 day, 20:21:25.902302 INFO: Finished candidate processing
+1 day, 20:21:25.902470 INFO: Collecting candidate features
+1 day, 20:21:25.954091 INFO: Collecting fragment features
+1 day, 20:21:25.972169 INFO: Finished candidate scoring
+1 day, 20:21:25.985776 PROGRESS: === Extracted 30398 precursors and 330740 fragments ===
+1 day, 20:21:25.986181 INFO: performing precursor FDR with 47 features
+1 day, 20:21:25.986219 INFO: Decoy channel: -1
+1 day, 20:21:25.986243 INFO: Competetive: True
+1 day, 20:21:25.994914 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:21:26.358745 INFO: Test AUC: 0.794
+1 day, 20:21:26.358884 INFO: Train AUC: 0.782
+1 day, 20:21:26.358915 INFO: AUC difference: 1.50%
+1 day, 20:21:28.884447 INFO: Resetting torch num_threads to 100
+1 day, 20:21:28.885986 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:21:28.887831 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:21:28.887943 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:21:28.888005 PROGRESS: Target precursors: 7,848 (98.10%)
+1 day, 20:21:28.888057 PROGRESS: Decoy precursors: 152 (1.90%)
+1 day, 20:21:28.888106 PROGRESS: 
+1 day, 20:21:28.888152 PROGRESS: Precursor Summary:
+1 day, 20:21:28.891335 PROGRESS: Channel   0:	 0.05 FDR: 7,848; 0.01 FDR: 7,838; 0.001 FDR: 6,160
+1 day, 20:21:28.891465 PROGRESS: 
+1 day, 20:21:28.891524 PROGRESS: Protein Summary:
+1 day, 20:21:28.896253 PROGRESS: Channel   0:	 0.05 FDR: 4,164; 0.01 FDR: 4,162; 0.001 FDR: 3,445
+1 day, 20:21:28.896363 PROGRESS: =========================================================================
+1 day, 20:21:28.921973 INFO: fragments_df_filtered: 5000
+1 day, 20:21:28.938976 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:21:29.809752 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:21:30.692317 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:21:31.560473 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:21:31.977618 INFO: calibration group: precursor, predicting mz
+1 day, 20:21:31.980784 INFO: calibration group: precursor, predicting rt
+1 day, 20:21:31.990121 INFO: calibration group: precursor, predicting mobility
+1 day, 20:21:31.992505 INFO: calibration group: fragment, predicting mz
+1 day, 20:21:32.011919 INFO: === checking if optimization conditions were reached ===
+1 day, 20:21:32.012088 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 20:21:32.018198 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 639.0316.
+1 day, 20:21:32.018266 INFO: ==============================================
+1 day, 20:21:32.018378 INFO: Starting optimization step 6.
+1 day, 20:21:32.018448 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:21:32.018508 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:21:32.023731 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:21:32.023799 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:21:32.023838 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:21:32.023861 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:21:32.032447 INFO: Starting candidate selection
+1 day, 20:22:03.201230 INFO: Starting candidate scoring
+1 day, 20:22:04.240734 INFO: Finished candidate processing
+1 day, 20:22:04.240927 INFO: Collecting candidate features
+1 day, 20:22:04.327765 INFO: Collecting fragment features
+1 day, 20:22:04.352329 INFO: Finished candidate scoring
+1 day, 20:22:04.369682 PROGRESS: === Extracted 30389 precursors and 330593 fragments ===
+1 day, 20:22:04.370146 INFO: performing precursor FDR with 47 features
+1 day, 20:22:04.370187 INFO: Decoy channel: -1
+1 day, 20:22:04.370212 INFO: Competetive: True
+1 day, 20:22:04.383662 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:22:04.765932 INFO: Test AUC: 0.779
+1 day, 20:22:04.766071 INFO: Train AUC: 0.786
+1 day, 20:22:04.766101 INFO: AUC difference: 0.81%
+1 day, 20:22:04.855167 INFO: Resetting torch num_threads to 100
+1 day, 20:22:04.856738 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:22:04.858446 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:22:04.858555 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:22:04.858619 PROGRESS: Target precursors: 7,870 (98.38%)
+1 day, 20:22:04.858674 PROGRESS: Decoy precursors: 130 (1.62%)
+1 day, 20:22:04.858721 PROGRESS: 
+1 day, 20:22:04.858767 PROGRESS: Precursor Summary:
+1 day, 20:22:04.861871 PROGRESS: Channel   0:	 0.05 FDR: 7,870; 0.01 FDR: 7,855; 0.001 FDR: 6,235
+1 day, 20:22:04.862001 PROGRESS: 
+1 day, 20:22:04.862061 PROGRESS: Protein Summary:
+1 day, 20:22:04.866774 PROGRESS: Channel   0:	 0.05 FDR: 4,169; 0.01 FDR: 4,164; 0.001 FDR: 3,475
+1 day, 20:22:04.868265 PROGRESS: =========================================================================
+1 day, 20:22:04.894504 INFO: fragments_df_filtered: 5000
+1 day, 20:22:04.914240 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:22:05.789635 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:22:06.674764 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:22:07.545571 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:22:07.923263 INFO: calibration group: precursor, predicting mz
+1 day, 20:22:07.926443 INFO: calibration group: precursor, predicting rt
+1 day, 20:22:07.935854 INFO: calibration group: precursor, predicting mobility
+1 day, 20:22:07.938277 INFO: calibration group: fragment, predicting mz
+1 day, 20:22:07.958226 INFO: === checking if optimization conditions were reached ===
+1 day, 20:22:07.958423 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 20:22:07.959988 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 639.0316 found after 7 searches.
+1 day, 20:22:07.960047 INFO: ==============================================
+1 day, 20:22:07.960160 PROGRESS: Optimization finished for rt_error.
+1 day, 20:22:07.981650 INFO: calibration group: precursor, predicting mz
+1 day, 20:22:07.985062 INFO: calibration group: precursor, predicting rt
+1 day, 20:22:07.994909 INFO: calibration group: precursor, predicting mobility
+1 day, 20:22:07.997650 INFO: calibration group: fragment, predicting mz
+1 day, 20:22:08.052311 INFO: Starting optimization step 0.
+1 day, 20:22:08.052560 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:22:08.052653 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:22:08.059418 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:22:08.059488 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:22:08.059538 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:22:08.059566 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:22:08.068584 INFO: Starting candidate selection
+1 day, 20:22:39.831369 INFO: Starting candidate scoring
+1 day, 20:22:40.869587 INFO: Finished candidate processing
+1 day, 20:22:40.869709 INFO: Collecting candidate features
+1 day, 20:22:40.922008 INFO: Collecting fragment features
+1 day, 20:22:40.941611 INFO: Finished candidate scoring
+1 day, 20:22:40.959051 PROGRESS: === Extracted 30393 precursors and 330658 fragments ===
+1 day, 20:22:40.959483 INFO: performing precursor FDR with 47 features
+1 day, 20:22:40.959524 INFO: Decoy channel: -1
+1 day, 20:22:40.959552 INFO: Competetive: True
+1 day, 20:22:40.969934 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:22:41.244137 INFO: Test AUC: 0.788
+1 day, 20:22:41.244282 INFO: Train AUC: 0.786
+1 day, 20:22:41.244312 INFO: AUC difference: 0.26%
+1 day, 20:22:41.332439 INFO: Resetting torch num_threads to 100
+1 day, 20:22:41.334016 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 20:22:41.335625 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:22:41.335725 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:22:41.335785 PROGRESS: Target precursors: 7,853 (98.16%)
+1 day, 20:22:41.335839 PROGRESS: Decoy precursors: 147 (1.84%)
+1 day, 20:22:41.335886 PROGRESS: 
+1 day, 20:22:41.335932 PROGRESS: Precursor Summary:
+1 day, 20:22:41.339016 PROGRESS: Channel   0:	 0.05 FDR: 7,853; 0.01 FDR: 7,844; 0.001 FDR: 6,340
+1 day, 20:22:41.339146 PROGRESS: 
+1 day, 20:22:41.339204 PROGRESS: Protein Summary:
+1 day, 20:22:41.343856 PROGRESS: Channel   0:	 0.05 FDR: 4,166; 0.01 FDR: 4,164; 0.001 FDR: 3,507
+1 day, 20:22:41.343971 PROGRESS: =========================================================================
+1 day, 20:22:41.370062 INFO: fragments_df_filtered: 5000
+1 day, 20:22:41.387602 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:22:42.188076 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:22:43.006305 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:22:43.809350 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:22:44.161148 INFO: calibration group: precursor, predicting mz
+1 day, 20:22:44.164175 INFO: calibration group: precursor, predicting rt
+1 day, 20:22:44.173601 INFO: calibration group: precursor, predicting mobility
+1 day, 20:22:44.175920 INFO: calibration group: fragment, predicting mz
+1 day, 20:22:44.194033 INFO: === checking if optimization conditions were reached ===
+1 day, 20:22:44.194212 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:22:44.196855 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0703.
+1 day, 20:22:44.196913 INFO: ==============================================
+1 day, 20:22:44.197012 INFO: Starting optimization step 1.
+1 day, 20:22:44.197111 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:22:44.197180 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:22:44.202784 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:22:44.202843 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:22:44.202886 INFO: FWHM in RT is 2.91 seconds, sigma is 0.64
+1 day, 20:22:44.202910 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:22:44.203913 INFO: Starting candidate selection
+1 day, 20:23:05.937109 INFO: Starting candidate scoring
+1 day, 20:23:06.931257 INFO: Finished candidate processing
+1 day, 20:23:06.931429 INFO: Collecting candidate features
+1 day, 20:23:06.982204 INFO: Collecting fragment features
+1 day, 20:23:07.002141 INFO: Finished candidate scoring
+1 day, 20:23:07.018776 PROGRESS: === Extracted 30400 precursors and 329938 fragments ===
+1 day, 20:23:07.019185 INFO: performing precursor FDR with 47 features
+1 day, 20:23:07.019224 INFO: Decoy channel: -1
+1 day, 20:23:07.019248 INFO: Competetive: True
+1 day, 20:23:07.028025 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:23:07.389259 INFO: Test AUC: 0.788
+1 day, 20:23:07.389394 INFO: Train AUC: 0.786
+1 day, 20:23:07.389425 INFO: AUC difference: 0.20%
+1 day, 20:23:07.477542 INFO: Resetting torch num_threads to 100
+1 day, 20:23:07.479086 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 20:23:07.480648 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:23:07.480869 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:23:07.480943 PROGRESS: Target precursors: 7,864 (98.32%)
+1 day, 20:23:07.480996 PROGRESS: Decoy precursors: 134 (1.68%)
+1 day, 20:23:07.481058 PROGRESS: 
+1 day, 20:23:07.481108 PROGRESS: Precursor Summary:
+1 day, 20:23:07.484515 PROGRESS: Channel   0:	 0.05 FDR: 7,864; 0.01 FDR: 7,853; 0.001 FDR: 6,586
+1 day, 20:23:07.484640 PROGRESS: 
+1 day, 20:23:07.484699 PROGRESS: Protein Summary:
+1 day, 20:23:07.489451 PROGRESS: Channel   0:	 0.05 FDR: 4,175; 0.01 FDR: 4,169; 0.001 FDR: 3,607
+1 day, 20:23:07.489571 PROGRESS: =========================================================================
+1 day, 20:23:07.515311 INFO: fragments_df_filtered: 5000
+1 day, 20:23:07.531578 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:23:08.408142 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:23:09.293260 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:23:10.163976 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:23:10.581316 INFO: calibration group: precursor, predicting mz
+1 day, 20:23:10.584456 INFO: calibration group: precursor, predicting rt
+1 day, 20:23:10.594095 INFO: calibration group: precursor, predicting mobility
+1 day, 20:23:10.596492 INFO: calibration group: fragment, predicting mz
+1 day, 20:23:10.616468 INFO: === checking if optimization conditions were reached ===
+1 day, 20:23:10.616658 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:23:10.619326 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0583.
+1 day, 20:23:10.619382 INFO: ==============================================
+1 day, 20:23:10.619484 INFO: Starting optimization step 2.
+1 day, 20:23:10.619553 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:23:10.619612 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:23:10.624453 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:23:10.624510 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:23:10.624547 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 20:23:10.624570 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.85
+1 day, 20:23:10.625637 INFO: Starting candidate selection
+1 day, 20:23:28.076441 INFO: Starting candidate scoring
+1 day, 20:23:29.085725 INFO: Finished candidate processing
+1 day, 20:23:29.085849 INFO: Collecting candidate features
+1 day, 20:23:29.139993 WARNING: intensity_correlation has 2 NaNs ( 0.01 % out of 30391)
+1 day, 20:23:29.144610 INFO: Collecting fragment features
+1 day, 20:23:29.167470 INFO: Finished candidate scoring
+1 day, 20:23:29.184172 PROGRESS: === Extracted 30391 precursors and 329015 fragments ===
+1 day, 20:23:29.184657 INFO: performing precursor FDR with 47 features
+1 day, 20:23:29.184697 INFO: Decoy channel: -1
+1 day, 20:23:29.184726 INFO: Competetive: True
+1 day, 20:23:29.197597 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:23:29.202280 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 20:23:29.584356 INFO: Test AUC: 0.785
+1 day, 20:23:29.584490 INFO: Train AUC: 0.788
+1 day, 20:23:29.584533 INFO: AUC difference: 0.31%
+1 day, 20:23:29.675829 INFO: Resetting torch num_threads to 100
+1 day, 20:23:29.677432 INFO: === FDR correction performed with classifier version 9 ===
+1 day, 20:23:29.679058 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:23:29.679173 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:23:29.679244 PROGRESS: Target precursors: 7,872 (98.42%)
+1 day, 20:23:29.679306 PROGRESS: Decoy precursors: 126 (1.58%)
+1 day, 20:23:29.679362 PROGRESS: 
+1 day, 20:23:29.679418 PROGRESS: Precursor Summary:
+1 day, 20:23:29.682896 PROGRESS: Channel   0:	 0.05 FDR: 7,872; 0.01 FDR: 7,863; 0.001 FDR: 6,567
+1 day, 20:23:29.683034 PROGRESS: 
+1 day, 20:23:29.683103 PROGRESS: Protein Summary:
+1 day, 20:23:29.687874 PROGRESS: Channel   0:	 0.05 FDR: 4,172; 0.01 FDR: 4,168; 0.001 FDR: 3,599
+1 day, 20:23:29.688012 PROGRESS: =========================================================================
+1 day, 20:23:29.715436 INFO: fragments_df_filtered: 5000
+1 day, 20:23:29.735391 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:23:30.567523 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:23:31.391241 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:23:32.196960 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:23:32.551267 INFO: calibration group: precursor, predicting mz
+1 day, 20:23:32.554364 INFO: calibration group: precursor, predicting rt
+1 day, 20:23:32.563720 INFO: calibration group: precursor, predicting mobility
+1 day, 20:23:32.566156 INFO: calibration group: fragment, predicting mz
+1 day, 20:23:32.585899 INFO: === checking if optimization conditions were reached ===
+1 day, 20:23:32.586131 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:23:32.587236 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0583 found after 3 searches.
+1 day, 20:23:32.587294 INFO: ==============================================
+1 day, 20:23:32.587406 PROGRESS: Optimization finished for mobility_error.
+1 day, 20:23:32.608770 INFO: calibration group: precursor, predicting mz
+1 day, 20:23:32.612164 INFO: calibration group: precursor, predicting rt
+1 day, 20:23:32.622036 INFO: calibration group: precursor, predicting mobility
+1 day, 20:23:32.624751 INFO: calibration group: fragment, predicting mz
+1 day, 20:23:32.678603 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 20:23:32.678830 PROGRESS: ==============================================
+1 day, 20:23:32.678921 PROGRESS: ms2_error      : 15.0000
+1 day, 20:23:32.678994 PROGRESS: ms1_error      : 10.0000
+1 day, 20:23:32.679074 PROGRESS: rt_error       : 639.0316
+1 day, 20:23:32.679136 PROGRESS: mobility_error : 0.0583
+1 day, 20:23:32.679189 PROGRESS: ==============================================
+1 day, 20:23:32.680922 INFO: calibration group: precursor, predicting mz
+1 day, 20:23:32.702813 INFO: calibration group: precursor, predicting rt
+1 day, 20:23:32.792892 INFO: calibration group: precursor, predicting mobility
+1 day, 20:23:32.815324 INFO: calibration group: fragment, predicting mz
+1 day, 20:23:33.053500 PROGRESS: Extracting batch of 162861 precursors
+1 day, 20:23:33.106335 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:23:33.106486 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:23:33.106545 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 20:23:33.106570 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:23:33.107466 INFO: Starting candidate selection
+1 day, 20:26:20.226229 INFO: Applying score cutoff of 31.170629611968995
+1 day, 20:26:20.232631 INFO: Removed 4778 precursors with score below cutoff
+1 day, 20:26:20.578274 INFO: Starting candidate scoring
+1 day, 20:26:29.801122 INFO: Finished candidate processing
+1 day, 20:26:29.801294 INFO: Collecting candidate features
+1 day, 20:26:30.346121 INFO: Collecting fragment features
+1 day, 20:26:30.544167 INFO: Finished candidate scoring
+1 day, 20:26:30.803912 INFO: === FDR correction performed with classifier version 12 ===
+1 day, 20:26:30.805223 INFO: performing precursor FDR with 47 features
+1 day, 20:26:30.805283 INFO: Decoy channel: -1
+1 day, 20:26:30.805309 INFO: Competetive: True
+1 day, 20:26:30.912537 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:26:36.154163 INFO: Test AUC: 0.817
+1 day, 20:26:36.154304 INFO: Train AUC: 0.820
+1 day, 20:26:36.154336 INFO: AUC difference: 0.36%
+1 day, 20:26:36.268078 INFO: Resetting torch num_threads to 100
+1 day, 20:26:36.291068 INFO: Removing fragments below FDR threshold
+1 day, 20:26:36.355765 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:26:36.356106 PROGRESS: Total precursors accumulated: 73,542
+1 day, 20:26:36.356175 PROGRESS: Target precursors: 72,814 (99.01%)
+1 day, 20:26:36.356230 PROGRESS: Decoy precursors: 728 (0.99%)
+1 day, 20:26:36.356290 PROGRESS: 
+1 day, 20:26:36.356339 PROGRESS: Precursor Summary:
+1 day, 20:26:36.400597 PROGRESS: Channel   0:	 0.05 FDR: 72,814; 0.01 FDR: 72,814; 0.001 FDR: 70,132
+1 day, 20:26:36.400939 PROGRESS: 
+1 day, 20:26:36.401015 PROGRESS: Protein Summary:
+1 day, 20:26:36.455656 PROGRESS: Channel   0:	 0.05 FDR: 8,127; 0.01 FDR: 8,127; 0.001 FDR: 8,061
+1 day, 20:26:36.455944 PROGRESS: =========================================================================
+1 day, 20:26:37.113530 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:26:37.163259 PROGRESS: Loading raw file 6/6: ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:26:37.163435 INFO: Quantification results path: run_output/alphadia_1.10_defaultMBR/quant
+1 day, 20:26:37.163515 INFO: Creating workflow folder for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508 at run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:26:37.164471 INFO: Initializing RawFileManager
+1 day, 20:26:37.164581 INFO: Importing data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:37.164635 INFO: Using .d import for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:37.164671 INFO: Reading frame metadata for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:37.381802 INFO: Reading 39,129 frames with 2,804,178,635 detector events for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.888838 INFO: Indexing ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d...
+1 day, 20:26:43.890657 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.893836 INFO: Fetching mobility values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.894104 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.894504 INFO: Opening handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.896034 INFO: Fetching mz values from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.910313 INFO: Closing handle for ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:43.910588 INFO: Indexing quadrupole dimension
+1 day, 20:26:44.400709 INFO: Transposing detector events
+1 day, 20:26:53.333417 INFO: Finished transposing data
+1 day, 20:26:53.372956 INFO: Successfully imported data from ./raw_diapasef_2025/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d
+1 day, 20:26:53.375401 INFO: RT (min)            : 0.0 - 70.0
+1 day, 20:26:53.375521 INFO: RT duration (sec)   : 4199.8
+1 day, 20:26:53.375589 INFO: RT duration (min)   : 70.0
+1 day, 20:26:53.375652 INFO: Cycle len (scans)   : 9
+1 day, 20:26:53.375701 INFO: Cycle len (sec)     : 0.97
+1 day, 20:26:53.375746 INFO: Number of cycles    : 4347
+1 day, 20:26:53.375793 INFO: MS2 range (m/z)     : 400.0 - 1000.0
+1 day, 20:26:53.467479 INFO: Initializing CalibrationManager
+1 day, 20:26:53.467866 INFO: Loading calibration config
+1 day, 20:26:53.468810 INFO: Calibration config: [{'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}], 'name': 'fragment'}, {'estimators': [{'input_columns': ['mz_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mz', 'output_columns': ['mz_calibrated'], 'target_columns': ['mz_observed'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'input_columns': ['rt_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'name': 'rt', 'output_columns': ['rt_calibrated'], 'target_columns': ['rt_observed'], 'function': LOESSRegression()}, {'input_columns': ['mobility_library'], 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'name': 'mobility', 'output_columns': ['mobility_calibrated'], 'target_columns': ['mobility_observed'], 'function': LOESSRegression(n_kernels=2)}], 'name': 'precursor'}]
+1 day, 20:26:53.468909 INFO: Calibration group :fragment, found 1 estimator(s)
+1 day, 20:26:53.469016 INFO: Calibration group :precursor, found 3 estimator(s)
+1 day, 20:26:53.469246 INFO: Initializing OptimizationManager
+1 day, 20:26:53.469356 INFO: initial parameter: ms1_error = 30
+1 day, 20:26:53.469413 INFO: initial parameter: ms2_error = 30
+1 day, 20:26:53.469477 INFO: initial parameter: rt_error = 2099.9231665
+1 day, 20:26:53.469536 INFO: initial parameter: mobility_error = 0.1
+1 day, 20:26:53.469590 INFO: initial parameter: column_type = library
+1 day, 20:26:53.469635 INFO: initial parameter: num_candidates = 1
+1 day, 20:26:53.469681 INFO: initial parameter: classifier_version = -1
+1 day, 20:26:53.469723 INFO: initial parameter: fwhm_rt = 5
+1 day, 20:26:53.469769 INFO: initial parameter: fwhm_mobility = 0.01
+1 day, 20:26:53.469812 INFO: initial parameter: score_cutoff = 0
+1 day, 20:26:53.469876 INFO: Initializing TimingManager
+1 day, 20:26:53.469937 PROGRESS: Initializing workflow ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:26:53.470063 INFO: FDRManager not loaded from disk.
+1 day, 20:26:53.470089 INFO: Initializing FDRManager
+1 day, 20:26:53.470124 INFO: Loading classifier store from /home/robbe/.pyenv/versions/alphadia/lib/python3.11/site-packages/alphadia/constants/classifier
+1 day, 20:26:53.503844 PROGRESS: 82,039 target precursors potentially observable (0 removed)
+1 day, 20:26:53.546368 PROGRESS: Starting initial search for precursors.
+1 day, 20:26:53.570310 INFO: Starting optimization step 0.
+1 day, 20:26:53.570561 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:26:53.570657 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:26:53.575041 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:26:53.575094 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:26:53.575136 INFO: FWHM in RT is 5.00 seconds, sigma is 1.10
+1 day, 20:26:53.575161 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 4.64
+1 day, 20:26:53.576294 INFO: Starting candidate selection
+1 day, 20:28:18.994278 INFO: Starting candidate scoring
+1 day, 20:28:20.016850 INFO: Finished candidate processing
+1 day, 20:28:20.016952 INFO: Collecting candidate features
+1 day, 20:28:20.051309 INFO: Collecting fragment features
+1 day, 20:28:20.068236 INFO: Finished candidate scoring
+1 day, 20:28:20.078393 PROGRESS: === Extracted 15886 precursors and 175801 fragments ===
+1 day, 20:28:20.078830 INFO: performing precursor FDR with 47 features
+1 day, 20:28:20.078870 INFO: Decoy channel: -1
+1 day, 20:28:20.078894 INFO: Competetive: True
+1 day, 20:28:20.083638 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:28:20.249540 INFO: Test AUC: 0.817
+1 day, 20:28:20.249658 INFO: Train AUC: 0.826
+1 day, 20:28:20.249689 INFO: AUC difference: 1.13%
+1 day, 20:28:20.338838 INFO: Resetting torch num_threads to 100
+1 day, 20:28:20.339883 INFO: === FDR correction performed with classifier version -1 ===
+1 day, 20:28:20.341470 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:28:20.341581 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:28:20.341643 PROGRESS: Target precursors: 6,611 (82.64%)
+1 day, 20:28:20.341698 PROGRESS: Decoy precursors: 1,389 (17.36%)
+1 day, 20:28:20.341744 PROGRESS: 
+1 day, 20:28:20.341792 PROGRESS: Precursor Summary:
+1 day, 20:28:20.344081 PROGRESS: Channel   0:	 0.05 FDR: 5,194; 0.01 FDR: 4,073; 0.001 FDR: 2,210
+1 day, 20:28:20.344182 PROGRESS: 
+1 day, 20:28:20.344239 PROGRESS: Protein Summary:
+1 day, 20:28:20.347196 PROGRESS: Channel   0:	 0.05 FDR: 3,006; 0.01 FDR: 2,474; 0.001 FDR: 1,479
+1 day, 20:28:20.347303 PROGRESS: =========================================================================
+1 day, 20:28:20.356810 INFO: fragments_df_filtered: 5000
+1 day, 20:28:20.375789 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:28:20.692599 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:28:21.016096 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:28:21.333637 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:28:21.734486 INFO: calibration group: precursor, predicting mz
+1 day, 20:28:21.737417 INFO: calibration group: precursor, predicting rt
+1 day, 20:28:21.747190 INFO: calibration group: precursor, predicting mobility
+1 day, 20:28:21.749564 INFO: calibration group: fragment, predicting mz
+1 day, 20:28:21.768591 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1 day, 20:28:21.768824 INFO: Starting optimization step 1.
+1 day, 20:28:21.768911 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:28:21.768991 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:28:21.774294 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:28:21.774361 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:28:21.774414 INFO: FWHM in RT is 3.28 seconds, sigma is 0.72
+1 day, 20:28:21.774444 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.22
+1 day, 20:28:21.775659 INFO: Starting candidate selection
+1 day, 20:29:58.293572 INFO: Starting candidate scoring
+1 day, 20:30:00.257674 INFO: Finished candidate processing
+1 day, 20:30:00.257817 INFO: Collecting candidate features
+1 day, 20:30:00.326447 INFO: Collecting fragment features
+1 day, 20:30:00.352458 INFO: Finished candidate scoring
+1 day, 20:30:00.383160 PROGRESS: === Extracted 30497 precursors and 337597 fragments ===
+1 day, 20:30:00.383919 INFO: performing precursor FDR with 47 features
+1 day, 20:30:00.383963 INFO: Decoy channel: -1
+1 day, 20:30:00.383988 INFO: Competetive: True
+1 day, 20:30:00.399740 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:30:00.846780 INFO: Test AUC: 0.721
+1 day, 20:30:00.846935 INFO: Train AUC: 0.725
+1 day, 20:30:00.846968 INFO: AUC difference: 0.54%
+1 day, 20:30:00.942545 INFO: Resetting torch num_threads to 100
+1 day, 20:30:00.944273 INFO: === FDR correction performed with classifier version 0 ===
+1 day, 20:30:00.946092 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:30:00.946218 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:30:00.946281 PROGRESS: Target precursors: 7,224 (90.30%)
+1 day, 20:30:00.946336 PROGRESS: Decoy precursors: 776 (9.70%)
+1 day, 20:30:00.946385 PROGRESS: 
+1 day, 20:30:00.946432 PROGRESS: Precursor Summary:
+1 day, 20:30:00.948960 PROGRESS: Channel   0:	 0.05 FDR: 6,009; 0.01 FDR: 4,872; 0.001 FDR: 2,514
+1 day, 20:30:00.949096 PROGRESS: 
+1 day, 20:30:00.949171 PROGRESS: Protein Summary:
+1 day, 20:30:00.952532 PROGRESS: Channel   0:	 0.05 FDR: 3,379; 0.01 FDR: 2,862; 0.001 FDR: 1,662
+1 day, 20:30:00.952646 PROGRESS: =========================================================================
+1 day, 20:30:00.973018 INFO: fragments_df_filtered: 5000
+1 day, 20:30:01.009246 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:30:01.352759 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:30:01.708167 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:30:02.047400 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:30:02.399465 INFO: calibration group: precursor, predicting mz
+1 day, 20:30:02.402660 INFO: calibration group: precursor, predicting rt
+1 day, 20:30:02.416809 INFO: calibration group: precursor, predicting mobility
+1 day, 20:30:02.419313 INFO: calibration group: fragment, predicting mz
+1 day, 20:30:02.439612 INFO: === checking if optimization conditions were reached ===
+1 day, 20:30:02.441996 PROGRESS: ❌ ms2_error      : 15.0000 > 15.0000 or insufficient steps taken.
+1 day, 20:30:02.443844 PROGRESS: ❌ ms1_error      : 10.0000 > 10.0000 or insufficient steps taken.
+1 day, 20:30:02.443902 INFO: ==============================================
+1 day, 20:30:02.444026 INFO: Starting optimization step 2.
+1 day, 20:30:02.444108 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:30:02.444186 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:30:02.451741 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:30:02.451810 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:30:02.451861 INFO: FWHM in RT is 3.19 seconds, sigma is 0.70
+1 day, 20:30:02.451890 INFO: FWHM in mobility is 0.011 1/K_0, sigma is 5.02
+1 day, 20:30:02.457583 INFO: Starting candidate selection
+1 day, 20:31:30.982071 INFO: Starting candidate scoring
+1 day, 20:31:32.035760 INFO: Finished candidate processing
+1 day, 20:31:32.035865 INFO: Collecting candidate features
+1 day, 20:31:32.093264 INFO: Collecting fragment features
+1 day, 20:31:32.117069 INFO: Finished candidate scoring
+1 day, 20:31:32.131527 PROGRESS: === Extracted 30522 precursors and 333498 fragments ===
+1 day, 20:31:32.132008 INFO: performing precursor FDR with 47 features
+1 day, 20:31:32.132048 INFO: Decoy channel: -1
+1 day, 20:31:32.132071 INFO: Competetive: True
+1 day, 20:31:32.144422 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:31:32.520346 INFO: Test AUC: 0.759
+1 day, 20:31:32.520473 INFO: Train AUC: 0.765
+1 day, 20:31:32.520503 INFO: AUC difference: 0.85%
+1 day, 20:31:32.608974 INFO: Resetting torch num_threads to 100
+1 day, 20:31:32.610256 INFO: === FDR correction performed with classifier version 1 ===
+1 day, 20:31:32.611807 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:31:32.611913 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:31:32.611978 PROGRESS: Target precursors: 7,787 (97.34%)
+1 day, 20:31:32.612034 PROGRESS: Decoy precursors: 213 (2.66%)
+1 day, 20:31:32.612092 PROGRESS: 
+1 day, 20:31:32.612140 PROGRESS: Precursor Summary:
+1 day, 20:31:32.615096 PROGRESS: Channel   0:	 0.05 FDR: 7,787; 0.01 FDR: 6,719; 0.001 FDR: 5,470
+1 day, 20:31:32.615237 PROGRESS: 
+1 day, 20:31:32.615298 PROGRESS: Protein Summary:
+1 day, 20:31:32.619464 PROGRESS: Channel   0:	 0.05 FDR: 4,132; 0.01 FDR: 3,664; 0.001 FDR: 3,142
+1 day, 20:31:32.619582 PROGRESS: =========================================================================
+1 day, 20:31:32.642833 INFO: fragments_df_filtered: 5000
+1 day, 20:31:32.663595 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:31:33.262034 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:31:33.888433 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:31:34.490533 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:31:34.841053 INFO: calibration group: precursor, predicting mz
+1 day, 20:31:34.843876 INFO: calibration group: precursor, predicting rt
+1 day, 20:31:34.853006 INFO: calibration group: precursor, predicting mobility
+1 day, 20:31:34.855266 INFO: calibration group: fragment, predicting mz
+1 day, 20:31:34.873250 INFO: === checking if optimization conditions were reached ===
+1 day, 20:31:34.875339 PROGRESS: ✅ ms2_error      : 15.0000 <= 15.0000
+1 day, 20:31:34.877495 PROGRESS: ✅ ms1_error      : 10.0000 <= 10.0000
+1 day, 20:31:34.877570 INFO: ==============================================
+1 day, 20:31:34.877702 PROGRESS: Optimization finished for ms2_error, ms1_error.
+1 day, 20:31:34.899581 INFO: calibration group: precursor, predicting mz
+1 day, 20:31:34.902600 INFO: calibration group: precursor, predicting rt
+1 day, 20:31:34.914872 INFO: calibration group: precursor, predicting mobility
+1 day, 20:31:34.917184 INFO: calibration group: fragment, predicting mz
+1 day, 20:31:34.935962 INFO: Starting optimization step 0.
+1 day, 20:31:34.936119 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:31:34.936202 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:31:34.940060 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:31:34.940118 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:31:34.940164 INFO: FWHM in RT is 2.90 seconds, sigma is 0.64
+1 day, 20:31:34.940193 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.07
+1 day, 20:31:34.949162 INFO: Starting candidate selection
+1 day, 20:33:05.979743 INFO: Starting candidate scoring
+1 day, 20:33:07.042474 INFO: Finished candidate processing
+1 day, 20:33:07.042622 INFO: Collecting candidate features
+1 day, 20:33:07.118674 INFO: Collecting fragment features
+1 day, 20:33:07.145252 INFO: Finished candidate scoring
+1 day, 20:33:07.164063 PROGRESS: === Extracted 30444 precursors and 332292 fragments ===
+1 day, 20:33:07.164783 INFO: performing precursor FDR with 47 features
+1 day, 20:33:07.164824 INFO: Decoy channel: -1
+1 day, 20:33:07.164850 INFO: Competetive: True
+1 day, 20:33:07.177704 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:33:07.553905 INFO: Test AUC: 0.780
+1 day, 20:33:07.554026 INFO: Train AUC: 0.771
+1 day, 20:33:07.554058 INFO: AUC difference: 1.20%
+1 day, 20:33:07.646134 INFO: Resetting torch num_threads to 100
+1 day, 20:33:07.647415 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:33:07.648843 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:33:07.648942 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:33:07.649002 PROGRESS: Target precursors: 7,828 (97.85%)
+1 day, 20:33:07.649068 PROGRESS: Decoy precursors: 172 (2.15%)
+1 day, 20:33:07.649119 PROGRESS: 
+1 day, 20:33:07.649167 PROGRESS: Precursor Summary:
+1 day, 20:33:07.652253 PROGRESS: Channel   0:	 0.05 FDR: 7,828; 0.01 FDR: 6,780; 0.001 FDR: 5,860
+1 day, 20:33:07.652383 PROGRESS: 
+1 day, 20:33:07.652446 PROGRESS: Protein Summary:
+1 day, 20:33:07.656709 PROGRESS: Channel   0:	 0.05 FDR: 4,145; 0.01 FDR: 3,694; 0.001 FDR: 3,313
+1 day, 20:33:07.656830 PROGRESS: =========================================================================
+1 day, 20:33:07.680458 INFO: fragments_df_filtered: 5000
+1 day, 20:33:07.710747 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:33:08.334974 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:33:08.972678 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:33:09.583019 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:33:09.934753 INFO: calibration group: precursor, predicting mz
+1 day, 20:33:09.937625 INFO: calibration group: precursor, predicting rt
+1 day, 20:33:09.947170 INFO: calibration group: precursor, predicting mobility
+1 day, 20:33:09.949546 INFO: calibration group: fragment, predicting mz
+1 day, 20:33:09.969054 INFO: === checking if optimization conditions were reached ===
+1 day, 20:33:09.969252 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:33:09.974469 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 178.7724.
+1 day, 20:33:09.974529 INFO: ==============================================
+1 day, 20:33:09.974640 INFO: Starting optimization step 1.
+1 day, 20:33:09.974711 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:33:09.974779 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:33:09.979342 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:33:09.979407 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:33:09.979451 INFO: FWHM in RT is 2.89 seconds, sigma is 0.64
+1 day, 20:33:09.979473 INFO: FWHM in mobility is 0.009 1/K_0, sigma is 4.03
+1 day, 20:33:09.985120 INFO: Starting candidate selection
+1 day, 20:33:18.225731 INFO: Starting candidate scoring
+1 day, 20:33:19.199183 INFO: Finished candidate processing
+1 day, 20:33:19.200602 INFO: Collecting candidate features
+1 day, 20:33:19.251660 INFO: Collecting fragment features
+1 day, 20:33:19.269944 INFO: Finished candidate scoring
+1 day, 20:33:19.282583 PROGRESS: === Extracted 30352 precursors and 326267 fragments ===
+1 day, 20:33:19.282967 INFO: performing precursor FDR with 47 features
+1 day, 20:33:19.283003 INFO: Decoy channel: -1
+1 day, 20:33:19.283026 INFO: Competetive: True
+1 day, 20:33:19.293543 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:33:19.650242 INFO: Test AUC: 0.806
+1 day, 20:33:19.650363 INFO: Train AUC: 0.807
+1 day, 20:33:19.650393 INFO: AUC difference: 0.13%
+1 day, 20:33:19.735885 INFO: Resetting torch num_threads to 100
+1 day, 20:33:19.737072 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:33:19.738634 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:33:19.738732 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:33:19.738794 PROGRESS: Target precursors: 7,913 (98.91%)
+1 day, 20:33:19.738846 PROGRESS: Decoy precursors: 87 (1.09%)
+1 day, 20:33:19.738894 PROGRESS: 
+1 day, 20:33:19.738940 PROGRESS: Precursor Summary:
+1 day, 20:33:19.741992 PROGRESS: Channel   0:	 0.05 FDR: 7,913; 0.01 FDR: 7,904; 0.001 FDR: 6,632
+1 day, 20:33:19.742110 PROGRESS: 
+1 day, 20:33:19.742179 PROGRESS: Protein Summary:
+1 day, 20:33:19.746665 PROGRESS: Channel   0:	 0.05 FDR: 4,179; 0.01 FDR: 4,176; 0.001 FDR: 3,662
+1 day, 20:33:19.746781 PROGRESS: =========================================================================
+1 day, 20:33:19.773396 INFO: fragments_df_filtered: 5000
+1 day, 20:33:19.787785 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:33:20.665272 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:33:21.564571 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:33:22.442393 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:33:22.857682 INFO: calibration group: precursor, predicting mz
+1 day, 20:33:22.860507 INFO: calibration group: precursor, predicting rt
+1 day, 20:33:22.869627 INFO: calibration group: precursor, predicting mobility
+1 day, 20:33:22.871970 INFO: calibration group: fragment, predicting mz
+1 day, 20:33:22.890652 INFO: === checking if optimization conditions were reached ===
+1 day, 20:33:22.890830 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:33:22.897202 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 161.9899.
+1 day, 20:33:22.897269 INFO: ==============================================
+1 day, 20:33:22.897380 INFO: Starting optimization step 2.
+1 day, 20:33:22.897458 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:33:22.897532 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:33:22.902283 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:33:22.902345 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:33:22.902388 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:33:22.902416 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:33:22.903514 INFO: Starting candidate selection
+1 day, 20:33:30.189006 INFO: Starting candidate scoring
+1 day, 20:33:31.139056 INFO: Finished candidate processing
+1 day, 20:33:31.139189 INFO: Collecting candidate features
+1 day, 20:33:31.184152 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30361)
+1 day, 20:33:31.188607 INFO: Collecting fragment features
+1 day, 20:33:31.208983 INFO: Finished candidate scoring
+1 day, 20:33:31.221798 PROGRESS: === Extracted 30361 precursors and 325669 fragments ===
+1 day, 20:33:31.222179 INFO: performing precursor FDR with 47 features
+1 day, 20:33:31.222220 INFO: Decoy channel: -1
+1 day, 20:33:31.222248 INFO: Competetive: True
+1 day, 20:33:31.231061 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:33:31.234998 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 20:33:31.570404 INFO: Test AUC: 0.814
+1 day, 20:33:31.570534 INFO: Train AUC: 0.811
+1 day, 20:33:31.570567 INFO: AUC difference: 0.37%
+1 day, 20:33:31.656082 INFO: Resetting torch num_threads to 100
+1 day, 20:33:31.657258 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:33:31.658628 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:33:31.658730 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:33:31.658798 PROGRESS: Target precursors: 7,911 (98.89%)
+1 day, 20:33:31.658855 PROGRESS: Decoy precursors: 89 (1.11%)
+1 day, 20:33:31.658908 PROGRESS: 
+1 day, 20:33:31.658961 PROGRESS: Precursor Summary:
+1 day, 20:33:31.661931 PROGRESS: Channel   0:	 0.05 FDR: 7,911; 0.01 FDR: 7,907; 0.001 FDR: 7,095
+1 day, 20:33:31.662058 PROGRESS: 
+1 day, 20:33:31.662123 PROGRESS: Protein Summary:
+1 day, 20:33:31.666605 PROGRESS: Channel   0:	 0.05 FDR: 4,180; 0.01 FDR: 4,177; 0.001 FDR: 3,846
+1 day, 20:33:31.666718 PROGRESS: =========================================================================
+1 day, 20:33:31.691952 INFO: fragments_df_filtered: 5000
+1 day, 20:33:31.706799 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:33:32.525208 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:33:33.423300 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:33:34.304282 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:33:34.720894 INFO: calibration group: precursor, predicting mz
+1 day, 20:33:34.723753 INFO: calibration group: precursor, predicting rt
+1 day, 20:33:34.732837 INFO: calibration group: precursor, predicting mobility
+1 day, 20:33:34.735165 INFO: calibration group: fragment, predicting mz
+1 day, 20:33:34.752934 INFO: === checking if optimization conditions were reached ===
+1 day, 20:33:34.753119 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:33:34.759109 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 140.4229.
+1 day, 20:33:34.759172 INFO: ==============================================
+1 day, 20:33:34.759271 INFO: Starting optimization step 3.
+1 day, 20:33:34.759339 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:33:34.759400 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:33:34.763315 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:33:34.763372 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:33:34.763407 INFO: FWHM in RT is 2.87 seconds, sigma is 0.63
+1 day, 20:33:34.763430 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.84
+1 day, 20:33:34.764236 INFO: Starting candidate selection
+1 day, 20:33:41.553936 INFO: Starting candidate scoring
+1 day, 20:33:42.490649 INFO: Finished candidate processing
+1 day, 20:33:42.490786 INFO: Collecting candidate features
+1 day, 20:33:42.539033 INFO: Collecting fragment features
+1 day, 20:33:42.558349 INFO: Finished candidate scoring
+1 day, 20:33:42.570965 PROGRESS: === Extracted 30351 precursors and 325410 fragments ===
+1 day, 20:33:42.572101 INFO: performing precursor FDR with 47 features
+1 day, 20:33:42.572141 INFO: Decoy channel: -1
+1 day, 20:33:42.572165 INFO: Competetive: True
+1 day, 20:33:42.580000 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:33:42.936572 INFO: Test AUC: 0.814
+1 day, 20:33:42.936697 INFO: Train AUC: 0.814
+1 day, 20:33:42.936727 INFO: AUC difference: 0.08%
+1 day, 20:33:43.021406 INFO: Resetting torch num_threads to 100
+1 day, 20:33:43.022575 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:33:43.024015 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:33:43.024108 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:33:43.024170 PROGRESS: Target precursors: 7,908 (98.85%)
+1 day, 20:33:43.024220 PROGRESS: Decoy precursors: 92 (1.15%)
+1 day, 20:33:43.024267 PROGRESS: 
+1 day, 20:33:43.024319 PROGRESS: Precursor Summary:
+1 day, 20:33:43.027288 PROGRESS: Channel   0:	 0.05 FDR: 7,908; 0.01 FDR: 7,896; 0.001 FDR: 6,925
+1 day, 20:33:43.027405 PROGRESS: 
+1 day, 20:33:43.027462 PROGRESS: Protein Summary:
+1 day, 20:33:43.031945 PROGRESS: Channel   0:	 0.05 FDR: 4,178; 0.01 FDR: 4,174; 0.001 FDR: 3,787
+1 day, 20:33:43.032052 PROGRESS: =========================================================================
+1 day, 20:33:43.057253 INFO: fragments_df_filtered: 5000
+1 day, 20:33:43.071735 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:33:43.947516 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:33:44.848670 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:33:45.723674 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:33:46.121697 INFO: calibration group: precursor, predicting mz
+1 day, 20:33:46.125293 INFO: calibration group: precursor, predicting rt
+1 day, 20:33:46.134570 INFO: calibration group: precursor, predicting mobility
+1 day, 20:33:46.136961 INFO: calibration group: fragment, predicting mz
+1 day, 20:33:46.156393 INFO: === checking if optimization conditions were reached ===
+1 day, 20:33:46.156539 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1 day, 20:33:46.162421 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 118.2421.
+1 day, 20:33:46.162485 INFO: ==============================================
+1 day, 20:33:46.162578 INFO: Starting optimization step 4.
+1 day, 20:33:46.162645 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:33:46.162713 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:33:46.166499 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:33:46.166550 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:33:46.166585 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:33:46.166607 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.83
+1 day, 20:33:46.167489 INFO: Starting candidate selection
+1 day, 20:33:51.972813 INFO: Starting candidate scoring
+1 day, 20:33:52.926017 INFO: Finished candidate processing
+1 day, 20:33:52.926163 INFO: Collecting candidate features
+1 day, 20:33:52.970792 WARNING: intensity_correlation has 2 NaNs ( 0.01 % out of 30369)
+1 day, 20:33:52.975113 INFO: Collecting fragment features
+1 day, 20:33:52.993572 INFO: Finished candidate scoring
+1 day, 20:33:53.006252 PROGRESS: === Extracted 30369 precursors and 325210 fragments ===
+1 day, 20:33:53.006611 INFO: performing precursor FDR with 47 features
+1 day, 20:33:53.006647 INFO: Decoy channel: -1
+1 day, 20:33:53.006668 INFO: Competetive: True
+1 day, 20:33:53.014422 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:33:53.018232 WARNING: dropped 2 decoy PSMs due to missing features
+1 day, 20:33:53.364511 INFO: Test AUC: 0.818
+1 day, 20:33:53.364644 INFO: Train AUC: 0.817
+1 day, 20:33:53.364673 INFO: AUC difference: 0.16%
+1 day, 20:33:53.448828 INFO: Resetting torch num_threads to 100
+1 day, 20:33:53.450042 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:33:53.451473 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:33:53.451570 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:33:53.451630 PROGRESS: Target precursors: 7,910 (98.88%)
+1 day, 20:33:53.451681 PROGRESS: Decoy precursors: 90 (1.12%)
+1 day, 20:33:53.451728 PROGRESS: 
+1 day, 20:33:53.451773 PROGRESS: Precursor Summary:
+1 day, 20:33:53.454703 PROGRESS: Channel   0:	 0.05 FDR: 7,910; 0.01 FDR: 7,905; 0.001 FDR: 6,800
+1 day, 20:33:53.454812 PROGRESS: 
+1 day, 20:33:53.454870 PROGRESS: Protein Summary:
+1 day, 20:33:53.459291 PROGRESS: Channel   0:	 0.05 FDR: 4,181; 0.01 FDR: 4,178; 0.001 FDR: 3,736
+1 day, 20:33:53.459404 PROGRESS: =========================================================================
+1 day, 20:33:53.484443 INFO: fragments_df_filtered: 5000
+1 day, 20:33:53.498789 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:33:54.309015 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:33:55.149048 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:33:55.957978 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:33:56.310584 INFO: calibration group: precursor, predicting mz
+1 day, 20:33:56.313385 INFO: calibration group: precursor, predicting rt
+1 day, 20:33:56.322590 INFO: calibration group: precursor, predicting mobility
+1 day, 20:33:56.324915 INFO: calibration group: fragment, predicting mz
+1 day, 20:33:56.343425 INFO: === checking if optimization conditions were reached ===
+1 day, 20:33:56.343578 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+1 day, 20:33:56.349494 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 100.6859.
+1 day, 20:33:56.349552 INFO: ==============================================
+1 day, 20:33:56.349647 INFO: Starting optimization step 5.
+1 day, 20:33:56.349717 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:33:56.349777 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:33:56.353329 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:33:56.353384 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:33:56.353420 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:33:56.353444 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.83
+1 day, 20:33:56.354342 INFO: Starting candidate selection
+1 day, 20:34:01.537211 INFO: Starting candidate scoring
+1 day, 20:34:02.494940 INFO: Finished candidate processing
+1 day, 20:34:02.495077 INFO: Collecting candidate features
+1 day, 20:34:02.543472 INFO: Collecting fragment features
+1 day, 20:34:02.566247 INFO: Finished candidate scoring
+1 day, 20:34:02.579684 PROGRESS: === Extracted 30384 precursors and 325044 fragments ===
+1 day, 20:34:02.580060 INFO: performing precursor FDR with 47 features
+1 day, 20:34:02.580096 INFO: Decoy channel: -1
+1 day, 20:34:02.580121 INFO: Competetive: True
+1 day, 20:34:02.588122 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:02.929185 INFO: Test AUC: 0.817
+1 day, 20:34:02.929310 INFO: Train AUC: 0.822
+1 day, 20:34:02.929342 INFO: AUC difference: 0.64%
+1 day, 20:34:03.014591 INFO: Resetting torch num_threads to 100
+1 day, 20:34:03.015705 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:03.017149 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:03.017253 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:03.017315 PROGRESS: Target precursors: 7,907 (98.84%)
+1 day, 20:34:03.017367 PROGRESS: Decoy precursors: 93 (1.16%)
+1 day, 20:34:03.017415 PROGRESS: 
+1 day, 20:34:03.017460 PROGRESS: Precursor Summary:
+1 day, 20:34:03.020379 PROGRESS: Channel   0:	 0.05 FDR: 7,907; 0.01 FDR: 7,901; 0.001 FDR: 6,916
+1 day, 20:34:03.020489 PROGRESS: 
+1 day, 20:34:03.020545 PROGRESS: Protein Summary:
+1 day, 20:34:03.024938 PROGRESS: Channel   0:	 0.05 FDR: 4,179; 0.01 FDR: 4,176; 0.001 FDR: 3,781
+1 day, 20:34:03.025054 PROGRESS: =========================================================================
+1 day, 20:34:03.050561 INFO: fragments_df_filtered: 5000
+1 day, 20:34:03.064823 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:03.873540 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:04.715664 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:05.528969 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:05.881334 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:05.884735 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:05.894148 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:05.896490 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:05.916420 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:05.916605 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+1 day, 20:34:05.923300 PROGRESS: ❌ rt_error       : optimization incomplete after 6 search(es). Will search with parameter 82.9194.
+1 day, 20:34:05.923382 INFO: ==============================================
+1 day, 20:34:05.923515 INFO: Starting optimization step 6.
+1 day, 20:34:05.923603 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:05.923685 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:05.943282 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:05.943360 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:05.943411 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:05.943440 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.83
+1 day, 20:34:05.952202 INFO: Starting candidate selection
+1 day, 20:34:10.087809 INFO: Starting candidate scoring
+1 day, 20:34:11.068821 INFO: Finished candidate processing
+1 day, 20:34:11.068969 INFO: Collecting candidate features
+1 day, 20:34:11.123191 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30360)
+1 day, 20:34:11.130345 INFO: Collecting fragment features
+1 day, 20:34:11.151755 INFO: Finished candidate scoring
+1 day, 20:34:11.164938 PROGRESS: === Extracted 30360 precursors and 324285 fragments ===
+1 day, 20:34:11.165378 INFO: performing precursor FDR with 47 features
+1 day, 20:34:11.165415 INFO: Decoy channel: -1
+1 day, 20:34:11.165438 INFO: Competetive: True
+1 day, 20:34:11.175322 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:11.179526 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 20:34:11.521130 INFO: Test AUC: 0.824
+1 day, 20:34:11.521253 INFO: Train AUC: 0.823
+1 day, 20:34:11.521283 INFO: AUC difference: 0.05%
+1 day, 20:34:13.827120 INFO: Resetting torch num_threads to 100
+1 day, 20:34:13.828335 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:13.829905 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:13.830012 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:13.830075 PROGRESS: Target precursors: 7,926 (99.08%)
+1 day, 20:34:13.830126 PROGRESS: Decoy precursors: 74 (0.92%)
+1 day, 20:34:13.830178 PROGRESS: 
+1 day, 20:34:13.830225 PROGRESS: Precursor Summary:
+1 day, 20:34:13.833548 PROGRESS: Channel   0:	 0.05 FDR: 7,926; 0.01 FDR: 7,926; 0.001 FDR: 7,032
+1 day, 20:34:13.833670 PROGRESS: 
+1 day, 20:34:13.833728 PROGRESS: Protein Summary:
+1 day, 20:34:13.838360 PROGRESS: Channel   0:	 0.05 FDR: 4,188; 0.01 FDR: 4,188; 0.001 FDR: 3,827
+1 day, 20:34:13.838484 PROGRESS: =========================================================================
+1 day, 20:34:13.864124 INFO: fragments_df_filtered: 5000
+1 day, 20:34:13.882365 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:14.698293 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:15.546650 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:16.366014 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:16.718205 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:16.721206 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:16.730649 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:16.733055 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:16.752784 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:16.752942 PROGRESS: === Optimization of rt_error has been performed 7 time(s); minimum number is 2 ===
+1 day, 20:34:16.758922 PROGRESS: ❌ rt_error       : optimization incomplete after 7 search(es). Will search with parameter 68.6647.
+1 day, 20:34:16.759002 INFO: ==============================================
+1 day, 20:34:16.759104 INFO: Starting optimization step 7.
+1 day, 20:34:16.759175 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:16.759236 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:16.763715 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:16.763772 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:16.763815 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:16.763842 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.83
+1 day, 20:34:16.766497 INFO: Starting candidate selection
+1 day, 20:34:20.427404 INFO: Starting candidate scoring
+1 day, 20:34:21.378287 INFO: Finished candidate processing
+1 day, 20:34:21.378425 INFO: Collecting candidate features
+1 day, 20:34:21.425292 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 30357)
+1 day, 20:34:21.429644 INFO: Collecting fragment features
+1 day, 20:34:21.450766 INFO: Finished candidate scoring
+1 day, 20:34:21.467208 PROGRESS: === Extracted 30357 precursors and 323663 fragments ===
+1 day, 20:34:21.467631 INFO: performing precursor FDR with 47 features
+1 day, 20:34:21.467676 INFO: Decoy channel: -1
+1 day, 20:34:21.467708 INFO: Competetive: True
+1 day, 20:34:21.476979 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:21.481105 WARNING: dropped 1 decoy PSMs due to missing features
+1 day, 20:34:21.818142 INFO: Test AUC: 0.829
+1 day, 20:34:21.818265 INFO: Train AUC: 0.826
+1 day, 20:34:21.818295 INFO: AUC difference: 0.29%
+1 day, 20:34:21.901964 INFO: Resetting torch num_threads to 100
+1 day, 20:34:21.903201 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:21.904631 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:21.904746 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:21.904809 PROGRESS: Target precursors: 7,930 (99.12%)
+1 day, 20:34:21.904861 PROGRESS: Decoy precursors: 70 (0.88%)
+1 day, 20:34:21.904910 PROGRESS: 
+1 day, 20:34:21.904956 PROGRESS: Precursor Summary:
+1 day, 20:34:21.908038 PROGRESS: Channel   0:	 0.05 FDR: 7,930; 0.01 FDR: 7,930; 0.001 FDR: 6,935
+1 day, 20:34:21.908161 PROGRESS: 
+1 day, 20:34:21.908218 PROGRESS: Protein Summary:
+1 day, 20:34:21.912814 PROGRESS: Channel   0:	 0.05 FDR: 4,195; 0.01 FDR: 4,195; 0.001 FDR: 3,786
+1 day, 20:34:21.912930 PROGRESS: =========================================================================
+1 day, 20:34:21.938098 INFO: fragments_df_filtered: 5000
+1 day, 20:34:21.952734 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:22.769696 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:23.681357 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:24.563732 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:24.930063 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:24.933008 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:24.942232 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:24.944537 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:24.962237 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:24.962399 PROGRESS: === Optimization of rt_error has been performed 8 time(s); minimum number is 2 ===
+1 day, 20:34:24.968337 PROGRESS: ❌ rt_error       : optimization incomplete after 8 search(es). Will search with parameter 56.5468.
+1 day, 20:34:24.968402 INFO: ==============================================
+1 day, 20:34:24.968500 INFO: Starting optimization step 8.
+1 day, 20:34:24.968568 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:24.968625 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:24.972480 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:24.972532 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:24.972569 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:24.972591 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:34:24.973713 INFO: Starting candidate selection
+1 day, 20:34:28.443144 INFO: Starting candidate scoring
+1 day, 20:34:29.376381 INFO: Finished candidate processing
+1 day, 20:34:29.376563 INFO: Collecting candidate features
+1 day, 20:34:29.424389 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 30330)
+1 day, 20:34:29.428761 INFO: Collecting fragment features
+1 day, 20:34:29.446675 INFO: Finished candidate scoring
+1 day, 20:34:29.462608 PROGRESS: === Extracted 30330 precursors and 323205 fragments ===
+1 day, 20:34:29.462997 INFO: performing precursor FDR with 47 features
+1 day, 20:34:29.463037 INFO: Decoy channel: -1
+1 day, 20:34:29.463063 INFO: Competetive: True
+1 day, 20:34:29.471545 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:29.475781 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 20:34:29.813524 INFO: Test AUC: 0.828
+1 day, 20:34:29.813656 INFO: Train AUC: 0.828
+1 day, 20:34:29.813690 INFO: AUC difference: 0.00%
+1 day, 20:34:29.897237 INFO: Resetting torch num_threads to 100
+1 day, 20:34:29.898458 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:29.899904 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:29.900016 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:29.900081 PROGRESS: Target precursors: 7,930 (99.12%)
+1 day, 20:34:29.900136 PROGRESS: Decoy precursors: 70 (0.88%)
+1 day, 20:34:29.900189 PROGRESS: 
+1 day, 20:34:29.900238 PROGRESS: Precursor Summary:
+1 day, 20:34:29.903270 PROGRESS: Channel   0:	 0.05 FDR: 7,930; 0.01 FDR: 7,930; 0.001 FDR: 6,801
+1 day, 20:34:29.903410 PROGRESS: 
+1 day, 20:34:29.903475 PROGRESS: Protein Summary:
+1 day, 20:34:29.908116 PROGRESS: Channel   0:	 0.05 FDR: 4,195; 0.01 FDR: 4,195; 0.001 FDR: 3,731
+1 day, 20:34:29.908226 PROGRESS: =========================================================================
+1 day, 20:34:29.933521 INFO: fragments_df_filtered: 5000
+1 day, 20:34:29.948117 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:30.776544 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:31.625338 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:32.447856 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:32.798517 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:32.801499 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:32.810819 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:32.813217 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:32.832279 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:32.832463 PROGRESS: === Optimization of rt_error has been performed 9 time(s); minimum number is 2 ===
+1 day, 20:34:32.838997 PROGRESS: ❌ rt_error       : optimization incomplete after 9 search(es). Will search with parameter 48.1562.
+1 day, 20:34:32.839067 INFO: ==============================================
+1 day, 20:34:32.839174 INFO: Starting optimization step 9.
+1 day, 20:34:32.839247 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:32.839314 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:32.844860 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:32.844921 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:32.844966 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:32.844993 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:34:32.847130 INFO: Starting candidate selection
+1 day, 20:34:36.041940 INFO: Starting candidate scoring
+1 day, 20:34:36.972137 INFO: Finished candidate processing
+1 day, 20:34:36.972274 INFO: Collecting candidate features
+1 day, 20:34:37.018229 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 30318)
+1 day, 20:34:37.022713 INFO: Collecting fragment features
+1 day, 20:34:37.040277 INFO: Finished candidate scoring
+1 day, 20:34:37.055927 PROGRESS: === Extracted 30318 precursors and 322738 fragments ===
+1 day, 20:34:37.056365 INFO: performing precursor FDR with 47 features
+1 day, 20:34:37.056412 INFO: Decoy channel: -1
+1 day, 20:34:37.056443 INFO: Competetive: True
+1 day, 20:34:37.064522 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:37.068627 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 20:34:37.400748 INFO: Test AUC: 0.828
+1 day, 20:34:37.400878 INFO: Train AUC: 0.831
+1 day, 20:34:37.400914 INFO: AUC difference: 0.37%
+1 day, 20:34:37.485185 INFO: Resetting torch num_threads to 100
+1 day, 20:34:37.486455 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:37.487949 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:37.488059 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:37.488138 PROGRESS: Target precursors: 7,938 (99.22%)
+1 day, 20:34:37.488211 PROGRESS: Decoy precursors: 62 (0.78%)
+1 day, 20:34:37.488271 PROGRESS: 
+1 day, 20:34:37.488329 PROGRESS: Precursor Summary:
+1 day, 20:34:37.491525 PROGRESS: Channel   0:	 0.05 FDR: 7,938; 0.01 FDR: 7,938; 0.001 FDR: 7,114
+1 day, 20:34:37.491671 PROGRESS: 
+1 day, 20:34:37.491755 PROGRESS: Protein Summary:
+1 day, 20:34:37.496487 PROGRESS: Channel   0:	 0.05 FDR: 4,194; 0.01 FDR: 4,194; 0.001 FDR: 3,858
+1 day, 20:34:37.496615 PROGRESS: =========================================================================
+1 day, 20:34:37.521271 INFO: fragments_df_filtered: 5000
+1 day, 20:34:37.535935 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:38.420418 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:39.338068 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:40.223213 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:40.640688 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:40.643647 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:40.653034 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:40.655374 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:40.674743 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:40.674908 PROGRESS: === Optimization of rt_error has been performed 10 time(s); minimum number is 2 ===
+1 day, 20:34:40.680907 PROGRESS: ❌ rt_error       : optimization incomplete after 10 search(es). Will search with parameter 42.0282.
+1 day, 20:34:40.680967 INFO: ==============================================
+1 day, 20:34:40.681075 INFO: Starting optimization step 10.
+1 day, 20:34:40.681149 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:40.681208 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:40.685748 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:40.685802 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:40.685837 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:40.685858 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:34:40.686871 INFO: Starting candidate selection
+1 day, 20:34:43.514672 INFO: Starting candidate scoring
+1 day, 20:34:44.443527 INFO: Finished candidate processing
+1 day, 20:34:44.444138 INFO: Collecting candidate features
+1 day, 20:34:44.487504 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 30300)
+1 day, 20:34:44.491853 INFO: Collecting fragment features
+1 day, 20:34:44.509425 INFO: Finished candidate scoring
+1 day, 20:34:44.524456 PROGRESS: === Extracted 30300 precursors and 322091 fragments ===
+1 day, 20:34:44.524837 INFO: performing precursor FDR with 47 features
+1 day, 20:34:44.524874 INFO: Decoy channel: -1
+1 day, 20:34:44.524898 INFO: Competetive: True
+1 day, 20:34:44.533123 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:44.537991 WARNING: dropped 1 target PSMs due to missing features
+1 day, 20:34:44.538083 WARNING: dropped 3 decoy PSMs due to missing features
+1 day, 20:34:44.867384 INFO: Test AUC: 0.833
+1 day, 20:34:44.867510 INFO: Train AUC: 0.832
+1 day, 20:34:44.867542 INFO: AUC difference: 0.16%
+1 day, 20:34:44.951283 INFO: Resetting torch num_threads to 100
+1 day, 20:34:44.952499 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:44.953945 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:44.954048 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:44.954108 PROGRESS: Target precursors: 7,942 (99.28%)
+1 day, 20:34:44.954438 PROGRESS: Decoy precursors: 58 (0.73%)
+1 day, 20:34:44.954496 PROGRESS: 
+1 day, 20:34:44.954543 PROGRESS: Precursor Summary:
+1 day, 20:34:44.957603 PROGRESS: Channel   0:	 0.05 FDR: 7,942; 0.01 FDR: 7,942; 0.001 FDR: 7,095
+1 day, 20:34:44.957728 PROGRESS: 
+1 day, 20:34:44.957787 PROGRESS: Protein Summary:
+1 day, 20:34:44.962376 PROGRESS: Channel   0:	 0.05 FDR: 4,197; 0.01 FDR: 4,197; 0.001 FDR: 3,854
+1 day, 20:34:44.962487 PROGRESS: =========================================================================
+1 day, 20:34:44.987042 INFO: fragments_df_filtered: 5000
+1 day, 20:34:45.002126 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:45.885891 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:46.793742 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:47.637236 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:47.988086 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:47.991034 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:48.000320 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:48.002687 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:48.021899 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:48.022070 PROGRESS: === Optimization of rt_error has been performed 11 time(s); minimum number is 2 ===
+1 day, 20:34:48.028052 PROGRESS: ❌ rt_error       : optimization incomplete after 11 search(es). Will search with parameter 33.5393.
+1 day, 20:34:48.028112 INFO: ==============================================
+1 day, 20:34:48.028203 INFO: Starting optimization step 11.
+1 day, 20:34:48.028270 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:48.029147 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:48.032822 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:48.032871 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:48.032905 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:48.032928 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:34:48.034021 INFO: Starting candidate selection
+1 day, 20:34:50.668639 INFO: Starting candidate scoring
+1 day, 20:34:51.603460 INFO: Finished candidate processing
+1 day, 20:34:51.603612 INFO: Collecting candidate features
+1 day, 20:34:51.646500 WARNING: intensity_correlation has 5 NaNs ( 0.02 % out of 30321)
+1 day, 20:34:51.650808 INFO: Collecting fragment features
+1 day, 20:34:51.670337 INFO: Finished candidate scoring
+1 day, 20:34:51.684680 PROGRESS: === Extracted 30321 precursors and 321803 fragments ===
+1 day, 20:34:51.685068 INFO: performing precursor FDR with 47 features
+1 day, 20:34:51.685109 INFO: Decoy channel: -1
+1 day, 20:34:51.685133 INFO: Competetive: True
+1 day, 20:34:51.692949 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:51.696922 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 20:34:52.026234 INFO: Test AUC: 0.833
+1 day, 20:34:52.026357 INFO: Train AUC: 0.837
+1 day, 20:34:52.026387 INFO: AUC difference: 0.44%
+1 day, 20:34:52.110593 INFO: Resetting torch num_threads to 100
+1 day, 20:34:52.111794 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:52.113283 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:52.113383 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:52.113445 PROGRESS: Target precursors: 7,940 (99.25%)
+1 day, 20:34:52.113498 PROGRESS: Decoy precursors: 60 (0.75%)
+1 day, 20:34:52.113545 PROGRESS: 
+1 day, 20:34:52.113596 PROGRESS: Precursor Summary:
+1 day, 20:34:52.116676 PROGRESS: Channel   0:	 0.05 FDR: 7,940; 0.01 FDR: 7,940; 0.001 FDR: 7,186
+1 day, 20:34:52.116800 PROGRESS: 
+1 day, 20:34:52.116860 PROGRESS: Protein Summary:
+1 day, 20:34:52.121521 PROGRESS: Channel   0:	 0.05 FDR: 4,195; 0.01 FDR: 4,195; 0.001 FDR: 3,894
+1 day, 20:34:52.121639 PROGRESS: =========================================================================
+1 day, 20:34:52.146031 INFO: fragments_df_filtered: 5000
+1 day, 20:34:52.160522 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:52.978605 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:34:53.829548 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:34:54.647011 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:34:54.997998 INFO: calibration group: precursor, predicting mz
+1 day, 20:34:55.000915 INFO: calibration group: precursor, predicting rt
+1 day, 20:34:55.010194 INFO: calibration group: precursor, predicting mobility
+1 day, 20:34:55.012541 INFO: calibration group: fragment, predicting mz
+1 day, 20:34:55.032465 INFO: === checking if optimization conditions were reached ===
+1 day, 20:34:55.032621 PROGRESS: === Optimization of rt_error has been performed 12 time(s); minimum number is 2 ===
+1 day, 20:34:55.038604 PROGRESS: ❌ rt_error       : optimization incomplete after 12 search(es). Will search with parameter 24.6929.
+1 day, 20:34:55.038663 INFO: ==============================================
+1 day, 20:34:55.038754 INFO: Starting optimization step 12.
+1 day, 20:34:55.038821 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:34:55.038879 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:34:55.042817 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:34:55.042871 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:34:55.042906 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:34:55.042929 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:34:55.043973 INFO: Starting candidate selection
+1 day, 20:34:57.213339 INFO: Starting candidate scoring
+1 day, 20:34:58.142167 INFO: Finished candidate processing
+1 day, 20:34:58.142300 INFO: Collecting candidate features
+1 day, 20:34:58.185673 WARNING: intensity_correlation has 4 NaNs ( 0.01 % out of 30315)
+1 day, 20:34:58.189999 INFO: Collecting fragment features
+1 day, 20:34:58.208805 INFO: Finished candidate scoring
+1 day, 20:34:58.222909 PROGRESS: === Extracted 30315 precursors and 321119 fragments ===
+1 day, 20:34:58.223290 INFO: performing precursor FDR with 47 features
+1 day, 20:34:58.223330 INFO: Decoy channel: -1
+1 day, 20:34:58.223354 INFO: Competetive: True
+1 day, 20:34:58.231144 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:34:58.235073 WARNING: dropped 4 decoy PSMs due to missing features
+1 day, 20:34:58.565059 INFO: Test AUC: 0.846
+1 day, 20:34:58.565183 INFO: Train AUC: 0.841
+1 day, 20:34:58.565215 INFO: AUC difference: 0.51%
+1 day, 20:34:58.650485 INFO: Resetting torch num_threads to 100
+1 day, 20:34:58.651629 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:34:58.653099 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:34:58.653199 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:34:58.653260 PROGRESS: Target precursors: 7,946 (99.33%)
+1 day, 20:34:58.653313 PROGRESS: Decoy precursors: 54 (0.68%)
+1 day, 20:34:58.653360 PROGRESS: 
+1 day, 20:34:58.653404 PROGRESS: Precursor Summary:
+1 day, 20:34:58.656432 PROGRESS: Channel   0:	 0.05 FDR: 7,946; 0.01 FDR: 7,946; 0.001 FDR: 7,375
+1 day, 20:34:58.656550 PROGRESS: 
+1 day, 20:34:58.656607 PROGRESS: Protein Summary:
+1 day, 20:34:58.661261 PROGRESS: Channel   0:	 0.05 FDR: 4,202; 0.01 FDR: 4,202; 0.001 FDR: 3,980
+1 day, 20:34:58.661376 PROGRESS: =========================================================================
+1 day, 20:34:58.686248 INFO: fragments_df_filtered: 5000
+1 day, 20:34:58.700810 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:34:59.520034 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:00.360158 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:01.185464 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:01.537577 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:01.540583 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:01.549942 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:01.552317 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:01.571723 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:01.571887 PROGRESS: === Optimization of rt_error has been performed 13 time(s); minimum number is 2 ===
+1 day, 20:35:01.577927 PROGRESS: ❌ rt_error       : optimization incomplete after 13 search(es). Will search with parameter 19.9764.
+1 day, 20:35:01.577987 INFO: ==============================================
+1 day, 20:35:01.578081 INFO: Starting optimization step 13.
+1 day, 20:35:01.578147 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:01.578204 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:01.582358 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:01.582413 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:01.582449 INFO: FWHM in RT is 2.86 seconds, sigma is 0.63
+1 day, 20:35:01.582473 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:35:01.583477 INFO: Starting candidate selection
+1 day, 20:35:03.503894 INFO: Starting candidate scoring
+1 day, 20:35:04.418536 INFO: Finished candidate processing
+1 day, 20:35:04.418641 INFO: Collecting candidate features
+1 day, 20:35:04.462625 WARNING: intensity_correlation has 7 NaNs ( 0.02 % out of 30270)
+1 day, 20:35:04.466971 INFO: Collecting fragment features
+1 day, 20:35:04.484897 INFO: Finished candidate scoring
+1 day, 20:35:04.498411 PROGRESS: === Extracted 30270 precursors and 319583 fragments ===
+1 day, 20:35:04.498785 INFO: performing precursor FDR with 47 features
+1 day, 20:35:04.498824 INFO: Decoy channel: -1
+1 day, 20:35:04.498848 INFO: Competetive: True
+1 day, 20:35:04.506685 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:04.511406 WARNING: dropped 1 target PSMs due to missing features
+1 day, 20:35:04.511494 WARNING: dropped 6 decoy PSMs due to missing features
+1 day, 20:35:04.836603 INFO: Test AUC: 0.845
+1 day, 20:35:04.836730 INFO: Train AUC: 0.847
+1 day, 20:35:04.836759 INFO: AUC difference: 0.16%
+1 day, 20:35:04.921574 INFO: Resetting torch num_threads to 100
+1 day, 20:35:04.922791 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:35:04.924346 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:04.924444 PROGRESS: Total precursors accumulated: 7,999
+1 day, 20:35:04.924508 PROGRESS: Target precursors: 7,950 (99.39%)
+1 day, 20:35:04.924565 PROGRESS: Decoy precursors: 49 (0.61%)
+1 day, 20:35:04.924614 PROGRESS: 
+1 day, 20:35:04.924663 PROGRESS: Precursor Summary:
+1 day, 20:35:04.927813 PROGRESS: Channel   0:	 0.05 FDR: 7,950; 0.01 FDR: 7,950; 0.001 FDR: 7,401
+1 day, 20:35:04.927936 PROGRESS: 
+1 day, 20:35:04.928008 PROGRESS: Protein Summary:
+1 day, 20:35:04.932722 PROGRESS: Channel   0:	 0.05 FDR: 4,202; 0.01 FDR: 4,202; 0.001 FDR: 3,984
+1 day, 20:35:04.932830 PROGRESS: =========================================================================
+1 day, 20:35:04.957594 INFO: fragments_df_filtered: 5000
+1 day, 20:35:04.972233 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:05.795460 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:06.628336 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:07.452673 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:07.802119 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:07.805021 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:07.814280 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:07.816643 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:07.835678 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:07.835831 PROGRESS: === Optimization of rt_error has been performed 14 time(s); minimum number is 2 ===
+1 day, 20:35:07.841816 PROGRESS: ❌ rt_error       : optimization incomplete after 14 search(es). Will search with parameter 15.7169.
+1 day, 20:35:07.841877 INFO: ==============================================
+1 day, 20:35:07.841970 INFO: Starting optimization step 14.
+1 day, 20:35:07.842035 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:07.842094 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:07.846231 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:07.846284 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:07.846319 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 20:35:07.846343 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:35:07.847297 INFO: Starting candidate selection
+1 day, 20:35:09.585294 INFO: Starting candidate scoring
+1 day, 20:35:10.496430 INFO: Finished candidate processing
+1 day, 20:35:10.496610 INFO: Collecting candidate features
+1 day, 20:35:10.569103 WARNING: intensity_correlation has 7 NaNs ( 0.02 % out of 30263)
+1 day, 20:35:10.573436 INFO: Collecting fragment features
+1 day, 20:35:10.591379 INFO: Finished candidate scoring
+1 day, 20:35:10.604683 PROGRESS: === Extracted 30263 precursors and 318736 fragments ===
+1 day, 20:35:10.605062 INFO: performing precursor FDR with 47 features
+1 day, 20:35:10.605101 INFO: Decoy channel: -1
+1 day, 20:35:10.605124 INFO: Competetive: True
+1 day, 20:35:10.613001 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:10.616858 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 20:35:10.946198 INFO: Test AUC: 0.850
+1 day, 20:35:10.946326 INFO: Train AUC: 0.850
+1 day, 20:35:10.946356 INFO: AUC difference: 0.02%
+1 day, 20:35:11.030322 INFO: Resetting torch num_threads to 100
+1 day, 20:35:11.031540 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:35:11.032927 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:11.033034 PROGRESS: Total precursors accumulated: 8,000
+1 day, 20:35:11.033099 PROGRESS: Target precursors: 7,954 (99.42%)
+1 day, 20:35:11.033154 PROGRESS: Decoy precursors: 46 (0.57%)
+1 day, 20:35:11.033204 PROGRESS: 
+1 day, 20:35:11.033251 PROGRESS: Precursor Summary:
+1 day, 20:35:11.036249 PROGRESS: Channel   0:	 0.05 FDR: 7,954; 0.01 FDR: 7,954; 0.001 FDR: 7,397
+1 day, 20:35:11.036374 PROGRESS: 
+1 day, 20:35:11.036433 PROGRESS: Protein Summary:
+1 day, 20:35:11.040997 PROGRESS: Channel   0:	 0.05 FDR: 4,205; 0.01 FDR: 4,205; 0.001 FDR: 3,976
+1 day, 20:35:11.041125 PROGRESS: =========================================================================
+1 day, 20:35:11.065741 INFO: fragments_df_filtered: 5000
+1 day, 20:35:11.080071 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:11.914023 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:12.755286 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:13.577898 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:13.928905 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:13.931901 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:13.941226 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:13.943634 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:13.963288 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:13.963466 PROGRESS: === Optimization of rt_error has been performed 15 time(s); minimum number is 2 ===
+1 day, 20:35:13.970047 PROGRESS: ❌ rt_error       : optimization incomplete after 15 search(es). Will search with parameter 14.5561.
+1 day, 20:35:13.970118 INFO: ==============================================
+1 day, 20:35:13.970228 INFO: Starting optimization step 15.
+1 day, 20:35:13.970315 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:13.970382 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:13.975757 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:13.975821 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:13.975865 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 20:35:13.975892 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:35:13.977736 INFO: Starting candidate selection
+1 day, 20:35:15.531713 INFO: Starting candidate scoring
+1 day, 20:35:16.459107 INFO: Finished candidate processing
+1 day, 20:35:16.459289 INFO: Collecting candidate features
+1 day, 20:35:16.507441 WARNING: intensity_correlation has 8 NaNs ( 0.03 % out of 30224)
+1 day, 20:35:16.511774 INFO: Collecting fragment features
+1 day, 20:35:16.531534 INFO: Finished candidate scoring
+1 day, 20:35:16.544713 PROGRESS: === Extracted 30224 precursors and 317425 fragments ===
+1 day, 20:35:16.545102 INFO: performing precursor FDR with 47 features
+1 day, 20:35:16.545143 INFO: Decoy channel: -1
+1 day, 20:35:16.545166 INFO: Competetive: True
+1 day, 20:35:16.552896 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:16.556703 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 20:35:16.889282 INFO: Test AUC: 0.859
+1 day, 20:35:16.889410 INFO: Train AUC: 0.855
+1 day, 20:35:16.889439 INFO: AUC difference: 0.49%
+1 day, 20:35:16.975426 INFO: Resetting torch num_threads to 100
+1 day, 20:35:16.976671 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:35:16.978055 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:16.978152 PROGRESS: Total precursors accumulated: 7,999
+1 day, 20:35:16.978213 PROGRESS: Target precursors: 7,958 (99.49%)
+1 day, 20:35:16.978266 PROGRESS: Decoy precursors: 41 (0.51%)
+1 day, 20:35:16.978314 PROGRESS: 
+1 day, 20:35:16.978373 PROGRESS: Precursor Summary:
+1 day, 20:35:16.981347 PROGRESS: Channel   0:	 0.05 FDR: 7,958; 0.01 FDR: 7,958; 0.001 FDR: 7,122
+1 day, 20:35:16.981469 PROGRESS: 
+1 day, 20:35:16.981534 PROGRESS: Protein Summary:
+1 day, 20:35:16.986088 PROGRESS: Channel   0:	 0.05 FDR: 4,208; 0.01 FDR: 4,208; 0.001 FDR: 3,867
+1 day, 20:35:16.986202 PROGRESS: =========================================================================
+1 day, 20:35:17.010375 INFO: fragments_df_filtered: 5000
+1 day, 20:35:17.024904 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:17.847284 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:18.680979 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:19.507092 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:19.857945 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:19.860819 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:19.869991 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:19.872359 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:19.890928 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:19.891083 PROGRESS: === Optimization of rt_error has been performed 16 time(s); minimum number is 2 ===
+1 day, 20:35:19.897076 PROGRESS: ❌ rt_error       : optimization incomplete after 16 search(es). Will search with parameter 12.5333.
+1 day, 20:35:19.897135 INFO: ==============================================
+1 day, 20:35:19.897231 INFO: Starting optimization step 16.
+1 day, 20:35:19.897299 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:19.897361 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:19.901091 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:19.901149 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:19.901185 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 20:35:19.901209 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:35:19.902129 INFO: Starting candidate selection
+1 day, 20:35:21.454183 INFO: Starting candidate scoring
+1 day, 20:35:22.378598 INFO: Finished candidate processing
+1 day, 20:35:22.378784 INFO: Collecting candidate features
+1 day, 20:35:22.423138 WARNING: intensity_correlation has 7 NaNs ( 0.02 % out of 30206)
+1 day, 20:35:22.427478 INFO: Collecting fragment features
+1 day, 20:35:22.445172 INFO: Finished candidate scoring
+1 day, 20:35:22.458340 PROGRESS: === Extracted 30206 precursors and 317218 fragments ===
+1 day, 20:35:22.458718 INFO: performing precursor FDR with 47 features
+1 day, 20:35:22.458757 INFO: Decoy channel: -1
+1 day, 20:35:22.458781 INFO: Competetive: True
+1 day, 20:35:22.466480 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:22.471168 WARNING: dropped 2 target PSMs due to missing features
+1 day, 20:35:22.471254 WARNING: dropped 5 decoy PSMs due to missing features
+1 day, 20:35:22.797191 INFO: Test AUC: 0.864
+1 day, 20:35:22.797314 INFO: Train AUC: 0.854
+1 day, 20:35:22.797344 INFO: AUC difference: 1.12%
+1 day, 20:35:22.881080 INFO: Resetting torch num_threads to 100
+1 day, 20:35:22.882289 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:35:22.883667 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:22.883762 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:35:22.883822 PROGRESS: Target precursors: 7,959 (99.51%)
+1 day, 20:35:22.883874 PROGRESS: Decoy precursors: 39 (0.49%)
+1 day, 20:35:22.883922 PROGRESS: 
+1 day, 20:35:22.883966 PROGRESS: Precursor Summary:
+1 day, 20:35:22.886988 PROGRESS: Channel   0:	 0.05 FDR: 7,959; 0.01 FDR: 7,959; 0.001 FDR: 7,528
+1 day, 20:35:22.887114 PROGRESS: 
+1 day, 20:35:22.887173 PROGRESS: Protein Summary:
+1 day, 20:35:22.891800 PROGRESS: Channel   0:	 0.05 FDR: 4,207; 0.01 FDR: 4,207; 0.001 FDR: 4,038
+1 day, 20:35:22.891909 PROGRESS: =========================================================================
+1 day, 20:35:22.916548 INFO: fragments_df_filtered: 5000
+1 day, 20:35:22.930860 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:23.819273 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:24.726310 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:25.616693 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:26.033334 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:26.036116 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:26.045385 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:26.047629 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:26.065127 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:26.065291 PROGRESS: === Optimization of rt_error has been performed 17 time(s); minimum number is 2 ===
+1 day, 20:35:26.071124 PROGRESS: ❌ rt_error       : optimization incomplete after 17 search(es). Will search with parameter 12.0108.
+1 day, 20:35:26.071183 INFO: ==============================================
+1 day, 20:35:26.071275 INFO: Starting optimization step 17.
+1 day, 20:35:26.071345 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:26.071403 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:26.075561 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:26.075618 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:26.075653 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 20:35:26.075677 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.81
+1 day, 20:35:26.076845 INFO: Starting candidate selection
+1 day, 20:35:27.611315 INFO: Starting candidate scoring
+1 day, 20:35:28.527710 INFO: Finished candidate processing
+1 day, 20:35:28.527812 INFO: Collecting candidate features
+1 day, 20:35:28.571355 WARNING: intensity_correlation has 11 NaNs ( 0.04 % out of 30214)
+1 day, 20:35:28.575636 INFO: Collecting fragment features
+1 day, 20:35:28.593283 INFO: Finished candidate scoring
+1 day, 20:35:28.605875 PROGRESS: === Extracted 30214 precursors and 317276 fragments ===
+1 day, 20:35:28.606257 INFO: performing precursor FDR with 47 features
+1 day, 20:35:28.606295 INFO: Decoy channel: -1
+1 day, 20:35:28.606319 INFO: Competetive: True
+1 day, 20:35:28.614309 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:28.619223 WARNING: dropped 4 target PSMs due to missing features
+1 day, 20:35:28.619308 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 20:35:28.946068 INFO: Test AUC: 0.859
+1 day, 20:35:28.946189 INFO: Train AUC: 0.854
+1 day, 20:35:28.946221 INFO: AUC difference: 0.55%
+1 day, 20:35:29.029932 INFO: Resetting torch num_threads to 100
+1 day, 20:35:29.031129 INFO: === FDR correction performed with classifier version 2 ===
+1 day, 20:35:29.032524 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:29.032640 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:35:29.032707 PROGRESS: Target precursors: 7,962 (99.55%)
+1 day, 20:35:29.032761 PROGRESS: Decoy precursors: 36 (0.45%)
+1 day, 20:35:29.032807 PROGRESS: 
+1 day, 20:35:29.032853 PROGRESS: Precursor Summary:
+1 day, 20:35:29.035862 PROGRESS: Channel   0:	 0.05 FDR: 7,962; 0.01 FDR: 7,962; 0.001 FDR: 7,544
+1 day, 20:35:29.035991 PROGRESS: 
+1 day, 20:35:29.036049 PROGRESS: Protein Summary:
+1 day, 20:35:29.040610 PROGRESS: Channel   0:	 0.05 FDR: 4,208; 0.01 FDR: 4,208; 0.001 FDR: 4,046
+1 day, 20:35:29.040727 PROGRESS: =========================================================================
+1 day, 20:35:29.065094 INFO: fragments_df_filtered: 5000
+1 day, 20:35:29.079643 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:29.906357 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:30.742179 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:31.569019 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:31.918186 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:31.921045 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:31.930256 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:31.932599 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:31.950703 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:31.950855 PROGRESS: === Optimization of rt_error has been performed 18 time(s); minimum number is 2 ===
+1 day, 20:35:31.951865 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 12.0108 found after 18 searches.
+1 day, 20:35:31.951914 INFO: ==============================================
+1 day, 20:35:31.952015 PROGRESS: Optimization finished for rt_error.
+1 day, 20:35:31.966295 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:31.969123 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:31.978326 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:31.980700 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:32.024396 INFO: Starting optimization step 0.
+1 day, 20:35:32.024577 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:32.024643 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:32.028457 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:32.028514 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:32.028549 INFO: FWHM in RT is 2.85 seconds, sigma is 0.63
+1 day, 20:35:32.028571 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.82
+1 day, 20:35:32.037405 INFO: Starting candidate selection
+1 day, 20:35:33.617319 INFO: Starting candidate scoring
+1 day, 20:35:34.540856 INFO: Finished candidate processing
+1 day, 20:35:34.541067 INFO: Collecting candidate features
+1 day, 20:35:34.585119 WARNING: intensity_correlation has 11 NaNs ( 0.04 % out of 30198)
+1 day, 20:35:34.589459 INFO: Collecting fragment features
+1 day, 20:35:34.607090 INFO: Finished candidate scoring
+1 day, 20:35:34.619816 PROGRESS: === Extracted 30198 precursors and 317110 fragments ===
+1 day, 20:35:34.620187 INFO: performing precursor FDR with 47 features
+1 day, 20:35:34.620225 INFO: Decoy channel: -1
+1 day, 20:35:34.620260 INFO: Competetive: True
+1 day, 20:35:34.628030 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:34.632819 WARNING: dropped 4 target PSMs due to missing features
+1 day, 20:35:34.632910 WARNING: dropped 7 decoy PSMs due to missing features
+1 day, 20:35:34.961013 INFO: Test AUC: 0.856
+1 day, 20:35:34.961152 INFO: Train AUC: 0.857
+1 day, 20:35:34.961185 INFO: AUC difference: 0.20%
+1 day, 20:35:35.045229 INFO: Resetting torch num_threads to 100
+1 day, 20:35:35.046420 INFO: === FDR correction performed with classifier version 20 ===
+1 day, 20:35:35.047805 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:35.047900 PROGRESS: Total precursors accumulated: 7,998
+1 day, 20:35:35.047961 PROGRESS: Target precursors: 7,958 (99.50%)
+1 day, 20:35:35.048014 PROGRESS: Decoy precursors: 40 (0.50%)
+1 day, 20:35:35.048062 PROGRESS: 
+1 day, 20:35:35.048123 PROGRESS: Precursor Summary:
+1 day, 20:35:35.051115 PROGRESS: Channel   0:	 0.05 FDR: 7,958; 0.01 FDR: 7,958; 0.001 FDR: 7,436
+1 day, 20:35:35.051241 PROGRESS: 
+1 day, 20:35:35.051301 PROGRESS: Protein Summary:
+1 day, 20:35:35.055853 PROGRESS: Channel   0:	 0.05 FDR: 4,208; 0.01 FDR: 4,208; 0.001 FDR: 3,999
+1 day, 20:35:35.055962 PROGRESS: =========================================================================
+1 day, 20:35:35.080048 INFO: fragments_df_filtered: 5000
+1 day, 20:35:35.094392 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:35.928955 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:36.762755 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:37.589961 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:37.959890 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:37.962732 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:37.972022 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:37.974360 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:37.993357 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:37.993509 PROGRESS: === Optimization of mobility_error has been performed 1 time(s); minimum number is 2 ===
+1 day, 20:35:37.996155 PROGRESS: ❌ mobility_error : optimization incomplete after 1 search(es). Will search with parameter 0.0609.
+1 day, 20:35:37.996208 INFO: ==============================================
+1 day, 20:35:37.996298 INFO: Starting optimization step 1.
+1 day, 20:35:37.996367 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:37.996426 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:38.000022 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:38.000076 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:38.000113 INFO: FWHM in RT is 2.84 seconds, sigma is 0.63
+1 day, 20:35:38.000136 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.81
+1 day, 20:35:38.001161 INFO: Starting candidate selection
+1 day, 20:35:39.347291 INFO: Starting candidate scoring
+1 day, 20:35:40.295900 INFO: Finished candidate processing
+1 day, 20:35:40.296089 INFO: Collecting candidate features
+1 day, 20:35:40.339447 WARNING: intensity_correlation has 11 NaNs ( 0.04 % out of 30160)
+1 day, 20:35:40.343771 INFO: Collecting fragment features
+1 day, 20:35:40.361372 INFO: Finished candidate scoring
+1 day, 20:35:40.374212 PROGRESS: === Extracted 30160 precursors and 314586 fragments ===
+1 day, 20:35:40.374580 INFO: performing precursor FDR with 47 features
+1 day, 20:35:40.374619 INFO: Decoy channel: -1
+1 day, 20:35:40.374642 INFO: Competetive: True
+1 day, 20:35:40.382263 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:40.386954 WARNING: dropped 3 target PSMs due to missing features
+1 day, 20:35:40.387045 WARNING: dropped 8 decoy PSMs due to missing features
+1 day, 20:35:40.714408 INFO: Test AUC: 0.856
+1 day, 20:35:40.714535 INFO: Train AUC: 0.859
+1 day, 20:35:40.714565 INFO: AUC difference: 0.30%
+1 day, 20:35:40.798172 INFO: Resetting torch num_threads to 100
+1 day, 20:35:40.799381 INFO: === FDR correction performed with classifier version 20 ===
+1 day, 20:35:40.800745 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:40.800838 PROGRESS: Total precursors accumulated: 7,996
+1 day, 20:35:40.800901 PROGRESS: Target precursors: 7,963 (99.59%)
+1 day, 20:35:40.800955 PROGRESS: Decoy precursors: 33 (0.41%)
+1 day, 20:35:40.801004 PROGRESS: 
+1 day, 20:35:40.801058 PROGRESS: Precursor Summary:
+1 day, 20:35:40.804027 PROGRESS: Channel   0:	 0.05 FDR: 7,963; 0.01 FDR: 7,963; 0.001 FDR: 7,590
+1 day, 20:35:40.804145 PROGRESS: 
+1 day, 20:35:40.804205 PROGRESS: Protein Summary:
+1 day, 20:35:40.808739 PROGRESS: Channel   0:	 0.05 FDR: 4,206; 0.01 FDR: 4,206; 0.001 FDR: 4,066
+1 day, 20:35:40.808851 PROGRESS: =========================================================================
+1 day, 20:35:40.832874 INFO: fragments_df_filtered: 5000
+1 day, 20:35:40.847243 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:41.684230 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:42.522515 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:43.350733 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:43.701680 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:43.704440 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:43.713500 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:43.715811 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:43.734342 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:43.734525 PROGRESS: === Optimization of mobility_error has been performed 2 time(s); minimum number is 2 ===
+1 day, 20:35:43.737403 PROGRESS: ❌ mobility_error : optimization incomplete after 2 search(es). Will search with parameter 0.0534.
+1 day, 20:35:43.737466 INFO: ==============================================
+1 day, 20:35:43.737571 INFO: Starting optimization step 2.
+1 day, 20:35:43.737650 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1 day, 20:35:43.737721 PROGRESS: Extracting batch of 15886 precursors
+1 day, 20:35:43.742616 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:43.742678 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:43.742720 INFO: FWHM in RT is 2.84 seconds, sigma is 0.62
+1 day, 20:35:43.742747 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.80
+1 day, 20:35:43.743905 INFO: Starting candidate selection
+1 day, 20:35:45.017729 INFO: Starting candidate scoring
+1 day, 20:35:45.936660 INFO: Finished candidate processing
+1 day, 20:35:45.936850 INFO: Collecting candidate features
+1 day, 20:35:45.982225 WARNING: intensity_correlation has 12 NaNs ( 0.04 % out of 30132)
+1 day, 20:35:45.989523 INFO: Collecting fragment features
+1 day, 20:35:46.009090 INFO: Finished candidate scoring
+1 day, 20:35:46.021737 PROGRESS: === Extracted 30132 precursors and 313099 fragments ===
+1 day, 20:35:46.022109 INFO: performing precursor FDR with 47 features
+1 day, 20:35:46.022148 INFO: Decoy channel: -1
+1 day, 20:35:46.022172 INFO: Competetive: True
+1 day, 20:35:46.030301 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:35:46.035004 WARNING: dropped 3 target PSMs due to missing features
+1 day, 20:35:46.035092 WARNING: dropped 9 decoy PSMs due to missing features
+1 day, 20:35:46.360970 INFO: Test AUC: 0.848
+1 day, 20:35:46.361101 INFO: Train AUC: 0.856
+1 day, 20:35:46.361131 INFO: AUC difference: 0.95%
+1 day, 20:35:46.444968 INFO: Resetting torch num_threads to 100
+1 day, 20:35:46.446154 INFO: === FDR correction performed with classifier version 20 ===
+1 day, 20:35:46.447547 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:35:46.447655 PROGRESS: Total precursors accumulated: 7,997
+1 day, 20:35:46.447720 PROGRESS: Target precursors: 7,967 (99.62%)
+1 day, 20:35:46.447773 PROGRESS: Decoy precursors: 30 (0.38%)
+1 day, 20:35:46.447822 PROGRESS: 
+1 day, 20:35:46.447878 PROGRESS: Precursor Summary:
+1 day, 20:35:46.450934 PROGRESS: Channel   0:	 0.05 FDR: 7,967; 0.01 FDR: 7,967; 0.001 FDR: 7,586
+1 day, 20:35:46.451066 PROGRESS: 
+1 day, 20:35:46.451126 PROGRESS: Protein Summary:
+1 day, 20:35:46.455680 PROGRESS: Channel   0:	 0.05 FDR: 4,206; 0.01 FDR: 4,206; 0.001 FDR: 4,064
+1 day, 20:35:46.455795 PROGRESS: =========================================================================
+1 day, 20:35:46.480229 INFO: fragments_df_filtered: 5000
+1 day, 20:35:46.494404 INFO: calibration group: precursor, fitting mz estimator 
+1 day, 20:35:47.385721 INFO: calibration group: precursor, fitting rt estimator 
+1 day, 20:35:48.287401 INFO: calibration group: precursor, fitting mobility estimator 
+1 day, 20:35:49.169440 INFO: calibration group: fragment, fitting mz estimator 
+1 day, 20:35:49.520245 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:49.522994 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:49.532112 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:49.534400 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:49.552493 INFO: === checking if optimization conditions were reached ===
+1 day, 20:35:49.552655 PROGRESS: === Optimization of mobility_error has been performed 3 time(s); minimum number is 2 ===
+1 day, 20:35:49.553429 PROGRESS: ✅ mobility_error : optimization complete. Optimal parameter 0.0534 found after 3 searches.
+1 day, 20:35:49.553482 INFO: ==============================================
+1 day, 20:35:49.554630 PROGRESS: Optimization finished for mobility_error.
+1 day, 20:35:49.568734 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:49.571445 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:49.580428 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:49.582752 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:49.625036 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1 day, 20:35:49.625204 PROGRESS: ==============================================
+1 day, 20:35:49.625281 PROGRESS: ms2_error      : 15.0000
+1 day, 20:35:49.625339 PROGRESS: ms1_error      : 10.0000
+1 day, 20:35:49.625390 PROGRESS: rt_error       : 12.0108
+1 day, 20:35:49.625441 PROGRESS: mobility_error : 0.0534
+1 day, 20:35:49.625492 PROGRESS: ==============================================
+1 day, 20:35:49.626298 INFO: calibration group: precursor, predicting mz
+1 day, 20:35:49.645486 INFO: calibration group: precursor, predicting rt
+1 day, 20:35:49.731818 INFO: calibration group: precursor, predicting mobility
+1 day, 20:35:49.751323 INFO: calibration group: fragment, predicting mz
+1 day, 20:35:49.965779 PROGRESS: Extracting batch of 162861 precursors
+1 day, 20:35:50.000490 INFO: Duty cycle consists of 9 frames, 0.97 seconds cycle time
+1 day, 20:35:50.000623 INFO: Duty cycle consists of 919 scans, 0.00092 1/K_0 resolution
+1 day, 20:35:50.000669 INFO: FWHM in RT is 2.84 seconds, sigma is 0.62
+1 day, 20:35:50.000694 INFO: FWHM in mobility is 0.008 1/K_0, sigma is 3.79
+1 day, 20:35:50.001477 INFO: Starting candidate selection
+1 day, 20:35:58.065130 INFO: Applying score cutoff of 18.31161153793335
+1 day, 20:35:58.072954 INFO: Removed 7714 precursors with score below cutoff
+1 day, 20:35:58.404373 INFO: Starting candidate scoring
+1 day, 20:36:06.921557 INFO: Finished candidate processing
+1 day, 20:36:06.921670 INFO: Collecting candidate features
+1 day, 20:36:07.350207 WARNING: intensity_correlation has 34 NaNs ( 0.01 % out of 302133)
+1 day, 20:36:07.350771 WARNING: height_correlation has 1 NaNs ( 0.00 % out of 302133)
+1 day, 20:36:07.366441 INFO: Collecting fragment features
+1 day, 20:36:07.548130 INFO: Finished candidate scoring
+1 day, 20:36:07.697847 INFO: === FDR correction performed with classifier version 23 ===
+1 day, 20:36:07.698700 INFO: performing precursor FDR with 47 features
+1 day, 20:36:07.698747 INFO: Decoy channel: -1
+1 day, 20:36:07.698771 INFO: Competetive: True
+1 day, 20:36:07.794470 INFO: Setting torch num_threads to 2 for FDR classification task
+1 day, 20:36:07.839330 WARNING: dropped 3 target PSMs due to missing features
+1 day, 20:36:07.839471 WARNING: dropped 31 decoy PSMs due to missing features
+1 day, 20:36:12.747649 INFO: Test AUC: 0.882
+1 day, 20:36:12.747777 INFO: Train AUC: 0.886
+1 day, 20:36:12.747808 INFO: AUC difference: 0.43%
+1 day, 20:36:12.843484 INFO: Resetting torch num_threads to 100
+1 day, 20:36:12.856906 INFO: Removing fragments below FDR threshold
+1 day, 20:36:12.908359 PROGRESS: ============================= Precursor FDR =============================
+1 day, 20:36:12.908631 PROGRESS: Total precursors accumulated: 81,954
+1 day, 20:36:12.908706 PROGRESS: Target precursors: 81,296 (99.20%)
+1 day, 20:36:12.908761 PROGRESS: Decoy precursors: 658 (0.80%)
+1 day, 20:36:12.908812 PROGRESS: 
+1 day, 20:36:12.908857 PROGRESS: Precursor Summary:
+1 day, 20:36:12.943657 PROGRESS: Channel   0:	 0.05 FDR: 81,296; 0.01 FDR: 81,296; 0.001 FDR: 79,731
+1 day, 20:36:12.943977 PROGRESS: 
+1 day, 20:36:12.944045 PROGRESS: Protein Summary:
+1 day, 20:36:12.992593 PROGRESS: Channel   0:	 0.05 FDR: 8,249; 0.01 FDR: 8,249; 0.001 FDR: 8,243
+1 day, 20:36:12.992864 PROGRESS: =========================================================================
+1 day, 20:36:13.659564 INFO: Finished workflow for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:36:14.096495 PROGRESS: Processing search outputs
+1 day, 20:36:14.096637 PROGRESS: Performing protein grouping and FDR
+1 day, 20:36:14.096689 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 20:36:14.169183 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 20:36:14.237838 INFO: Building output for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 20:36:14.305371 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 20:36:14.379763 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:36:14.442785 INFO: Building output for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:36:14.510396 INFO: Building combined output
+1 day, 20:36:14.653792 INFO: Performing protein inference
+1 day, 20:36:15.171181 INFO: Inference strategy: library. Using library grouping for protein inference
+1 day, 20:36:15.175302 INFO: Performing protein FDR
+1 day, 20:36:19.899988 INFO: Normalizing q-values using 8,253 targets and 2,392 decoys
+1 day, 20:36:19.909410 INFO: Test AUC: 1.000
+1 day, 20:36:19.909468 INFO: Train AUC: 1.000
+1 day, 20:36:19.909497 INFO: AUC difference: 0.03%
+1 day, 20:36:20.456545 PROGRESS: ================ Protein FDR =================
+1 day, 20:36:20.456690 PROGRESS: Unique protein groups in output
+1 day, 20:36:20.456719 PROGRESS:   1% protein FDR: 8,247
+1 day, 20:36:20.456740 PROGRESS: 
+1 day, 20:36:20.456758 PROGRESS: Unique precursor in output
+1 day, 20:36:20.456777 PROGRESS:   1% protein FDR: 82,019
+1 day, 20:36:20.456796 PROGRESS: ================================================
+1 day, 20:36:20.532171 PROGRESS: Building search statistics
+1 day, 20:36:20.653512 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/optimization_manager.pkl
+1 day, 20:36:20.653715 INFO: Initializing OptimizationManager
+1 day, 20:36:20.653944 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/calibration_manager.pkl
+1 day, 20:36:20.654024 INFO: Initializing CalibrationManager
+1 day, 20:36:20.654223 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/raw_file_manager.pkl
+1 day, 20:36:20.654299 INFO: Initializing RawFileManager
+1 day, 20:36:20.690016 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/optimization_manager.pkl
+1 day, 20:36:20.690222 INFO: Initializing OptimizationManager
+1 day, 20:36:20.690454 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/calibration_manager.pkl
+1 day, 20:36:20.690549 INFO: Initializing CalibrationManager
+1 day, 20:36:20.690752 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/raw_file_manager.pkl
+1 day, 20:36:20.690841 INFO: Initializing RawFileManager
+1 day, 20:36:20.726555 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/optimization_manager.pkl
+1 day, 20:36:20.726755 INFO: Initializing OptimizationManager
+1 day, 20:36:20.726981 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/calibration_manager.pkl
+1 day, 20:36:20.727063 INFO: Initializing CalibrationManager
+1 day, 20:36:20.727265 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/raw_file_manager.pkl
+1 day, 20:36:20.727341 INFO: Initializing RawFileManager
+1 day, 20:36:20.764880 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/optimization_manager.pkl
+1 day, 20:36:20.765101 INFO: Initializing OptimizationManager
+1 day, 20:36:20.765333 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/calibration_manager.pkl
+1 day, 20:36:20.765413 INFO: Initializing CalibrationManager
+1 day, 20:36:20.765608 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/raw_file_manager.pkl
+1 day, 20:36:20.765684 INFO: Initializing RawFileManager
+1 day, 20:36:20.806334 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/optimization_manager.pkl
+1 day, 20:36:20.806532 INFO: Initializing OptimizationManager
+1 day, 20:36:20.806748 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/calibration_manager.pkl
+1 day, 20:36:20.806829 INFO: Initializing CalibrationManager
+1 day, 20:36:20.807023 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/raw_file_manager.pkl
+1 day, 20:36:20.807099 INFO: Initializing RawFileManager
+1 day, 20:36:20.843202 INFO: Loaded OptimizationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/optimization_manager.pkl
+1 day, 20:36:20.843403 INFO: Initializing OptimizationManager
+1 day, 20:36:20.843633 INFO: Loaded CalibrationManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/calibration_manager.pkl
+1 day, 20:36:20.843714 INFO: Initializing CalibrationManager
+1 day, 20:36:20.843907 INFO: Loaded RawFileManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/raw_file_manager.pkl
+1 day, 20:36:20.843984 INFO: Initializing RawFileManager
+1 day, 20:36:20.846730 INFO: Writing stat output to disk
+1 day, 20:36:20.846789 INFO: Saving run_output/alphadia_1.10_defaultMBR/stat.tsv to disk
+1 day, 20:36:20.856161 PROGRESS: Building internal statistics
+1 day, 20:36:20.856467 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494/timing_manager.pkl
+1 day, 20:36:20.856514 INFO: Initializing TimingManager
+1 day, 20:36:20.856942 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500/timing_manager.pkl
+1 day, 20:36:20.856985 INFO: Initializing TimingManager
+1 day, 20:36:20.857174 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506/timing_manager.pkl
+1 day, 20:36:20.857214 INFO: Initializing TimingManager
+1 day, 20:36:20.857374 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496/timing_manager.pkl
+1 day, 20:36:20.857423 INFO: Initializing TimingManager
+1 day, 20:36:20.857582 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502/timing_manager.pkl
+1 day, 20:36:20.857617 INFO: Initializing TimingManager
+1 day, 20:36:20.857769 INFO: Loaded TimingManager from run_output/alphadia_1.10_defaultMBR/quant/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508/timing_manager.pkl
+1 day, 20:36:20.857804 INFO: Initializing TimingManager
+1 day, 20:36:20.858217 INFO: Writing internal output to disk
+1 day, 20:36:20.858262 INFO: Saving run_output/alphadia_1.10_defaultMBR/internal.tsv to disk
+1 day, 20:36:20.858779 PROGRESS: Performing label free quantification
+1 day, 20:36:20.945122 INFO: Accumulating fragment data
+1 day, 20:36:20.945286 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494
+1 day, 20:36:21.008922 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500
+1 day, 20:36:22.130352 INFO: reading frag file for ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506
+1 day, 20:36:23.170397 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496
+1 day, 20:36:24.212378 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502
+1 day, 20:36:25.238708 INFO: reading frag file for ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508
+1 day, 20:36:26.445985 PROGRESS: Performing label free quantification on the precursor level
+1 day, 20:36:26.446116 INFO: Filtering fragments by quality
+1 day, 20:36:26.709476 INFO: Performing label-free quantification using directLFQ
+1 day, 20:36:27.707112 INFO: 82019 lfq-groups total
+1 day, 20:37:37.665622 INFO: using 100 processes
+1 day, 20:37:37.868770 INFO: lfq-object 0
+1 day, 20:37:37.986536 INFO: lfq-object 100
+1 day, 20:37:38.051606 INFO: lfq-object 300
+1 day, 20:37:38.106609 INFO: lfq-object 200
+1 day, 20:37:38.126381 INFO: lfq-object 700
+1 day, 20:37:38.131342 INFO: lfq-object 500
+1 day, 20:37:38.190113 INFO: lfq-object 400
+1 day, 20:37:38.210966 INFO: lfq-object 900
+1 day, 20:37:38.240644 INFO: lfq-object 1100
+1 day, 20:37:38.257289 INFO: lfq-object 1300
+1 day, 20:37:38.272561 INFO: lfq-object 600
+1 day, 20:37:38.281280 INFO: lfq-object 800
+1 day, 20:37:38.316708 INFO: lfq-object 1500
+1 day, 20:37:38.337315 INFO: lfq-object 1000
+1 day, 20:37:38.359151 INFO: lfq-object 1200
+1 day, 20:37:38.361068 INFO: lfq-object 1700
+1 day, 20:37:38.378432 INFO: lfq-object 1400
+1 day, 20:37:38.452329 INFO: lfq-object 1600
+1 day, 20:37:38.467615 INFO: lfq-object 1900
+1 day, 20:37:38.481573 INFO: lfq-object 1800
+1 day, 20:37:38.515703 INFO: lfq-object 2100
+1 day, 20:37:38.591924 INFO: lfq-object 2000
+1 day, 20:37:38.593500 INFO: lfq-object 2300
+1 day, 20:37:38.633810 INFO: lfq-object 2200
+1 day, 20:37:38.685564 INFO: lfq-object 2500
+1 day, 20:37:38.715111 INFO: lfq-object 2400
+1 day, 20:37:38.782235 INFO: lfq-object 2700
+1 day, 20:37:38.804365 INFO: lfq-object 2600
+1 day, 20:37:38.855175 INFO: lfq-object 2900
+1 day, 20:37:38.901472 INFO: lfq-object 2800
+1 day, 20:37:38.913864 INFO: lfq-object 3100
+1 day, 20:37:38.974448 INFO: lfq-object 3000
+1 day, 20:37:39.032756 INFO: lfq-object 3200
+1 day, 20:37:39.037812 INFO: lfq-object 3300
+1 day, 20:37:39.164077 INFO: lfq-object 3400
+1 day, 20:37:39.274960 INFO: lfq-object 3600
+1 day, 20:37:39.283328 INFO: lfq-object 3500
+1 day, 20:37:39.394556 INFO: lfq-object 3700
+1 day, 20:37:39.429636 INFO: lfq-object 3800
+1 day, 20:37:39.507329 INFO: lfq-object 4000
+1 day, 20:37:39.549348 INFO: lfq-object 3900
+1 day, 20:37:39.569550 INFO: lfq-object 4200
+1 day, 20:37:39.625751 INFO: lfq-object 4100
+1 day, 20:37:39.629472 INFO: lfq-object 4400
+1 day, 20:37:39.687640 INFO: lfq-object 4300
+1 day, 20:37:39.699042 INFO: lfq-object 4600
+1 day, 20:37:39.745286 INFO: lfq-object 4500
+1 day, 20:37:39.748196 INFO: lfq-object 4800
+1 day, 20:37:39.817737 INFO: lfq-object 4700
+1 day, 20:37:39.822118 INFO: lfq-object 5000
+1 day, 20:37:39.864871 INFO: lfq-object 4900
+1 day, 20:37:39.901626 INFO: lfq-object 5200
+1 day, 20:37:39.940506 INFO: lfq-object 5100
+1 day, 20:37:40.021183 INFO: lfq-object 5300
+1 day, 20:37:40.025324 INFO: lfq-object 5400
+1 day, 20:37:40.143162 INFO: lfq-object 5500
+1 day, 20:37:43.544141 INFO: lfq-object 5600
+1 day, 20:37:43.661924 INFO: lfq-object 5700
+1 day, 20:37:43.672951 INFO: lfq-object 5800
+1 day, 20:37:43.751606 INFO: lfq-object 6000
+1 day, 20:37:43.795186 INFO: lfq-object 5900
+1 day, 20:37:43.829006 INFO: lfq-object 6200
+1 day, 20:37:43.870760 INFO: lfq-object 6100
+1 day, 20:37:43.876727 INFO: lfq-object 6400
+1 day, 20:37:43.948574 INFO: lfq-object 6300
+1 day, 20:37:43.955530 INFO: lfq-object 6600
+1 day, 20:37:43.996826 INFO: lfq-object 6800
+1 day, 20:37:43.997618 INFO: lfq-object 6500
+1 day, 20:37:44.078742 INFO: lfq-object 6700
+1 day, 20:37:44.124319 INFO: lfq-object 6900
+1 day, 20:37:44.204071 INFO: lfq-object 7100
+1 day, 20:37:44.246433 INFO: lfq-object 7000
+1 day, 20:37:44.275455 INFO: lfq-object 7300
+1 day, 20:37:44.325137 INFO: lfq-object 7200
+1 day, 20:37:44.354321 INFO: lfq-object 7500
+1 day, 20:37:44.396179 INFO: lfq-object 7400
+1 day, 20:37:44.419120 INFO: lfq-object 7700
+1 day, 20:37:44.478130 INFO: lfq-object 7600
+1 day, 20:37:44.538831 INFO: lfq-object 7800
+1 day, 20:37:44.540545 INFO: lfq-object 7900
+1 day, 20:37:44.615803 INFO: lfq-object 8100
+1 day, 20:37:44.658941 INFO: lfq-object 8000
+1 day, 20:37:44.695714 INFO: lfq-object 8300
+1 day, 20:37:44.736915 INFO: lfq-object 8200
+1 day, 20:37:44.776676 INFO: lfq-object 8500
+1 day, 20:37:44.814433 INFO: lfq-object 8400
+1 day, 20:37:44.849548 INFO: lfq-object 8700
+1 day, 20:37:44.876066 INFO: lfq-object 8900
+1 day, 20:37:44.896613 INFO: lfq-object 8600
+1 day, 20:37:44.969714 INFO: lfq-object 8800
+1 day, 20:37:44.992813 INFO: lfq-object 9100
+1 day, 20:37:44.994694 INFO: lfq-object 9000
+1 day, 20:37:45.033556 INFO: lfq-object 9300
+1 day, 20:37:45.109331 INFO: lfq-object 9200
+1 day, 20:37:45.109470 INFO: lfq-object 9500
+1 day, 20:37:45.170739 INFO: lfq-object 9400
+1 day, 20:37:45.192202 INFO: lfq-object 9700
+1 day, 20:37:45.229049 INFO: lfq-object 9600
+1 day, 20:37:45.251070 INFO: lfq-object 9900
+1 day, 20:37:45.307652 INFO: lfq-object 9800
+1 day, 20:37:45.353307 INFO: lfq-object 10100
+1 day, 20:37:45.369775 INFO: lfq-object 10000
+1 day, 20:37:45.424459 INFO: lfq-object 10300
+1 day, 20:37:45.477495 INFO: lfq-object 10200
+1 day, 20:37:45.556001 INFO: lfq-object 10400
+1 day, 20:37:45.626762 INFO: lfq-object 10600
+1 day, 20:37:45.678925 INFO: lfq-object 10500
+1 day, 20:37:45.735538 INFO: lfq-object 10800
+1 day, 20:37:45.744522 INFO: lfq-object 10700
+1 day, 20:37:45.809116 INFO: lfq-object 11000
+1 day, 20:37:45.854310 INFO: lfq-object 10900
+1 day, 20:37:45.895792 INFO: lfq-object 11200
+1 day, 20:37:45.930156 INFO: lfq-object 11100
+1 day, 20:37:45.972986 INFO: lfq-object 11400
+1 day, 20:37:46.014716 INFO: lfq-object 11300
+1 day, 20:37:46.060603 INFO: lfq-object 11600
+1 day, 20:37:46.090775 INFO: lfq-object 11500
+1 day, 20:37:46.149400 INFO: lfq-object 11800
+1 day, 20:37:46.180475 INFO: lfq-object 11700
+1 day, 20:37:46.221467 INFO: lfq-object 12000
+1 day, 20:37:46.269040 INFO: lfq-object 11900
+1 day, 20:37:46.305963 INFO: lfq-object 12200
+1 day, 20:37:46.344809 INFO: lfq-object 12100
+1 day, 20:37:46.382452 INFO: lfq-object 12400
+1 day, 20:37:46.426277 INFO: lfq-object 12300
+1 day, 20:37:46.469655 INFO: lfq-object 12600
+1 day, 20:37:46.504866 INFO: lfq-object 12500
+1 day, 20:37:46.517005 INFO: lfq-object 12800
+1 day, 20:37:46.587391 INFO: lfq-object 12700
+1 day, 20:37:46.618068 INFO: lfq-object 13000
+1 day, 20:37:46.635165 INFO: lfq-object 12900
+1 day, 20:37:46.681720 INFO: lfq-object 13200
+1 day, 20:37:46.737697 INFO: lfq-object 13100
+1 day, 20:37:46.785634 INFO: lfq-object 13400
+1 day, 20:37:46.802965 INFO: lfq-object 13300
+1 day, 20:37:46.842805 INFO: lfq-object 13600
+1 day, 20:37:46.903744 INFO: lfq-object 13500
+1 day, 20:37:46.963485 INFO: lfq-object 13700
+1 day, 20:37:47.035795 INFO: lfq-object 13900
+1 day, 20:37:47.082436 INFO: lfq-object 13800
+1 day, 20:37:47.123310 INFO: lfq-object 14100
+1 day, 20:37:47.156291 INFO: lfq-object 14000
+1 day, 20:37:47.218252 INFO: lfq-object 14300
+1 day, 20:37:47.243095 INFO: lfq-object 14200
+1 day, 20:37:47.291022 INFO: lfq-object 14500
+1 day, 20:37:47.335233 INFO: lfq-object 14400
+1 day, 20:37:47.377050 INFO: lfq-object 14700
+1 day, 20:37:47.408939 INFO: lfq-object 14600
+1 day, 20:37:47.446763 INFO: lfq-object 14900
+1 day, 20:37:47.492966 INFO: lfq-object 14800
+1 day, 20:37:47.542512 INFO: lfq-object 15100
+1 day, 20:37:47.566049 INFO: lfq-object 15000
+1 day, 20:37:47.602684 INFO: lfq-object 15300
+1 day, 20:37:47.656433 INFO: lfq-object 15200
+1 day, 20:37:47.689421 INFO: lfq-object 15500
+1 day, 20:37:47.720579 INFO: lfq-object 15400
+1 day, 20:37:47.753130 INFO: lfq-object 15700
+1 day, 20:37:47.807034 INFO: lfq-object 15600
+1 day, 20:37:47.849094 INFO: lfq-object 15900
+1 day, 20:37:47.874007 INFO: lfq-object 15800
+1 day, 20:37:47.883183 INFO: lfq-object 16100
+1 day, 20:37:47.969140 INFO: lfq-object 16000
+1 day, 20:37:47.978070 INFO: lfq-object 16300
+1 day, 20:37:48.002670 INFO: lfq-object 16200
+1 day, 20:37:48.048969 INFO: lfq-object 16500
+1 day, 20:37:48.097354 INFO: lfq-object 16400
+1 day, 20:37:48.146637 INFO: lfq-object 16700
+1 day, 20:37:48.165547 INFO: lfq-object 16600
+1 day, 20:37:48.186370 INFO: lfq-object 16900
+1 day, 20:37:48.242519 INFO: lfq-object 17100
+1 day, 20:37:48.265695 INFO: lfq-object 16800
+1 day, 20:37:48.305215 INFO: lfq-object 17000
+1 day, 20:37:48.361011 INFO: lfq-object 17200
+1 day, 20:37:48.481384 INFO: lfq-object 17300
+1 day, 20:37:48.489826 INFO: lfq-object 17400
+1 day, 20:37:48.514355 INFO: lfq-object 17600
+1 day, 20:37:48.610968 INFO: lfq-object 17500
+1 day, 20:37:48.626640 INFO: lfq-object 17800
+1 day, 20:37:48.638254 INFO: lfq-object 17700
+1 day, 20:37:48.719090 INFO: lfq-object 18000
+1 day, 20:37:48.745439 INFO: lfq-object 17900
+1 day, 20:37:48.796987 INFO: lfq-object 18200
+1 day, 20:37:48.835447 INFO: lfq-object 18100
+1 day, 20:37:48.863346 INFO: lfq-object 18400
+1 day, 20:37:48.919446 INFO: lfq-object 18300
+1 day, 20:37:48.937256 INFO: lfq-object 18600
+1 day, 20:37:48.979358 INFO: lfq-object 18500
+1 day, 20:37:48.987903 INFO: lfq-object 18800
+1 day, 20:37:49.056646 INFO: lfq-object 18700
+1 day, 20:37:49.087167 INFO: lfq-object 19000
+1 day, 20:37:49.107858 INFO: lfq-object 18900
+1 day, 20:37:49.153497 INFO: lfq-object 19200
+1 day, 20:37:49.203390 INFO: lfq-object 19100
+1 day, 20:37:49.236499 INFO: lfq-object 19400
+1 day, 20:37:49.273566 INFO: lfq-object 19300
+1 day, 20:37:49.318267 INFO: lfq-object 19600
+1 day, 20:37:49.357497 INFO: lfq-object 19500
+1 day, 20:37:49.375223 INFO: lfq-object 19800
+1 day, 20:37:49.440707 INFO: lfq-object 19700
+1 day, 20:37:49.476024 INFO: lfq-object 20000
+1 day, 20:37:49.494371 INFO: lfq-object 19900
+1 day, 20:37:49.579072 INFO: lfq-object 20200
+1 day, 20:37:49.595166 INFO: lfq-object 20100
+1 day, 20:37:49.651282 INFO: lfq-object 20400
+1 day, 20:37:49.694056 INFO: lfq-object 20300
+1 day, 20:37:49.715518 INFO: lfq-object 20600
+1 day, 20:37:49.779182 INFO: lfq-object 20500
+1 day, 20:37:49.830016 INFO: lfq-object 20700
+1 day, 20:37:49.902715 INFO: lfq-object 20900
+1 day, 20:37:49.942613 INFO: lfq-object 20800
+1 day, 20:37:49.982960 INFO: lfq-object 21100
+1 day, 20:37:50.018177 INFO: lfq-object 21000
+1 day, 20:37:50.062650 INFO: lfq-object 21300
+1 day, 20:37:50.098068 INFO: lfq-object 21200
+1 day, 20:37:50.112352 INFO: lfq-object 21500
+1 day, 20:37:50.180480 INFO: lfq-object 21400
+1 day, 20:37:50.232768 INFO: lfq-object 21600
+1 day, 20:37:50.239880 INFO: lfq-object 21700
+1 day, 20:37:50.302490 INFO: lfq-object 21900
+1 day, 20:37:50.356398 INFO: lfq-object 21800
+1 day, 20:37:50.418641 INFO: lfq-object 22000
+1 day, 20:37:53.749734 INFO: lfq-object 22100
+1 day, 20:37:53.834167 INFO: lfq-object 22300
+1 day, 20:37:53.863021 INFO: lfq-object 22200
+1 day, 20:37:53.921797 INFO: lfq-object 22500
+1 day, 20:37:53.950368 INFO: lfq-object 22400
+1 day, 20:37:53.954642 INFO: lfq-object 22700
+1 day, 20:37:54.017539 INFO: lfq-object 22900
+1 day, 20:37:54.036786 INFO: lfq-object 23100
+1 day, 20:37:54.039626 INFO: lfq-object 22600
+1 day, 20:37:54.071850 INFO: lfq-object 22800
+1 day, 20:37:54.133984 INFO: lfq-object 23000
+1 day, 20:37:54.145408 INFO: lfq-object 23300
+1 day, 20:37:54.154153 INFO: lfq-object 23200
+1 day, 20:37:54.262629 INFO: lfq-object 23400
+1 day, 20:37:54.297948 INFO: lfq-object 23500
+1 day, 20:37:54.417372 INFO: lfq-object 23600
+1 day, 20:37:54.424437 INFO: lfq-object 23700
+1 day, 20:37:54.502122 INFO: lfq-object 23900
+1 day, 20:37:54.539566 INFO: lfq-object 23800
+1 day, 20:37:54.616672 INFO: lfq-object 24000
+1 day, 20:37:54.671668 INFO: lfq-object 24200
+1 day, 20:37:54.712313 INFO: lfq-object 24400
+1 day, 20:37:54.730861 INFO: lfq-object 24100
+1 day, 20:37:54.783616 INFO: lfq-object 24600
+1 day, 20:37:54.789034 INFO: lfq-object 24300
+1 day, 20:37:54.832291 INFO: lfq-object 24800
+1 day, 20:37:54.841612 INFO: lfq-object 24500
+1 day, 20:37:54.901258 INFO: lfq-object 24700
+1 day, 20:37:54.909390 INFO: lfq-object 25000
+1 day, 20:37:54.951012 INFO: lfq-object 24900
+1 day, 20:37:55.017272 INFO: lfq-object 25200
+1 day, 20:37:55.026914 INFO: lfq-object 25100
+1 day, 20:37:55.128206 INFO: lfq-object 25400
+1 day, 20:37:55.134196 INFO: lfq-object 25300
+1 day, 20:37:55.222253 INFO: lfq-object 25600
+1 day, 20:37:55.243212 INFO: lfq-object 25500
+1 day, 20:37:55.304881 INFO: lfq-object 25800
+1 day, 20:37:55.340792 INFO: lfq-object 25700
+1 day, 20:37:55.357061 INFO: lfq-object 26000
+1 day, 20:37:55.402270 INFO: lfq-object 26200
+1 day, 20:37:55.422332 INFO: lfq-object 25900
+1 day, 20:37:55.467378 INFO: lfq-object 26400
+1 day, 20:37:55.473049 INFO: lfq-object 26100
+1 day, 20:37:55.521422 INFO: lfq-object 26300
+1 day, 20:37:55.523605 INFO: lfq-object 26600
+1 day, 20:37:55.583331 INFO: lfq-object 26500
+1 day, 20:37:55.600446 INFO: lfq-object 26800
+1 day, 20:37:55.640359 INFO: lfq-object 26700
+1 day, 20:37:55.682634 INFO: lfq-object 27000
+1 day, 20:37:55.716986 INFO: lfq-object 26900
+1 day, 20:37:55.761376 INFO: lfq-object 27200
+1 day, 20:37:55.798056 INFO: lfq-object 27100
+1 day, 20:37:55.868820 INFO: lfq-object 27400
+1 day, 20:37:55.877822 INFO: lfq-object 27300
+1 day, 20:37:55.984544 INFO: lfq-object 27500
+1 day, 20:37:56.101802 INFO: lfq-object 27600
+1 day, 20:37:56.135096 INFO: lfq-object 27700
+1 day, 20:37:56.232798 INFO: lfq-object 27900
+1 day, 20:37:56.252446 INFO: lfq-object 27800
+1 day, 20:37:56.290184 INFO: lfq-object 28100
+1 day, 20:37:56.347377 INFO: lfq-object 28000
+1 day, 20:37:56.369842 INFO: lfq-object 28300
+1 day, 20:37:56.410986 INFO: lfq-object 28200
+1 day, 20:37:56.418399 INFO: lfq-object 28500
+1 day, 20:37:56.486761 INFO: lfq-object 28400
+1 day, 20:37:56.502035 INFO: lfq-object 28700
+1 day, 20:37:56.532720 INFO: lfq-object 28600
+1 day, 20:37:56.575549 INFO: lfq-object 28900
+1 day, 20:37:56.620589 INFO: lfq-object 28800
+1 day, 20:37:56.623925 INFO: lfq-object 29100
+1 day, 20:37:56.689034 INFO: lfq-object 29000
+1 day, 20:37:56.696291 INFO: lfq-object 29300
+1 day, 20:37:56.743854 INFO: lfq-object 29200
+1 day, 20:37:56.800704 INFO: lfq-object 29500
+1 day, 20:37:56.811230 INFO: lfq-object 29400
+1 day, 20:37:56.889574 INFO: lfq-object 29700
+1 day, 20:37:56.915070 INFO: lfq-object 29600
+1 day, 20:37:56.975499 INFO: lfq-object 29900
+1 day, 20:37:57.004675 INFO: lfq-object 29800
+1 day, 20:37:57.050665 INFO: lfq-object 30100
+1 day, 20:37:57.072820 INFO: lfq-object 30300
+1 day, 20:37:57.091027 INFO: lfq-object 30000
+1 day, 20:37:57.149929 INFO: lfq-object 30500
+1 day, 20:37:57.171497 INFO: lfq-object 30200
+1 day, 20:37:57.178784 INFO: lfq-object 30700
+1 day, 20:37:57.203717 INFO: lfq-object 30400
+1 day, 20:37:57.241489 INFO: lfq-object 30900
+1 day, 20:37:57.268660 INFO: lfq-object 30600
+1 day, 20:37:57.295087 INFO: lfq-object 30800
+1 day, 20:37:57.362846 INFO: lfq-object 31000
+1 day, 20:37:57.417224 INFO: lfq-object 31200
+1 day, 20:37:57.466877 INFO: lfq-object 31400
+1 day, 20:37:57.484539 INFO: lfq-object 31100
+1 day, 20:37:57.533077 INFO: lfq-object 31300
+1 day, 20:37:57.535834 INFO: lfq-object 31600
+1 day, 20:37:57.582731 INFO: lfq-object 31500
+1 day, 20:37:57.597376 INFO: lfq-object 31800
+1 day, 20:37:57.655623 INFO: lfq-object 31700
+1 day, 20:37:57.657016 INFO: lfq-object 32000
+1 day, 20:37:57.716409 INFO: lfq-object 31900
+1 day, 20:37:57.721637 INFO: lfq-object 32200
+1 day, 20:37:57.771628 INFO: lfq-object 32100
+1 day, 20:37:57.800360 INFO: lfq-object 32400
+1 day, 20:37:57.840105 INFO: lfq-object 32300
+1 day, 20:37:57.910302 INFO: lfq-object 32600
+1 day, 20:37:57.913743 INFO: lfq-object 32500
+1 day, 20:37:57.983027 INFO: lfq-object 32800
+1 day, 20:37:58.024195 INFO: lfq-object 32700
+1 day, 20:37:58.027919 INFO: lfq-object 33000
+1 day, 20:37:58.081383 INFO: lfq-object 33200
+1 day, 20:37:58.102934 INFO: lfq-object 32900
+1 day, 20:37:58.140156 INFO: lfq-object 33400
+1 day, 20:37:58.143017 INFO: lfq-object 33100
+1 day, 20:37:58.184875 INFO: lfq-object 33600
+1 day, 20:37:58.196840 INFO: lfq-object 33300
+1 day, 20:37:58.249932 INFO: lfq-object 33800
+1 day, 20:37:58.257647 INFO: lfq-object 33500
+1 day, 20:37:58.298332 INFO: lfq-object 33700
+1 day, 20:37:58.306923 INFO: lfq-object 34000
+1 day, 20:37:58.368018 INFO: lfq-object 33900
+1 day, 20:37:58.372921 INFO: lfq-object 34200
+1 day, 20:37:58.418575 INFO: lfq-object 34100
+1 day, 20:37:58.488122 INFO: lfq-object 34300
+1 day, 20:37:58.540761 INFO: lfq-object 34500
+1 day, 20:37:58.604648 INFO: lfq-object 34400
+1 day, 20:37:58.659293 INFO: lfq-object 34600
+1 day, 20:37:58.666336 INFO: lfq-object 34700
+1 day, 20:37:58.721951 INFO: lfq-object 34900
+1 day, 20:37:58.773959 INFO: lfq-object 35100
+1 day, 20:37:58.783961 INFO: lfq-object 34800
+1 day, 20:37:58.827953 INFO: lfq-object 35300
+1 day, 20:37:58.839985 INFO: lfq-object 35000
+1 day, 20:37:58.883488 INFO: lfq-object 35500
+1 day, 20:37:58.921878 INFO: lfq-object 35200
+1 day, 20:37:58.941753 INFO: lfq-object 35400
+1 day, 20:37:58.963055 INFO: lfq-object 35700
+1 day, 20:37:58.986553 INFO: lfq-object 35900
+1 day, 20:37:59.002948 INFO: lfq-object 35600
+1 day, 20:37:59.038319 INFO: lfq-object 36100
+1 day, 20:37:59.079351 INFO: lfq-object 35800
+1 day, 20:37:59.093701 INFO: lfq-object 36300
+1 day, 20:37:59.104407 INFO: lfq-object 36000
+1 day, 20:37:59.151632 INFO: lfq-object 36200
+1 day, 20:37:59.187982 INFO: lfq-object 36500
+1 day, 20:37:59.213057 INFO: lfq-object 36400
+1 day, 20:37:59.238516 INFO: lfq-object 36700
+1 day, 20:37:59.296679 INFO: lfq-object 36900
+1 day, 20:37:59.301962 INFO: lfq-object 36600
+1 day, 20:37:59.353635 INFO: lfq-object 36800
+1 day, 20:37:59.396343 INFO: lfq-object 37100
+1 day, 20:37:59.411512 INFO: lfq-object 37000
+1 day, 20:37:59.434385 INFO: lfq-object 37300
+1 day, 20:37:59.476786 INFO: lfq-object 37500
+1 day, 20:37:59.515990 INFO: lfq-object 37200
+1 day, 20:37:59.540750 INFO: lfq-object 37700
+1 day, 20:37:59.549214 INFO: lfq-object 37400
+1 day, 20:37:59.593168 INFO: lfq-object 37600
+1 day, 20:37:59.656873 INFO: lfq-object 37800
+1 day, 20:37:59.720159 INFO: lfq-object 38000
+1 day, 20:37:59.773349 INFO: lfq-object 37900
+1 day, 20:37:59.773868 INFO: lfq-object 38200
+1 day, 20:37:59.837744 INFO: lfq-object 38100
+1 day, 20:37:59.844187 INFO: lfq-object 38400
+1 day, 20:37:59.892751 INFO: lfq-object 38300
+1 day, 20:37:59.911061 INFO: lfq-object 38600
+1 day, 20:37:59.957773 INFO: lfq-object 38800
+1 day, 20:37:59.959913 INFO: lfq-object 38500
+1 day, 20:38:00.016664 INFO: lfq-object 39000
+1 day, 20:38:00.034725 INFO: lfq-object 38700
+1 day, 20:38:00.073657 INFO: lfq-object 39200
+1 day, 20:38:00.077816 INFO: lfq-object 38900
+1 day, 20:38:00.130817 INFO: lfq-object 39100
+1 day, 20:38:00.156978 INFO: lfq-object 39400
+1 day, 20:38:00.190194 INFO: lfq-object 39300
+1 day, 20:38:00.223370 INFO: lfq-object 39600
+1 day, 20:38:00.258608 INFO: lfq-object 39800
+1 day, 20:38:00.269045 INFO: lfq-object 39500
+1 day, 20:38:00.314901 INFO: lfq-object 40000
+1 day, 20:38:00.341632 INFO: lfq-object 39700
+1 day, 20:38:00.370519 INFO: lfq-object 40200
+1 day, 20:38:00.373408 INFO: lfq-object 39900
+1 day, 20:38:00.428761 INFO: lfq-object 40100
+1 day, 20:38:00.488380 INFO: lfq-object 40300
+1 day, 20:38:04.219536 INFO: lfq-object 40400
+1 day, 20:38:04.286470 INFO: lfq-object 40600
+1 day, 20:38:04.334826 INFO: lfq-object 40500
+1 day, 20:38:04.361661 INFO: lfq-object 40800
+1 day, 20:38:04.402535 INFO: lfq-object 40700
+1 day, 20:38:04.437833 INFO: lfq-object 41000
+1 day, 20:38:04.482578 INFO: lfq-object 40900
+1 day, 20:38:04.492344 INFO: lfq-object 41200
+1 day, 20:38:04.553675 INFO: lfq-object 41100
+1 day, 20:38:04.610685 INFO: lfq-object 41300
+1 day, 20:38:04.681854 INFO: lfq-object 41500
+1 day, 20:38:04.748868 INFO: lfq-object 41400
+1 day, 20:38:04.770301 INFO: lfq-object 41700
+1 day, 20:38:04.798546 INFO: lfq-object 41600
+1 day, 20:38:04.810508 INFO: lfq-object 41900
+1 day, 20:38:04.874608 INFO: lfq-object 42100
+1 day, 20:38:04.887429 INFO: lfq-object 41800
+1 day, 20:38:04.925899 INFO: lfq-object 42000
+1 day, 20:38:04.961592 INFO: lfq-object 42300
+1 day, 20:38:04.992876 INFO: lfq-object 42200
+1 day, 20:38:05.025077 INFO: lfq-object 42500
+1 day, 20:38:05.074607 INFO: lfq-object 42400
+1 day, 20:38:05.078608 INFO: lfq-object 42700
+1 day, 20:38:05.129221 INFO: lfq-object 42900
+1 day, 20:38:05.142156 INFO: lfq-object 42600
+1 day, 20:38:05.194482 INFO: lfq-object 42800
+1 day, 20:38:05.195602 INFO: lfq-object 43100
+1 day, 20:38:05.241655 INFO: lfq-object 43000
+1 day, 20:38:05.273032 INFO: lfq-object 43300
+1 day, 20:38:05.312442 INFO: lfq-object 43200
+1 day, 20:38:05.340918 INFO: lfq-object 43500
+1 day, 20:38:05.390395 INFO: lfq-object 43400
+1 day, 20:38:05.436972 INFO: lfq-object 43700
+1 day, 20:38:05.461087 INFO: lfq-object 43600
+1 day, 20:38:05.469995 INFO: lfq-object 43900
+1 day, 20:38:05.540517 INFO: lfq-object 44100
+1 day, 20:38:05.552701 INFO: lfq-object 43800
+1 day, 20:38:05.587449 INFO: lfq-object 44000
+1 day, 20:38:05.611575 INFO: lfq-object 44300
+1 day, 20:38:05.657990 INFO: lfq-object 44200
+1 day, 20:38:05.664265 INFO: lfq-object 44500
+1 day, 20:38:05.730022 INFO: lfq-object 44400
+1 day, 20:38:05.783560 INFO: lfq-object 44600
+1 day, 20:38:05.831379 INFO: lfq-object 44800
+1 day, 20:38:05.884459 INFO: lfq-object 45000
+1 day, 20:38:05.902255 INFO: lfq-object 44700
+1 day, 20:38:05.946840 INFO: lfq-object 44900
+1 day, 20:38:05.958284 INFO: lfq-object 45200
+1 day, 20:38:05.999251 INFO: lfq-object 45100
+1 day, 20:38:06.031511 INFO: lfq-object 45400
+1 day, 20:38:06.068575 INFO: lfq-object 45300
+1 day, 20:38:06.098034 INFO: lfq-object 45600
+1 day, 20:38:06.149193 INFO: lfq-object 45500
+1 day, 20:38:06.165021 INFO: lfq-object 45800
+1 day, 20:38:06.215463 INFO: lfq-object 45700
+1 day, 20:38:06.245126 INFO: lfq-object 46000
+1 day, 20:38:06.283506 INFO: lfq-object 45900
+1 day, 20:38:06.345859 INFO: lfq-object 46200
+1 day, 20:38:06.359941 INFO: lfq-object 46100
+1 day, 20:38:06.414658 INFO: lfq-object 46400
+1 day, 20:38:06.463230 INFO: lfq-object 46300
+1 day, 20:38:06.510001 INFO: lfq-object 46600
+1 day, 20:38:06.529438 INFO: lfq-object 46500
+1 day, 20:38:06.599924 INFO: lfq-object 46800
+1 day, 20:38:06.625188 INFO: lfq-object 46700
+1 day, 20:38:06.668916 INFO: lfq-object 47000
+1 day, 20:38:06.719039 INFO: lfq-object 46900
+1 day, 20:38:06.779343 INFO: lfq-object 47200
+1 day, 20:38:06.784313 INFO: lfq-object 47100
+1 day, 20:38:06.864493 INFO: lfq-object 47400
+1 day, 20:38:06.895276 INFO: lfq-object 47300
+1 day, 20:38:06.908304 INFO: lfq-object 47600
+1 day, 20:38:06.973238 INFO: lfq-object 47800
+1 day, 20:38:06.984089 INFO: lfq-object 47500
+1 day, 20:38:07.024639 INFO: lfq-object 47700
+1 day, 20:38:07.050808 INFO: lfq-object 48000
+1 day, 20:38:07.089912 INFO: lfq-object 47900
+1 day, 20:38:07.167805 INFO: lfq-object 48100
+1 day, 20:38:07.265242 INFO: lfq-object 48300
+1 day, 20:38:07.283885 INFO: lfq-object 48200
+1 day, 20:38:07.380869 INFO: lfq-object 48400
+1 day, 20:38:07.391641 INFO: lfq-object 48500
+1 day, 20:38:07.469105 INFO: lfq-object 48700
+1 day, 20:38:07.523027 INFO: lfq-object 48600
+1 day, 20:38:07.547183 INFO: lfq-object 48900
+1 day, 20:38:07.577694 INFO: lfq-object 49100
+1 day, 20:38:07.584807 INFO: lfq-object 48800
+1 day, 20:38:07.635855 INFO: lfq-object 49300
+1 day, 20:38:07.663756 INFO: lfq-object 49000
+1 day, 20:38:07.679034 INFO: lfq-object 49500
+1 day, 20:38:07.691957 INFO: lfq-object 49200
+1 day, 20:38:07.737605 INFO: lfq-object 49700
+1 day, 20:38:07.755363 INFO: lfq-object 49400
+1 day, 20:38:07.791930 INFO: lfq-object 49600
+1 day, 20:38:07.800184 INFO: lfq-object 49900
+1 day, 20:38:07.840214 INFO: lfq-object 50100
+1 day, 20:38:07.853224 INFO: lfq-object 49800
+1 day, 20:38:07.914746 INFO: lfq-object 50300
+1 day, 20:38:07.916644 INFO: lfq-object 50000
+1 day, 20:38:07.954750 INFO: lfq-object 50200
+1 day, 20:38:07.988264 INFO: lfq-object 50500
+1 day, 20:38:08.033300 INFO: lfq-object 50700
+1 day, 20:38:08.033507 INFO: lfq-object 50400
+1 day, 20:38:08.086280 INFO: lfq-object 50900
+1 day, 20:38:08.107132 INFO: lfq-object 50600
+1 day, 20:38:08.150335 INFO: lfq-object 50800
+1 day, 20:38:08.152798 INFO: lfq-object 51100
+1 day, 20:38:08.203163 INFO: lfq-object 51000
+1 day, 20:38:08.205009 INFO: lfq-object 51300
+1 day, 20:38:08.276274 INFO: lfq-object 51500
+1 day, 20:38:08.282016 INFO: lfq-object 51200
+1 day, 20:38:08.332778 INFO: lfq-object 51400
+1 day, 20:38:08.395279 INFO: lfq-object 51600
+1 day, 20:38:08.460301 INFO: lfq-object 51800
+1 day, 20:38:08.514261 INFO: lfq-object 51700
+1 day, 20:38:08.550709 INFO: lfq-object 52000
+1 day, 20:38:08.579150 INFO: lfq-object 51900
+1 day, 20:38:08.668669 INFO: lfq-object 52100
+1 day, 20:38:08.673929 INFO: lfq-object 52200
+1 day, 20:38:08.748852 INFO: lfq-object 52400
+1 day, 20:38:08.788786 INFO: lfq-object 52300
+1 day, 20:38:08.821174 INFO: lfq-object 52600
+1 day, 20:38:08.871121 INFO: lfq-object 52500
+1 day, 20:38:08.891132 INFO: lfq-object 52800
+1 day, 20:38:08.937269 INFO: lfq-object 52700
+1 day, 20:38:08.960953 INFO: lfq-object 53000
+1 day, 20:38:09.009525 INFO: lfq-object 52900
+1 day, 20:38:09.041641 INFO: lfq-object 53200
+1 day, 20:38:09.076547 INFO: lfq-object 53100
+1 day, 20:38:09.109989 INFO: lfq-object 53400
+1 day, 20:38:09.153543 INFO: lfq-object 53300
+1 day, 20:38:09.166198 INFO: lfq-object 53600
+1 day, 20:38:09.227301 INFO: lfq-object 53500
+1 day, 20:38:09.244089 INFO: lfq-object 53800
+1 day, 20:38:09.283286 INFO: lfq-object 53700
+1 day, 20:38:09.328256 INFO: lfq-object 54000
+1 day, 20:38:09.362059 INFO: lfq-object 53900
+1 day, 20:38:09.444438 INFO: lfq-object 54100
+1 day, 20:38:09.452927 INFO: lfq-object 54200
+1 day, 20:38:09.495837 INFO: lfq-object 54400
+1 day, 20:38:09.571012 INFO: lfq-object 54300
+1 day, 20:38:09.574778 INFO: lfq-object 54600
+1 day, 20:38:09.613063 INFO: lfq-object 54500
+1 day, 20:38:09.648743 INFO: lfq-object 54800
+1 day, 20:38:09.690010 INFO: lfq-object 54700
+1 day, 20:38:09.766107 INFO: lfq-object 54900
+1 day, 20:38:09.840328 INFO: lfq-object 55100
+1 day, 20:38:09.882835 INFO: lfq-object 55000
+1 day, 20:38:09.887332 INFO: lfq-object 55300
+1 day, 20:38:09.957238 INFO: lfq-object 55200
+1 day, 20:38:10.002764 INFO: lfq-object 55500
+1 day, 20:38:10.007671 INFO: lfq-object 55400
+1 day, 20:38:10.088625 INFO: lfq-object 55700
+1 day, 20:38:10.119351 INFO: lfq-object 55600
+1 day, 20:38:10.154328 INFO: lfq-object 55900
+1 day, 20:38:10.206280 INFO: lfq-object 55800
+1 day, 20:38:10.234832 INFO: lfq-object 56100
+1 day, 20:38:10.269461 INFO: lfq-object 56000
+1 day, 20:38:10.313101 INFO: lfq-object 56300
+1 day, 20:38:10.356246 INFO: lfq-object 56200
+1 day, 20:38:10.410977 INFO: lfq-object 56500
+1 day, 20:38:10.432577 INFO: lfq-object 56400
+1 day, 20:38:10.474131 INFO: lfq-object 56700
+1 day, 20:38:10.528045 INFO: lfq-object 56600
+1 day, 20:38:10.555434 INFO: lfq-object 56900
+1 day, 20:38:10.587865 INFO: lfq-object 56800
+1 day, 20:38:10.661737 INFO: lfq-object 57100
+1 day, 20:38:10.671972 INFO: lfq-object 57000
+1 day, 20:38:10.715952 INFO: lfq-object 57300
+1 day, 20:38:10.778198 INFO: lfq-object 57200
+1 day, 20:38:10.800133 INFO: lfq-object 57500
+1 day, 20:38:10.832395 INFO: lfq-object 57400
+1 day, 20:38:10.879378 INFO: lfq-object 57700
+1 day, 20:38:10.919008 INFO: lfq-object 57600
+1 day, 20:38:10.961054 INFO: lfq-object 57900
+1 day, 20:38:10.998122 INFO: lfq-object 57800
+1 day, 20:38:11.057335 INFO: lfq-object 58100
+1 day, 20:38:11.076813 INFO: lfq-object 58000
+1 day, 20:38:11.117551 INFO: lfq-object 58300
+1 day, 20:38:11.173811 INFO: lfq-object 58200
+1 day, 20:38:11.233642 INFO: lfq-object 58400
+1 day, 20:38:11.311930 INFO: lfq-object 58600
+1 day, 20:38:11.354935 INFO: lfq-object 58500
+1 day, 20:38:11.384270 INFO: lfq-object 58800
+1 day, 20:38:11.446055 INFO: lfq-object 58700
+1 day, 20:38:11.490800 INFO: lfq-object 59000
+1 day, 20:38:11.502375 INFO: lfq-object 58900
+1 day, 20:38:11.520541 INFO: lfq-object 59200
+1 day, 20:38:11.590687 INFO: lfq-object 59400
+1 day, 20:38:11.609267 INFO: lfq-object 59100
+1 day, 20:38:11.636493 INFO: lfq-object 59300
+1 day, 20:38:11.652487 INFO: lfq-object 59600
+1 day, 20:38:11.706100 INFO: lfq-object 59500
+1 day, 20:38:11.757454 INFO: lfq-object 59800
+1 day, 20:38:11.767526 INFO: lfq-object 59700
+1 day, 20:38:11.873519 INFO: lfq-object 59900
+1 day, 20:38:16.016697 INFO: lfq-object 60000
+1 day, 20:38:16.077019 INFO: lfq-object 60200
+1 day, 20:38:16.128019 INFO: lfq-object 60400
+1 day, 20:38:16.135504 INFO: lfq-object 60100
+1 day, 20:38:16.188636 INFO: lfq-object 60600
+1 day, 20:38:16.197158 INFO: lfq-object 60300
+1 day, 20:38:16.241947 INFO: lfq-object 60500
+1 day, 20:38:16.302898 INFO: lfq-object 60700
+1 day, 20:38:16.303617 INFO: lfq-object 60800
+1 day, 20:38:16.395104 INFO: lfq-object 61000
+1 day, 20:38:16.420258 INFO: lfq-object 60900
+1 day, 20:38:16.485237 INFO: lfq-object 61200
+1 day, 20:38:16.509132 INFO: lfq-object 61100
+1 day, 20:38:16.535763 INFO: lfq-object 61400
+1 day, 20:38:16.600796 INFO: lfq-object 61300
+1 day, 20:38:16.656431 INFO: lfq-object 61500
+1 day, 20:38:16.671278 INFO: lfq-object 61600
+1 day, 20:38:16.744256 INFO: lfq-object 61800
+1 day, 20:38:16.799637 INFO: lfq-object 61700
+1 day, 20:38:16.875647 INFO: lfq-object 61900
+1 day, 20:38:16.932502 INFO: lfq-object 62100
+1 day, 20:38:16.994308 INFO: lfq-object 62000
+1 day, 20:38:17.050581 INFO: lfq-object 62200
+1 day, 20:38:17.061557 INFO: lfq-object 62300
+1 day, 20:38:17.080592 INFO: lfq-object 62500
+1 day, 20:38:17.151516 INFO: lfq-object 62700
+1 day, 20:38:17.179301 INFO: lfq-object 62400
+1 day, 20:38:17.196115 INFO: lfq-object 62600
+1 day, 20:38:17.210390 INFO: lfq-object 62900
+1 day, 20:38:17.265114 INFO: lfq-object 63100
+1 day, 20:38:17.269121 INFO: lfq-object 62800
+1 day, 20:38:17.326246 INFO: lfq-object 63000
+1 day, 20:38:17.345542 INFO: lfq-object 63300
+1 day, 20:38:17.383544 INFO: lfq-object 63200
+1 day, 20:38:17.425598 INFO: lfq-object 63500
+1 day, 20:38:17.463988 INFO: lfq-object 63400
+1 day, 20:38:17.518830 INFO: lfq-object 63700
+1 day, 20:38:17.541480 INFO: lfq-object 63600
+1 day, 20:38:17.590957 INFO: lfq-object 63900
+1 day, 20:38:17.637899 INFO: lfq-object 63800
+1 day, 20:38:17.661226 INFO: lfq-object 64100
+1 day, 20:38:17.707243 INFO: lfq-object 64000
+1 day, 20:38:17.711179 INFO: lfq-object 64300
+1 day, 20:38:17.749198 INFO: lfq-object 64500
+1 day, 20:38:17.779473 INFO: lfq-object 64200
+1 day, 20:38:17.827373 INFO: lfq-object 64400
+1 day, 20:38:17.848480 INFO: lfq-object 64700
+1 day, 20:38:17.895317 INFO: lfq-object 64600
+1 day, 20:38:17.961098 INFO: lfq-object 64900
+1 day, 20:38:17.965277 INFO: lfq-object 64800
+1 day, 20:38:18.009620 INFO: lfq-object 65100
+1 day, 20:38:18.085600 INFO: lfq-object 65000
+1 day, 20:38:18.141384 INFO: lfq-object 65200
+1 day, 20:38:18.192051 INFO: lfq-object 65400
+1 day, 20:38:18.260401 INFO: lfq-object 65300
+1 day, 20:38:18.297212 INFO: lfq-object 65600
+1 day, 20:38:18.310296 INFO: lfq-object 65500
+1 day, 20:38:18.365336 INFO: lfq-object 65800
+1 day, 20:38:18.407215 INFO: lfq-object 66000
+1 day, 20:38:18.413887 INFO: lfq-object 65700
+1 day, 20:38:18.482737 INFO: lfq-object 65900
+1 day, 20:38:18.497614 INFO: lfq-object 66200
+1 day, 20:38:18.522554 INFO: lfq-object 66100
+1 day, 20:38:18.596977 INFO: lfq-object 66400
+1 day, 20:38:18.614955 INFO: lfq-object 66300
+1 day, 20:38:18.660653 INFO: lfq-object 66600
+1 day, 20:38:18.711998 INFO: lfq-object 66500
+1 day, 20:38:18.730549 INFO: lfq-object 66800
+1 day, 20:38:18.778046 INFO: lfq-object 66700
+1 day, 20:38:18.799272 INFO: lfq-object 67000
+1 day, 20:38:18.847496 INFO: lfq-object 66900
+1 day, 20:38:18.889063 INFO: lfq-object 67200
+1 day, 20:38:18.916288 INFO: lfq-object 67100
+1 day, 20:38:18.954877 INFO: lfq-object 67400
+1 day, 20:38:19.007471 INFO: lfq-object 67300
+1 day, 20:38:19.032699 INFO: lfq-object 67600
+1 day, 20:38:19.072747 INFO: lfq-object 67500
+1 day, 20:38:19.101821 INFO: lfq-object 67800
+1 day, 20:38:19.147201 INFO: lfq-object 67700
+1 day, 20:38:19.174537 INFO: lfq-object 68000
+1 day, 20:38:19.220560 INFO: lfq-object 67900
+1 day, 20:38:19.238086 INFO: lfq-object 68200
+1 day, 20:38:19.295542 INFO: lfq-object 68100
+1 day, 20:38:19.330195 INFO: lfq-object 68400
+1 day, 20:38:19.356120 INFO: lfq-object 68300
+1 day, 20:38:19.406051 INFO: lfq-object 68600
+1 day, 20:38:19.446933 INFO: lfq-object 68500
+1 day, 20:38:19.521764 INFO: lfq-object 68700
+1 day, 20:38:19.606150 INFO: lfq-object 68900
+1 day, 20:38:19.643583 INFO: lfq-object 68800
+1 day, 20:38:19.679086 INFO: lfq-object 69100
+1 day, 20:38:19.721471 INFO: lfq-object 69000
+1 day, 20:38:19.751067 INFO: lfq-object 69300
+1 day, 20:38:19.795138 INFO: lfq-object 69200
+1 day, 20:38:19.831089 INFO: lfq-object 69500
+1 day, 20:38:19.867997 INFO: lfq-object 69400
+1 day, 20:38:19.905818 INFO: lfq-object 69700
+1 day, 20:38:19.949855 INFO: lfq-object 69600
+1 day, 20:38:19.985891 INFO: lfq-object 69900
+1 day, 20:38:20.022169 INFO: lfq-object 69800
+1 day, 20:38:20.048230 INFO: lfq-object 70100
+1 day, 20:38:20.100981 INFO: lfq-object 70300
+1 day, 20:38:20.104664 INFO: lfq-object 70000
+1 day, 20:38:20.164455 INFO: lfq-object 70200
+1 day, 20:38:20.200352 INFO: lfq-object 70500
+1 day, 20:38:20.254078 INFO: lfq-object 70400
+1 day, 20:38:20.261764 INFO: lfq-object 70700
+1 day, 20:38:20.293353 INFO: lfq-object 70900
+1 day, 20:38:20.324831 INFO: lfq-object 71100
+1 day, 20:38:20.356070 INFO: lfq-object 70600
+1 day, 20:38:20.372429 INFO: lfq-object 71300
+1 day, 20:38:20.388390 INFO: lfq-object 70800
+1 day, 20:38:20.408405 INFO: lfq-object 71000
+1 day, 20:38:20.447270 INFO: lfq-object 71200
+1 day, 20:38:20.462839 INFO: lfq-object 71500
+1 day, 20:38:20.491250 INFO: lfq-object 71400
+1 day, 20:38:20.500239 INFO: lfq-object 71700
+1 day, 20:38:20.564102 INFO: lfq-object 71900
+1 day, 20:38:20.582444 INFO: lfq-object 71600
+1 day, 20:38:20.614883 INFO: lfq-object 72100
+1 day, 20:38:20.619948 INFO: lfq-object 71800
+1 day, 20:38:20.677944 INFO: lfq-object 72000
+1 day, 20:38:20.730596 INFO: lfq-object 72200
+1 day, 20:38:20.788187 INFO: lfq-object 72400
+1 day, 20:38:20.848440 INFO: lfq-object 72300
+1 day, 20:38:20.862142 INFO: lfq-object 72600
+1 day, 20:38:20.906466 INFO: lfq-object 72500
+1 day, 20:38:20.943182 INFO: lfq-object 72800
+1 day, 20:38:20.980024 INFO: lfq-object 72700
+1 day, 20:38:21.023900 INFO: lfq-object 73000
+1 day, 20:38:21.059707 INFO: lfq-object 72900
+1 day, 20:38:21.078406 INFO: lfq-object 73200
+1 day, 20:38:21.142565 INFO: lfq-object 73100
+1 day, 20:38:21.142609 INFO: lfq-object 73400
+1 day, 20:38:21.197056 INFO: lfq-object 73300
+1 day, 20:38:21.228632 INFO: lfq-object 73600
+1 day, 20:38:21.259047 INFO: lfq-object 73500
+1 day, 20:38:21.300714 INFO: lfq-object 73800
+1 day, 20:38:21.341799 INFO: lfq-object 73700
+1 day, 20:38:21.376213 INFO: lfq-object 74000
+1 day, 20:38:21.413005 INFO: lfq-object 73900
+1 day, 20:38:21.434130 INFO: lfq-object 74200
+1 day, 20:38:21.490815 INFO: lfq-object 74400
+1 day, 20:38:21.493554 INFO: lfq-object 74100
+1 day, 20:38:21.548837 INFO: lfq-object 74600
+1 day, 20:38:21.549941 INFO: lfq-object 74300
+1 day, 20:38:21.605940 INFO: lfq-object 74800
+1 day, 20:38:21.609136 INFO: lfq-object 74500
+1 day, 20:38:21.669003 INFO: lfq-object 74700
+1 day, 20:38:21.684337 INFO: lfq-object 75000
+1 day, 20:38:21.720601 INFO: lfq-object 74900
+1 day, 20:38:21.762127 INFO: lfq-object 75200
+1 day, 20:38:21.801318 INFO: lfq-object 75100
+1 day, 20:38:21.852482 INFO: lfq-object 75400
+1 day, 20:38:21.879945 INFO: lfq-object 75300
+1 day, 20:38:21.966828 INFO: lfq-object 75500
+1 day, 20:38:22.075086 INFO: lfq-object 75700
+1 day, 20:38:22.084085 INFO: lfq-object 75600
+1 day, 20:38:22.167154 INFO: lfq-object 75900
+1 day, 20:38:22.194324 INFO: lfq-object 75800
+1 day, 20:38:22.258995 INFO: lfq-object 76100
+1 day, 20:38:22.288945 INFO: lfq-object 76000
+1 day, 20:38:22.358509 INFO: lfq-object 76300
+1 day, 20:38:22.372168 INFO: lfq-object 76200
+1 day, 20:38:22.440406 INFO: lfq-object 76500
+1 day, 20:38:22.476224 INFO: lfq-object 76400
+1 day, 20:38:22.530438 INFO: lfq-object 76700
+1 day, 20:38:22.559048 INFO: lfq-object 76600
+1 day, 20:38:22.606418 INFO: lfq-object 76900
+1 day, 20:38:22.647468 INFO: lfq-object 76800
+1 day, 20:38:22.719553 INFO: lfq-object 77100
+1 day, 20:38:22.724890 INFO: lfq-object 77000
+1 day, 20:38:22.799378 INFO: lfq-object 77300
+1 day, 20:38:22.836470 INFO: lfq-object 77200
+1 day, 20:38:22.918305 INFO: lfq-object 77400
+1 day, 20:38:22.948925 INFO: lfq-object 77500
+1 day, 20:38:23.037333 INFO: lfq-object 77700
+1 day, 20:38:23.067708 INFO: lfq-object 77600
+1 day, 20:38:23.113556 INFO: lfq-object 77900
+1 day, 20:38:23.147850 INFO: lfq-object 77800
+1 day, 20:38:23.180531 INFO: lfq-object 78100
+1 day, 20:38:23.229293 INFO: lfq-object 78000
+1 day, 20:38:23.266685 INFO: lfq-object 78300
+1 day, 20:38:23.302029 INFO: lfq-object 78200
+1 day, 20:38:23.334697 INFO: lfq-object 78500
+1 day, 20:38:23.381359 INFO: lfq-object 78400
+1 day, 20:38:23.395081 INFO: lfq-object 78700
+1 day, 20:38:23.447564 INFO: lfq-object 78600
+1 day, 20:38:23.455528 INFO: lfq-object 78900
+1 day, 20:38:23.514247 INFO: lfq-object 78800
+1 day, 20:38:23.573265 INFO: lfq-object 79000
+1 day, 20:38:23.674446 INFO: lfq-object 79200
+1 day, 20:38:23.693480 INFO: lfq-object 79100
+1 day, 20:38:23.739523 INFO: lfq-object 79400
+1 day, 20:38:23.792597 INFO: lfq-object 79300
+1 day, 20:38:23.835175 INFO: lfq-object 79600
+1 day, 20:38:23.856152 INFO: lfq-object 79500
+1 day, 20:38:23.871823 INFO: lfq-object 79800
+1 day, 20:38:23.941904 INFO: lfq-object 80000
+1 day, 20:38:23.952787 INFO: lfq-object 79700
+1 day, 20:38:23.989546 INFO: lfq-object 79900
+1 day, 20:38:23.995879 INFO: lfq-object 80200
+1 day, 20:38:24.060238 INFO: lfq-object 80100
+1 day, 20:38:24.085465 INFO: lfq-object 80400
+1 day, 20:38:24.112128 INFO: lfq-object 80300
+1 day, 20:38:24.183229 INFO: lfq-object 80600
+1 day, 20:38:24.201303 INFO: lfq-object 80500
+1 day, 20:38:24.300031 INFO: lfq-object 80700
+1 day, 20:38:24.362292 INFO: lfq-object 80800
+1 day, 20:38:24.478556 INFO: lfq-object 80900
+1 day, 20:38:24.516701 INFO: lfq-object 81000
+1 day, 20:38:24.634422 INFO: lfq-object 81100
+1 day, 20:38:24.671249 INFO: lfq-object 81200
+1 day, 20:38:24.788815 INFO: lfq-object 81300
+1 day, 20:38:29.215507 INFO: lfq-object 81400
+1 day, 20:38:29.254927 INFO: lfq-object 81600
+1 day, 20:38:29.305351 INFO: lfq-object 82000
+1 day, 20:38:29.308494 INFO: lfq-object 81800
+1 day, 20:38:29.331547 INFO: lfq-object 81500
+1 day, 20:38:29.374889 INFO: lfq-object 81700
+1 day, 20:38:29.425701 INFO: lfq-object 81900
+1 day, 20:38:34.718784 INFO: Writing precursor output to disk
+1 day, 20:38:34.718974 INFO: Saving run_output/alphadia_1.10_defaultMBR/precursor.matrix.tsv to disk
+1 day, 20:38:35.169302 PROGRESS: Performing label free quantification on the pg level
+1 day, 20:38:35.169410 INFO: Filtering fragments by quality
+1 day, 20:38:35.419792 INFO: Performing label-free quantification using directLFQ
+1 day, 20:38:35.881465 INFO: 8247 lfq-groups total
+1 day, 20:39:34.430773 INFO: using 100 processes
+1 day, 20:39:34.519204 INFO: lfq-object 0
+1 day, 20:39:34.687771 INFO: lfq-object 300
+1 day, 20:39:34.852339 INFO: lfq-object 400
+1 day, 20:39:34.993015 INFO: lfq-object 100
+1 day, 20:39:35.023940 INFO: lfq-object 200
+1 day, 20:39:35.087982 INFO: lfq-object 700
+1 day, 20:39:35.137345 INFO: lfq-object 800
+1 day, 20:39:35.138164 INFO: lfq-object 600
+1 day, 20:39:35.152001 INFO: lfq-object 500
+1 day, 20:39:35.249520 INFO: lfq-object 1100
+1 day, 20:39:35.289876 INFO: lfq-object 900
+1 day, 20:39:35.354125 INFO: lfq-object 1600
+1 day, 20:39:35.354949 INFO: lfq-object 1200
+1 day, 20:39:35.407401 INFO: lfq-object 1700
+1 day, 20:39:35.458599 INFO: lfq-object 1500
+1 day, 20:39:35.475915 INFO: lfq-object 1000
+1 day, 20:39:35.529522 INFO: lfq-object 1400
+1 day, 20:39:35.618089 INFO: lfq-object 2100
+1 day, 20:39:35.682074 INFO: lfq-object 1300
+1 day, 20:39:35.750459 INFO: lfq-object 1800
+1 day, 20:39:35.781311 INFO: lfq-object 2500
+1 day, 20:39:35.841767 INFO: lfq-object 2400
+1 day, 20:39:35.875718 INFO: lfq-object 2300
+1 day, 20:39:35.885395 INFO: lfq-object 2000
+1 day, 20:39:35.888169 INFO: lfq-object 1900
+1 day, 20:39:35.957876 INFO: lfq-object 2800
+1 day, 20:39:35.976885 INFO: lfq-object 2900
+1 day, 20:39:36.024890 INFO: lfq-object 2200
+1 day, 20:39:36.028826 INFO: lfq-object 2700
+1 day, 20:39:36.116206 INFO: lfq-object 2600
+1 day, 20:39:36.179673 INFO: lfq-object 3300
+1 day, 20:39:36.229216 INFO: lfq-object 3100
+1 day, 20:39:36.280878 INFO: lfq-object 3400
+1 day, 20:39:36.287499 INFO: lfq-object 3200
+1 day, 20:39:36.298787 INFO: lfq-object 3000
+1 day, 20:39:36.333490 INFO: lfq-object 3500
+1 day, 20:39:36.434322 INFO: lfq-object 3700
+1 day, 20:39:36.480362 INFO: lfq-object 3600
+1 day, 20:39:36.541707 INFO: lfq-object 4000
+1 day, 20:39:36.599431 INFO: lfq-object 3800
+1 day, 20:39:36.599928 INFO: lfq-object 4200
+1 day, 20:39:36.601905 INFO: lfq-object 4100
+1 day, 20:39:36.615119 INFO: lfq-object 3900
+1 day, 20:39:36.797667 INFO: lfq-object 4500
+1 day, 20:39:36.805854 INFO: lfq-object 4400
+1 day, 20:39:36.820014 INFO: lfq-object 4600
+1 day, 20:39:36.938053 INFO: lfq-object 4300
+1 day, 20:39:36.987046 INFO: lfq-object 4900
+1 day, 20:39:37.012633 INFO: lfq-object 4800
+1 day, 20:39:37.031399 INFO: lfq-object 5000
+1 day, 20:39:37.032637 INFO: lfq-object 4700
+1 day, 20:39:37.188225 INFO: lfq-object 5100
+1 day, 20:39:37.205151 INFO: lfq-object 5400
+1 day, 20:39:37.224151 INFO: lfq-object 5300
+1 day, 20:39:37.302872 INFO: lfq-object 5200
+1 day, 20:39:37.303236 INFO: lfq-object 5500
+1 day, 20:39:37.390937 INFO: lfq-object 5600
+1 day, 20:39:37.409255 INFO: lfq-object 5700
+1 day, 20:39:37.413619 INFO: lfq-object 5800
+1 day, 20:39:37.497177 INFO: lfq-object 5900
+1 day, 20:39:37.574402 INFO: lfq-object 6000
+1 day, 20:39:37.583692 INFO: lfq-object 6200
+1 day, 20:39:37.609307 INFO: lfq-object 6300
+1 day, 20:39:37.619458 INFO: lfq-object 6100
+1 day, 20:39:37.719368 INFO: lfq-object 6500
+1 day, 20:39:37.732588 INFO: lfq-object 6400
+1 day, 20:39:37.770419 INFO: lfq-object 6600
+1 day, 20:39:37.827110 INFO: lfq-object 6700
+1 day, 20:39:37.958870 INFO: lfq-object 6900
+1 day, 20:39:37.963680 INFO: lfq-object 7100
+1 day, 20:39:37.978794 INFO: lfq-object 7000
+1 day, 20:39:37.990436 INFO: lfq-object 6800
+1 day, 20:39:38.071666 INFO: lfq-object 7200
+1 day, 20:39:38.117734 INFO: lfq-object 7300
+1 day, 20:39:38.135960 INFO: lfq-object 7400
+1 day, 20:39:38.150784 INFO: lfq-object 7500
+1 day, 20:39:38.293964 INFO: lfq-object 7800
+1 day, 20:39:38.299128 INFO: lfq-object 7600
+1 day, 20:39:38.304153 INFO: lfq-object 7700
+1 day, 20:39:38.327183 INFO: lfq-object 7900
+1 day, 20:39:38.512142 INFO: lfq-object 8100
+1 day, 20:39:38.577760 INFO: lfq-object 8000
+1 day, 20:39:38.594546 INFO: lfq-object 8200
+1 day, 20:39:41.508688 INFO: Writing pg output to disk
+1 day, 20:39:41.508872 INFO: Saving run_output/alphadia_1.10_defaultMBR/pg.matrix.tsv to disk
+1 day, 20:39:41.757547 INFO: Writing psm output to disk
+1 day, 20:39:41.757703 INFO: Saving run_output/alphadia_1.10_defaultMBR/precursors.tsv to disk
+1 day, 20:40:09.184576 PROGRESS: Building spectral library
+1 day, 20:40:09.276563 INFO: Building MBR spectral library
+1 day, 20:40:09.276708 INFO: Running MbrLibraryBuilder
+1 day, 20:40:09.514988 INFO: MBR spectral library contains 82,019 precursors, 8,247 proteins
+1 day, 20:40:09.515134 INFO: Writing MBR spectral library to disk
+1 day, 20:40:10.129840 PROGRESS: =================== Search Finished ===================
+1 day, 20:40:10.160387 WARNING: WARNING: Temp mmap arrays were written to /tmp/temp_mmap_93r89lay. Cleanup of this folder is OS dependant, and might need to be triggered manually! Current space: 696,495,505,408

--- a/test/params/log_alphadia_1.8.csv
+++ b/test/params/log_alphadia_1.8.csv
@@ -1,6 +1,6 @@
 ,0
 software_name,AlphaDIA
-software_version,1.0
+software_version,1.8.1
 search_engine,AlphaDIA
 search_engine_version,None
 ident_fdr_psm,None
@@ -9,7 +9,7 @@ ident_fdr_protein,None
 enable_match_between_runs,False
 precursor_mass_tolerance,5 
 fragment_mass_tolerance,10 
-enzyme,trypsin
+enzyme,trypsin/p 
 allowed_miscleavages,1 
 min_peptide_length,6
 max_peptide_length,35

--- a/test/params/log_alphadia_1.8.csv
+++ b/test/params/log_alphadia_1.8.csv
@@ -10,14 +10,14 @@ enable_match_between_runs,False
 precursor_mass_tolerance,5 
 fragment_mass_tolerance,10 
 enzyme,trypsin
-allowed_miscleavages,1
+allowed_miscleavages,1 
 min_peptide_length,6
-max_peptide_length,40
-fixed_mods,Carbamidomethyl@C
-variable_mods,Oxidation@M;Acetyl@Protein N-term
+max_peptide_length,35
+fixed_mods,Carbamidomethyl@C 
+variable_mods,Oxidation@M;Acetyl@Protein_N-term 
 max_mods,1 
 min_precursor_charge,1
 max_precursor_charge,4
 quantification_method,DirectLFQ
-protein_inference,heuristic
+protein_inference,heuristic 
 abundance_normalization_ions,None

--- a/test/params/log_alphadia_1.8.txt
+++ b/test/params/log_alphadia_1.8.txt
@@ -1,0 +1,4172 @@
+0:00:00 PROGRESS:           _      _         ___ ___   _   
+0:00:00 PROGRESS:      __ _| |_ __| |_  __ _|   \_ _| /_\  
+0:00:00 PROGRESS:     / _` | | '_ \ ' \/ _` | |) | | / _ \ 
+0:00:00 PROGRESS:     \__,_|_| .__/_||_\__,_|___/___/_/ \_\
+0:00:00 PROGRESS:            |_|                           
+0:00:00 PROGRESS: 
+0:00:00 PROGRESS: version: 1.8.1
+0:00:00 PROGRESS: hostname: Agamemnon
+0:00:00 PROGRESS: date: 2024-10-31 20:45:45
+0:00:00 PROGRESS: =================== Environment ===================
+0:00:00 PROGRESS: alphatims       : 1.0.8
+0:00:00 PROGRESS: alpharaw        : 0.4.5
+0:00:00 PROGRESS: alphabase       : 1.4.0
+0:00:00 PROGRESS: alphapeptdeep   : 1.3.0
+0:00:00 PROGRESS: directlfq       : 0.2.19
+0:00:00 PROGRESS: ===================================================
+0:00:00 INFO: loading default config from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\default.yaml
+0:00:00.046872 INFO: ├──version: 1 (default)
+0:00:00.046872 INFO: ├──general
+0:00:00.046872 INFO: │   ├──thread_count: 10 (default)
+0:00:00.046872 INFO: │   ├──reuse_calibration: False (default)
+0:00:00.046872 INFO: │   ├──reuse_quant: False (default)
+0:00:00.046872 INFO: │   ├──astral_ms1: False (default)
+0:00:00.046872 INFO: │   ├──log_level: INFO (default)
+0:00:00.046872 INFO: │   ├──wsl: False (default)
+0:00:00.046872 INFO: │   ├──mmap_detector_events: False (default)
+0:00:00.046872 INFO: │   ├──use_gpu: True (default)
+0:00:00.046872 INFO: │   ├──save_library: True (default)
+0:00:00.046872 INFO: │   └──save_mbr_library: True (default)
+0:00:00.046872 INFO: ├──library_loading
+0:00:00.046872 INFO: │   └──rt_heuristic: 180 (default)
+0:00:00.046872 INFO: ├──library_prediction
+0:00:00.046872 INFO: │   ├──predict: False (default)
+0:00:00.046872 INFO: │   ├──[32;20mpredict: True (user defined)[0m
+0:00:00.046872 INFO: │   ├──enzyme: trypsin (default)
+0:00:00.046872 INFO: │   ├──[32;20menzyme: trypsin/p (user defined)[0m
+0:00:00.046872 INFO: │   ├──fixed_modifications: Carbamidomethyl@C (default)
+0:00:00.046872 INFO: │   ├──variable_modifications: Oxidation@M;Acetyl@Protein_N-term (default)
+0:00:00.046872 INFO: │   ├──max_var_mod_num: 2 (default)
+0:00:00.046872 INFO: │   ├──[32;20mmax_var_mod_num: 1 (user defined)[0m
+0:00:00.046872 INFO: │   ├──missed_cleavages: 1 (default)
+0:00:00.046872 INFO: │   ├──precursor_len
+0:00:00.046872 INFO: │   │   ├──7 (default)
+0:00:00.046872 INFO: │   │   ├──[32;20m6 (user defined)[0m
+0:00:00.046872 INFO: │   │   └──35 (default)
+0:00:00.046872 INFO: │   ├──precursor_charge
+0:00:00.046872 INFO: │   │   ├──2 (default)
+0:00:00.046872 INFO: │   │   ├──[32;20m1 (user defined)[0m
+0:00:00.046872 INFO: │   │   └──4 (default)
+0:00:00.046872 INFO: │   ├──precursor_mz
+0:00:00.046872 INFO: │   │   ├──400 (default)
+0:00:00.046872 INFO: │   │   └──1200 (default)
+0:00:00.046872 INFO: │   │   └──[32;20m1000 (user defined)[0m
+0:00:00.046872 INFO: │   ├──fragment_mz
+0:00:00.046872 INFO: │   │   ├──200 (default)
+0:00:00.046872 INFO: │   │   ├──[32;20m50 (user defined)[0m
+0:00:00.046872 INFO: │   │   └──2000 (default)
+0:00:00.046872 INFO: │   ├──nce: 25.0 (default)
+0:00:00.046872 INFO: │   ├──fragment_types: b;y (default)
+0:00:00.046872 INFO: │   ├──max_fragment_charge: 2 (default)
+0:00:00.046872 INFO: │   ├──instrument: Lumos (default)
+0:00:00.046872 INFO: │   ├──[32;20minstrument: QEHFX (user defined)[0m
+0:00:00.046872 INFO: │   ├──peptdeep_model_path: None (default)
+0:00:00.046872 INFO: │   └──peptdeep_model_type: None (default)
+0:00:00.046872 INFO: │   └──[32;20mpeptdeep_model_type: generic (user defined)[0m
+0:00:00.046872 INFO: ├──custom_modififcations
+0:00:00.046872 INFO: │   ├──Dimethyl:d12@K
+0:00:00.046872 INFO: │   │   └──composition: H(-2)2H(8)13C(2) (default)
+0:00:00.046872 INFO: │   ├──Dimethyl:d12@Any_N-term
+0:00:00.046872 INFO: │   │   └──composition: H(-2)2H(8)13C(2) (default)
+0:00:00.046872 INFO: │   ├──Dimethyl:d12@Protein_N-term
+0:00:00.046872 INFO: │   │   └──composition: H(-2)2H(8)13C(2) (default)
+0:00:00.046872 INFO: │   ├──mTRAQ:d12@K
+0:00:00.046872 INFO: │   │   └──composition: H(12)C(1)13C(10)15N(2)O(1) (default)
+0:00:00.046872 INFO: │   ├──mTRAQ:d12@Any_N-term
+0:00:00.046872 INFO: │   │   └──composition: H(12)C(1)13C(14)15N(2)O(1) (default)
+0:00:00.046872 INFO: │   ├──mTRAQ:d12@Protein_N-term
+0:00:00.046872 INFO: │   │   └──composition: H(12)C(1)13C(14)15N(2)O(1) (default)
+0:00:00.046872 INFO: │   └──Label:13C(12)@K
+0:00:00.046872 INFO: │       └──composition: C(12) (default)
+0:00:00.046872 INFO: ├──search
+0:00:00.046872 INFO: │   ├──channel_filter: 0 (default)
+0:00:00.046872 INFO: │   ├──[32;20mchannel_filter:  (user defined)[0m
+0:00:00.046872 INFO: │   ├──exclude_shared_ions: True (default)
+0:00:00.046872 INFO: │   ├──compete_for_fragments: True (default)
+0:00:00.046872 INFO: │   ├──target_num_candidates: 2 (default)
+0:00:00.046872 INFO: │   ├──target_ms1_tolerance: 5 (default)
+0:00:00.046872 INFO: │   ├──target_ms2_tolerance: 10 (default)
+0:00:00.046872 INFO: │   ├──target_mobility_tolerance: 0.0 (default)
+0:00:00.046872 INFO: │   ├──target_rt_tolerance: 0.0 (default)
+0:00:00.046872 INFO: │   ├──quant_window: 3 (default)
+0:00:00.046872 INFO: │   └──quant_all: True (default)
+0:00:00.046872 INFO: ├──search_advanced
+0:00:00.046872 INFO: │   └──top_k_fragments: 12 (default)
+0:00:00.046872 INFO: ├──calibration
+0:00:00.046872 INFO: │   ├──batch_size: 8000 (default)
+0:00:00.046872 INFO: │   ├──optimization_lock_target: 200 (default)
+0:00:00.046872 INFO: │   ├──max_steps: 20 (default)
+0:00:00.046872 INFO: │   ├──min_steps: 2 (default)
+0:00:00.046872 INFO: │   ├──max_skips: 1 (default)
+0:00:00.046872 INFO: │   ├──final_full_calibration: False (default)
+0:00:00.046872 INFO: │   ├──norm_rt_mode: linear (default)
+0:00:00.046872 INFO: │   ├──max_fragments: 5000 (default)
+0:00:00.046872 INFO: │   └──min_correlation: 0.7 (default)
+0:00:00.046872 INFO: ├──search_initial
+0:00:00.046872 INFO: │   ├──initial_num_candidates: 1 (default)
+0:00:00.046872 INFO: │   ├──initial_ms1_tolerance: 30 (default)
+0:00:00.046872 INFO: │   ├──initial_ms2_tolerance: 30 (default)
+0:00:00.046872 INFO: │   ├──initial_mobility_tolerance: 0.1 (default)
+0:00:00.046872 INFO: │   └──initial_rt_tolerance: 0.5 (default)
+0:00:00.046872 INFO: ├──selection_config
+0:00:00.046872 INFO: │   ├──peak_len_rt: 10.0 (default)
+0:00:00.046872 INFO: │   ├──sigma_scale_rt: 0.5 (default)
+0:00:00.046872 INFO: │   ├──peak_len_mobility: 0.01 (default)
+0:00:00.046872 INFO: │   ├──sigma_scale_mobility: 1.0 (default)
+0:00:00.046872 INFO: │   ├──top_k_precursors: 3 (default)
+0:00:00.046872 INFO: │   ├──kernel_size: 30 (default)
+0:00:00.046872 INFO: │   ├──f_mobility: 1.0 (default)
+0:00:00.046872 INFO: │   ├──f_rt: 0.99 (default)
+0:00:00.046872 INFO: │   ├──center_fraction: 0.5 (default)
+0:00:00.046872 INFO: │   ├──min_size_mobility: 8 (default)
+0:00:00.046872 INFO: │   ├──min_size_rt: 3 (default)
+0:00:00.046872 INFO: │   ├──max_size_mobility: 20 (default)
+0:00:00.046872 INFO: │   ├──max_size_rt: 15 (default)
+0:00:00.046872 INFO: │   ├──group_channels: False (default)
+0:00:00.046872 INFO: │   ├──use_weighted_score: True (default)
+0:00:00.046872 INFO: │   ├──join_close_candidates: False (default)
+0:00:00.046872 INFO: │   ├──join_close_candidates_scan_threshold: 0.6 (default)
+0:00:00.046872 INFO: │   └──join_close_candidates_cycle_threshold: 0.6 (default)
+0:00:00.046872 INFO: ├──scoring_config
+0:00:00.046872 INFO: │   ├──score_grouped: False (default)
+0:00:00.046872 INFO: │   ├──top_k_isotopes: 3 (default)
+0:00:00.046872 INFO: │   ├──reference_channel: -1 (default)
+0:00:00.046872 INFO: │   ├──precursor_mz_tolerance: 10 (default)
+0:00:00.046872 INFO: │   └──fragment_mz_tolerance: 15 (default)
+0:00:00.046872 INFO: ├──library_multiplexing
+0:00:00.046872 INFO: │   ├──enabled: False (default)
+0:00:00.046872 INFO: │   ├──input_channel: 0 (default)
+0:00:00.046872 INFO: │   └──multiplex_mapping
+0:00:00.046872 INFO: ├──multiplexing
+0:00:00.046872 INFO: │   ├──enabled: False (default)
+0:00:00.046872 INFO: │   ├──target_channels: 4,8 (default)
+0:00:00.046872 INFO: │   ├──decoy_channel: 12 (default)
+0:00:00.046872 INFO: │   ├──reference_channel: 0 (default)
+0:00:00.046872 INFO: │   └──competetive_scoring: True (default)
+0:00:00.046872 INFO: ├──fdr
+0:00:00.046872 INFO: │   ├──fdr: 0.01 (default)
+0:00:00.046872 INFO: │   ├──group_level: proteins (default)
+0:00:00.046872 INFO: │   ├──competetive_scoring: True (default)
+0:00:00.046872 INFO: │   ├──keep_decoys: False (default)
+0:00:00.046872 INFO: │   ├──[32;20mkeep_decoys: True (user defined)[0m
+0:00:00.046872 INFO: │   ├──channel_wise_fdr: False (default)
+0:00:00.060891 INFO: │   └──inference_strategy: heuristic (default)
+0:00:00.060891 INFO: ├──search_output
+0:00:00.060891 INFO: │   ├──peptide_level_lfq: False (default)
+0:00:00.060891 INFO: │   ├──precursor_level_lfq: False (default)
+0:00:00.060891 INFO: │   ├──min_k_fragments: 12 (default)
+0:00:00.060891 INFO: │   ├──min_correlation: 0.9 (default)
+0:00:00.060891 INFO: │   ├──num_samples_quadratic: 50 (default)
+0:00:00.060891 INFO: │   ├──min_nonnan: 3 (default)
+0:00:00.060891 INFO: │   ├──normalize_lfq: True (default)
+0:00:00.060891 INFO: │   └──file_format: tsv (default)
+0:00:00.060891 INFO: ├──optimization
+0:00:00.060891 INFO: │   ├──order_of_optimization: None (default)
+0:00:00.060891 INFO: │   ├──ms2_error
+0:00:00.060891 INFO: │   │   ├──targeted_update_percentile_range: 0.95 (default)
+0:00:00.060891 INFO: │   │   ├──targeted_update_factor: 1.0 (default)
+0:00:00.060891 INFO: │   │   ├──automatic_update_percentile_range: 0.99 (default)
+0:00:00.060891 INFO: │   │   ├──automatic_update_factor: 1.1 (default)
+0:00:00.060891 INFO: │   │   ├──try_narrower_values: True (default)
+0:00:00.060891 INFO: │   │   ├──maximal_decrease: 0.5 (default)
+0:00:00.060891 INFO: │   │   ├──favour_narrower_optimum: False (default)
+0:00:00.060891 INFO: │   │   └──maximum_decrease_from_maximum: 0.1 (default)
+0:00:00.060891 INFO: │   ├──ms1_error
+0:00:00.060891 INFO: │   │   ├──targeted_update_percentile_range: 0.95 (default)
+0:00:00.060891 INFO: │   │   ├──targeted_update_factor: 1.0 (default)
+0:00:00.060891 INFO: │   │   ├──automatic_update_percentile_range: 0.99 (default)
+0:00:00.060891 INFO: │   │   ├──automatic_update_factor: 1.1 (default)
+0:00:00.062901 INFO: │   │   ├──try_narrower_values: False (default)
+0:00:00.062901 INFO: │   │   ├──maximal_decrease: 0.2 (default)
+0:00:00.062901 INFO: │   │   ├──favour_narrower_optimum: False (default)
+0:00:00.062901 INFO: │   │   └──maximum_decrease_from_maximum: 0.1 (default)
+0:00:00.062901 INFO: │   ├──mobility_error
+0:00:00.062901 INFO: │   │   ├──targeted_update_percentile_range: 0.95 (default)
+0:00:00.062901 INFO: │   │   ├──targeted_update_factor: 1.0 (default)
+0:00:00.062901 INFO: │   │   ├──automatic_update_percentile_range: 0.99 (default)
+0:00:00.062901 INFO: │   │   ├──automatic_update_factor: 1.1 (default)
+0:00:00.062901 INFO: │   │   ├──try_narrower_values: False (default)
+0:00:00.062901 INFO: │   │   ├──maximal_decrease: 0.2 (default)
+0:00:00.062901 INFO: │   │   ├──favour_narrower_optimum: False (default)
+0:00:00.062901 INFO: │   │   └──maximum_decrease_from_maximum: 0.1 (default)
+0:00:00.062901 INFO: │   └──rt_error
+0:00:00.062901 INFO: │       ├──targeted_update_percentile_range: 0.95 (default)
+0:00:00.062901 INFO: │       ├──targeted_update_factor: 1.0 (default)
+0:00:00.062901 INFO: │       ├──automatic_update_percentile_range: 0.99 (default)
+0:00:00.062901 INFO: │       ├──automatic_update_factor: 1.1 (default)
+0:00:00.062901 INFO: │       ├──try_narrower_values: True (default)
+0:00:00.062901 INFO: │       ├──maximal_decrease: 0.2 (default)
+0:00:00.062901 INFO: │       ├──favour_narrower_optimum: True (default)
+0:00:00.062901 INFO: │       └──maximum_decrease_from_maximum: 0.1 (default)
+0:00:00.062901 INFO: ├──optimization_manager
+0:00:00.062901 INFO: │   ├──fwhm_rt: 5 (default)
+0:00:00.062901 INFO: │   ├──fwhm_mobility: 0.01 (default)
+0:00:00.062901 INFO: │   └──score_cutoff: 0 (default)
+0:00:00.062901 INFO: ├──transfer_library
+0:00:00.062901 INFO: │   ├──enabled: False (default)
+0:00:00.062901 INFO: │   ├──fragment_types: b;y (default)
+0:00:00.062901 INFO: │   ├──max_charge: 2 (default)
+0:00:00.062901 INFO: │   ├──top_k_samples: 3 (default)
+0:00:00.062901 INFO: │   ├──norm_delta_max: True (default)
+0:00:00.062901 INFO: │   ├──precursor_correlation_cutoff: 0.5 (default)
+0:00:00.062901 INFO: │   └──fragment_correlation_ratio: 0.75 (default)
+0:00:00.062901 INFO: ├──transfer_learning
+0:00:00.062901 INFO: │   ├──enabled: False (default)
+0:00:00.062901 INFO: │   ├──batch_size: 2000 (default)
+0:00:00.062901 INFO: │   ├──max_lr: 0.0001 (default)
+0:00:00.062901 INFO: │   ├──train_fraction: 0.7 (default)
+0:00:00.062901 INFO: │   ├──validation_fraction: 0.2 (default)
+0:00:00.062901 INFO: │   ├──test_fraction: 0.1 (default)
+0:00:00.062901 INFO: │   ├──test_interval: 1 (default)
+0:00:00.062901 INFO: │   ├──lr_patience: 3 (default)
+0:00:00.062901 INFO: │   ├──epochs: 51 (default)
+0:00:00.062901 INFO: │   ├──warmup_epochs: 5 (default)
+0:00:00.062901 INFO: │   ├──nce: 25 (default)
+0:00:00.062901 INFO: │   └──instrument: Lumos (default)
+0:00:00.062901 INFO: ├──calibration_manager
+0:00:00.062901 INFO: │   ├──0
+0:00:00.062901 INFO: │   │   ├──name: fragment (default)
+0:00:00.062901 INFO: │   │   └──estimators
+0:00:00.062901 INFO: │   │       └──0
+0:00:00.062901 INFO: │   │           ├──name: mz (default)
+0:00:00.062901 INFO: │   │           ├──model: LOESSRegression (default)
+0:00:00.062901 INFO: │   │           ├──model_args
+0:00:00.062901 INFO: │   │           │   └──n_kernels: 2 (default)
+0:00:00.062901 INFO: │   │           ├──input_columns
+0:00:00.062901 INFO: │   │           │   └──mz_library (default)
+0:00:00.062901 INFO: │   │           ├──target_columns
+0:00:00.062901 INFO: │   │           │   └──mz_observed (default)
+0:00:00.062901 INFO: │   │           ├──output_columns
+0:00:00.062901 INFO: │   │           │   └──mz_calibrated (default)
+0:00:00.062901 INFO: │   │           └──transform_deviation: 1e6 (default)
+0:00:00.062901 INFO: │   └──1
+0:00:00.062901 INFO: │       ├──name: precursor (default)
+0:00:00.062901 INFO: │       └──estimators
+0:00:00.062901 INFO: │           ├──0
+0:00:00.062901 INFO: │           │   ├──name: mz (default)
+0:00:00.062901 INFO: │           │   ├──model: LOESSRegression (default)
+0:00:00.062901 INFO: │           │   ├──model_args
+0:00:00.062901 INFO: │           │   │   └──n_kernels: 2 (default)
+0:00:00.062901 INFO: │           │   ├──input_columns
+0:00:00.062901 INFO: │           │   │   └──mz_library (default)
+0:00:00.062901 INFO: │           │   ├──target_columns
+0:00:00.062901 INFO: │           │   │   └──mz_observed (default)
+0:00:00.062901 INFO: │           │   ├──output_columns
+0:00:00.062901 INFO: │           │   │   └──mz_calibrated (default)
+0:00:00.062901 INFO: │           │   └──transform_deviation: 1e6 (default)
+0:00:00.062901 INFO: │           ├──1
+0:00:00.062901 INFO: │           │   ├──name: rt (default)
+0:00:00.062901 INFO: │           │   ├──model: LOESSRegression (default)
+0:00:00.062901 INFO: │           │   ├──model_args
+0:00:00.062901 INFO: │           │   │   └──n_kernels: 6 (default)
+0:00:00.062901 INFO: │           │   ├──input_columns
+0:00:00.062901 INFO: │           │   │   └──rt_library (default)
+0:00:00.062901 INFO: │           │   ├──target_columns
+0:00:00.062901 INFO: │           │   │   └──rt_observed (default)
+0:00:00.062901 INFO: │           │   └──output_columns
+0:00:00.062901 INFO: │           │       └──rt_calibrated (default)
+0:00:00.062901 INFO: │           └──2
+0:00:00.062901 INFO: │               ├──name: mobility (default)
+0:00:00.062901 INFO: │               ├──model: LOESSRegression (default)
+0:00:00.062901 INFO: │               ├──model_args
+0:00:00.062901 INFO: │               │   └──n_kernels: 2 (default)
+0:00:00.062901 INFO: │               ├──input_columns
+0:00:00.062901 INFO: │               │   └──mobility_library (default)
+0:00:00.062901 INFO: │               ├──target_columns
+0:00:00.062901 INFO: │               │   └──mobility_observed (default)
+0:00:00.062901 INFO: │               └──output_columns
+0:00:00.062901 INFO: │                   └──mobility_calibrated (default)
+0:00:00.062901 INFO: ├──[32;20mname: PeptideCentric.v1 (user defined)[0m
+0:00:00.062901 INFO: ├──[32;20mfasta_list[0m
+0:00:00.062901 INFO: │   └──[32;20mD:\Proteobench_manuscript_data\ProteoBenchFASTA_DDAQuantification.fasta (user defined)[0m
+0:00:00.062901 INFO: ├──[32;20mraw_path_list[0m
+0:00:00.062901 INFO: │   ├──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01.raw (user defined)[0m
+0:00:00.062901 INFO: │   ├──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02.raw (user defined)[0m
+0:00:00.062901 INFO: │   ├──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03.raw (user defined)[0m
+0:00:00.062901 INFO: │   ├──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01.raw (user defined)[0m
+0:00:00.062901 INFO: │   ├──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw (user defined)[0m
+0:00:00.062901 INFO: │   └──[32;20mD:\Proteobench_manuscript_data\RAW\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw (user defined)[0m
+0:00:00.062901 INFO: └──[32;20moutput_directory: D:\Proteobench_manuscript_data\run_output\alphadia_default (user defined)[0m
+0:00:00.062901 INFO: Registering 7 custom modifications
+0:00:00.141038 PROGRESS: No library provided. Building library from fasta files.
+0:00:00.141038 INFO: Running FastaDigest
+0:00:01.668102 INFO: Digesting fasta file
+0:00:16.783818 INFO: Adding modifications
+0:04:37.858952 INFO: Removing non-canonical amino acids
+0:04:47.998693 INFO: Fasta library contains 5,385,906 precursors
+0:04:47.998693 PROGRESS: Predicting library properties.
+0:04:47.998693 INFO: Running PeptDeepPrediction
+0:04:47.998693 INFO: Device set to cpu
+0:04:49.617849 INFO: Loading PeptDeep models of type generic
+0:04:50.951688 INFO: Predicting RT, MS2 and mobility
+0:04:50.951688 INFO: Using multiprocessing with 10 processes ...
+0:04:55.840101 INFO: Predicting rt,ms2,mobility ...
+1:05:21.132035 INFO: Adding fragment mz information
+1:05:22.066830 INFO: Adding fragment intensity information
+1:05:22.647955 INFO: Adding precursor information
+1:05:23.625780 INFO: Running PrecursorInitializer
+1:05:23.674779 INFO: Running AnnotateFasta
+1:05:24.110805 INFO: Dropping decoys from input library before annotation
+1:06:12.944755 INFO: Running IsotopeGenerator
+1:07:35.412885 INFO: Running RTNormalization
+1:07:35.412885 WARNING: Input library already contains normalized RT information. Skipping RT normalization
+1:07:35.413885 INFO: Saving library to D:\Proteobench_manuscript_data\run_output\alphadia_default\speclib.hdf
+1:08:50.184118 INFO: Running DecoyGenerator
+1:10:20.730461 INFO: Running FlattenLibrary
+1:10:43.534079 INFO: Running InitFlatColumns
+1:10:44.011969 INFO: Running LogFlatLibraryStats
+1:10:44.011969 INFO: ============ Library Stats ============
+1:10:44.011969 INFO: Number of precursors: 10,742,046
+1:10:45.395166 INFO: 	thereof targets:5,385,906
+1:10:45.395166 INFO: 	thereof decoys: 5,356,140
+1:10:45.480341 INFO: Number of elution groups: 5,385,906
+1:10:45.480341 INFO: 	average size: 1.99
+1:10:45.714514 INFO: Number of proteins: 118,119
+1:10:45.746068 INFO: Number of channels: 1 ([0])
+1:10:45.746068 INFO: Isotopes Distribution for 4 isotopes
+1:10:45.746068 INFO: =======================================
+1:10:45.996226 PROGRESS: Starting Search Workflows
+1:10:45.996226 PROGRESS: Loading raw file 1/6: LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+1:10:45.996226 INFO: Creating parent folder for workflows at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress
+1:10:45.996226 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+1:11:13.154980 INFO: Determining DIA cycle
+1:11:13.329889 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+1:11:13.329889 INFO: Determining DIA cycle
+1:11:13.457189 INFO: Found cycle with start 0.00 min and length 151.
+1:11:13.536521 INFO: ============ Raw file stats ============
+1:11:13.536521 INFO: RT (min)            : 0.0 - 150.0
+1:11:13.536521 INFO: RT duration (sec)   : 8999.7
+1:11:13.536521 INFO: RT duration (min)   : 150.0
+1:11:13.536521 INFO: Cycle len (scans)   : 151
+1:11:13.536521 INFO: Cycle len (sec)     : 5.83
+1:11:13.536521 INFO: Number of cycles    : 1542
+1:11:13.536521 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+1:11:13.536521 INFO: ========================================
+1:11:14.860109 INFO: Initializing CalibrationManager
+1:11:14.860109 INFO: Loading calibration config
+1:11:14.860109 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6'}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6'}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated']}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated']}]}]
+1:11:14.860109 INFO: Calibration group :fragment, found 1 estimator(s)
+1:11:14.860109 INFO: Calibration group :precursor, found 3 estimator(s)
+1:11:14.860109 INFO: Disabling ion mobility calibration
+1:11:14.860109 INFO: removed mobility estimator from group precursor
+1:11:14.860109 INFO: Initializing OptimizationManager
+1:11:14.860109 INFO: initial parameter: ms1_error = 30
+1:11:14.860109 INFO: initial parameter: ms2_error = 30
+1:11:14.860109 INFO: initial parameter: rt_error = 4500.00927734375
+1:11:14.860109 INFO: initial parameter: mobility_error = 0.1
+1:11:14.860109 INFO: initial parameter: column_type = library
+1:11:14.860109 INFO: initial parameter: num_candidates = 1
+1:11:14.860109 INFO: initial parameter: classifier_version = -1
+1:11:14.860109 INFO: initial parameter: fwhm_rt = 5
+1:11:14.860109 INFO: initial parameter: fwhm_mobility = 0.01
+1:11:14.860109 INFO: initial parameter: score_cutoff = 0
+1:11:14.860109 INFO: Initializing TimingManager
+1:11:14.860109 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+1:11:14.860109 INFO: Initializing FDRManager
+1:11:14.860109 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+1:11:16.105668 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+1:11:17.996588 PROGRESS: Starting initial search for precursors.
+1:11:18.739434 INFO: Starting optimization step 0.
+1:11:18.739434 PROGRESS: === Extracting elution groups 0 to 8000 ===
+1:11:18.739434 PROGRESS: Extracting batch of 15803 precursors
+1:11:20.611102 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:11:20.611102 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:11:20.611102 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+1:11:20.611102 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+1:11:21.867539 INFO: Starting candidate selection
+1:12:29.395127 INFO: Starting candidate scoring
+1:15:55.897818 INFO: Finished candidate processing
+1:15:55.897818 INFO: Collecting candidate features
+1:15:56.602240 INFO: Collecting fragment features
+1:15:59.773311 INFO: Finished candidate scoring
+1:15:59.793338 PROGRESS: === Extracted 15797 precursors and 135899 fragments ===
+1:15:59.793338 INFO: performing precursor FDR with 47 features
+1:15:59.793338 INFO: Decoy channel: -1
+1:15:59.793338 INFO: Competetive: True
+1:16:04.131439 INFO: Test AUC: 0.520
+1:16:04.132438 INFO: Train AUC: 0.527
+1:16:04.132438 INFO: AUC difference: 1.35%
+1:16:04.362284 INFO: === FDR correction performed with classifier version -1 ===
+1:16:04.364330 PROGRESS: ============================= Precursor FDR =============================
+1:16:04.364330 PROGRESS: Total precursors accumulated: 1
+1:16:04.364330 PROGRESS: Target precursors: 1 (100.00%)
+1:16:04.364330 PROGRESS: Decoy precursors: 0 (0.00%)
+1:16:04.364330 PROGRESS: 
+1:16:04.365285 PROGRESS: Precursor Summary:
+1:16:04.366292 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1:16:04.367285 PROGRESS: 
+1:16:04.367285 PROGRESS: Protein Summary:
+1:16:04.371289 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1:16:04.371289 PROGRESS: =========================================================================
+1:16:04.699745 INFO: Starting optimization step 1.
+1:16:04.699745 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+1:16:04.699745 PROGRESS: Extracting batch of 31592 precursors
+1:16:04.715401 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:16:04.715401 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:16:04.715401 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+1:16:04.715401 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+1:16:04.715401 INFO: Starting candidate selection
+1:16:24.488216 INFO: Starting candidate scoring
+1:16:25.791506 INFO: Finished candidate processing
+1:16:25.791506 INFO: Collecting candidate features
+1:16:25.988298 INFO: Collecting fragment features
+1:16:26.051466 INFO: Finished candidate scoring
+1:16:26.149489 PROGRESS: === Extracted 47345 precursors and 407903 fragments ===
+1:16:26.165118 INFO: performing precursor FDR with 47 features
+1:16:26.165118 INFO: Decoy channel: -1
+1:16:26.165118 INFO: Competetive: True
+1:16:27.443538 INFO: Test AUC: 0.552
+1:16:27.443538 INFO: Train AUC: 0.564
+1:16:27.443538 INFO: AUC difference: 2.11%
+1:16:27.614920 INFO: === FDR correction performed with classifier version -1 ===
+1:16:27.616925 PROGRESS: ============================= Precursor FDR =============================
+1:16:27.616925 PROGRESS: Total precursors accumulated: 1
+1:16:27.616925 PROGRESS: Target precursors: 1 (100.00%)
+1:16:27.617924 PROGRESS: Decoy precursors: 0 (0.00%)
+1:16:27.617924 PROGRESS: 
+1:16:27.617924 PROGRESS: Precursor Summary:
+1:16:27.620224 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1:16:27.621220 PROGRESS: 
+1:16:27.621220 PROGRESS: Protein Summary:
+1:16:27.624222 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+1:16:27.624222 PROGRESS: =========================================================================
+1:16:28.035071 INFO: Starting optimization step 2.
+1:16:28.035071 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+1:16:28.035071 PROGRESS: Extracting batch of 63206 precursors
+1:16:28.065230 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:16:28.065230 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:16:28.065230 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+1:16:28.065230 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+1:16:28.065230 INFO: Starting candidate selection
+1:18:16.507846 INFO: Starting candidate scoring
+1:18:19.095424 INFO: Finished candidate processing
+1:18:19.095424 INFO: Collecting candidate features
+1:18:19.395219 INFO: Collecting fragment features
+1:18:19.531490 INFO: Finished candidate scoring
+1:18:19.724932 PROGRESS: === Extracted 110504 precursors and 953068 fragments ===
+1:18:19.775558 INFO: performing precursor FDR with 47 features
+1:18:19.775558 INFO: Decoy channel: -1
+1:18:19.775558 INFO: Competetive: True
+1:18:24.118729 INFO: Test AUC: 0.566
+1:18:24.118729 INFO: Train AUC: 0.575
+1:18:24.118729 INFO: AUC difference: 1.51%
+1:18:24.340421 INFO: === FDR correction performed with classifier version -1 ===
+1:18:24.342423 PROGRESS: ============================= Precursor FDR =============================
+1:18:24.342423 PROGRESS: Total precursors accumulated: 356
+1:18:24.343431 PROGRESS: Target precursors: 326 (91.57%)
+1:18:24.343431 PROGRESS: Decoy precursors: 30 (8.43%)
+1:18:24.343431 PROGRESS: 
+1:18:24.343431 PROGRESS: Precursor Summary:
+1:18:24.346461 PROGRESS: Channel   0:	 0.05 FDR:   253; 0.01 FDR:    13; 0.001 FDR:    13
+1:18:24.346461 PROGRESS: 
+1:18:24.346461 PROGRESS: Protein Summary:
+1:18:24.349460 PROGRESS: Channel   0:	 0.05 FDR:   244; 0.01 FDR:    13; 0.001 FDR:    13
+1:18:24.350461 PROGRESS: =========================================================================
+1:18:24.913632 INFO: Starting optimization step 3.
+1:18:24.914629 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+1:18:24.914629 PROGRESS: Extracting batch of 126403 precursors
+1:18:24.957820 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:18:24.957820 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:18:24.957820 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+1:18:24.957820 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+1:18:24.957820 INFO: Starting candidate selection
+1:19:41.533703 INFO: Starting candidate scoring
+1:19:46.343021 INFO: Finished candidate processing
+1:19:46.343021 INFO: Collecting candidate features
+1:19:46.891675 INFO: Collecting fragment features
+1:19:47.119860 INFO: Finished candidate scoring
+1:19:47.453630 PROGRESS: === Extracted 236800 precursors and 2042688 fragments ===
+1:19:47.516565 INFO: performing precursor FDR with 47 features
+1:19:47.516565 INFO: Decoy channel: -1
+1:19:47.516565 INFO: Competetive: True
+1:19:54.501858 INFO: Test AUC: 0.569
+1:19:54.501858 INFO: Train AUC: 0.582
+1:19:54.501858 INFO: AUC difference: 2.19%
+1:19:54.758753 INFO: === FDR correction performed with classifier version -1 ===
+1:19:54.758753 PROGRESS: ============================= Precursor FDR =============================
+1:19:54.758753 PROGRESS: Total precursors accumulated: 1,058
+1:19:54.758753 PROGRESS: Target precursors: 963 (91.02%)
+1:19:54.758753 PROGRESS: Decoy precursors: 95 (8.98%)
+1:19:54.774799 PROGRESS: 
+1:19:54.775030 PROGRESS: Precursor Summary:
+1:19:54.778040 PROGRESS: Channel   0:	 0.05 FDR:   796; 0.01 FDR:   518; 0.001 FDR:   244
+1:19:54.778040 PROGRESS: 
+1:19:54.778040 PROGRESS: Protein Summary:
+1:19:54.779381 PROGRESS: Channel   0:	 0.05 FDR:   700; 0.01 FDR:   468; 0.001 FDR:   234
+1:19:54.779381 PROGRESS: =========================================================================
+1:19:54.815423 INFO: fragments_df_filtered: 3821
+1:19:55.282444 INFO: calibration group: precursor, fitting rt estimator 
+1:19:55.412237 INFO: calibration group: fragment, fitting mz estimator 
+1:19:58.845867 INFO: calibration group: precursor, predicting mz
+1:19:58.845867 WARNING: mz prediction was skipped as it has not been fitted yet
+1:19:58.845867 INFO: calibration group: precursor, predicting rt
+1:19:58.920763 INFO: calibration group: fragment, predicting mz
+1:19:59.304400 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+1:19:59.304400 INFO: Starting optimization step 4.
+1:19:59.304400 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:19:59.304400 PROGRESS: Extracting batch of 110601 precursors
+1:19:59.364254 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:19:59.364254 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:19:59.364254 INFO: FWHM in RT is 18.94 seconds, sigma is 0.69
+1:19:59.364254 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:19:59.364254 INFO: Starting candidate selection
+1:21:09.614461 INFO: Starting candidate scoring
+1:21:17.506581 INFO: Finished candidate processing
+1:21:17.506581 INFO: Collecting candidate features
+1:21:18.293297 INFO: Collecting fragment features
+1:21:18.664493 INFO: Finished candidate scoring
+1:21:18.848184 PROGRESS: === Extracted 221025 precursors and 1961676 fragments ===
+1:21:18.848184 INFO: performing precursor FDR with 47 features
+1:21:18.848184 INFO: Decoy channel: -1
+1:21:18.848184 INFO: Competetive: True
+1:21:25.197284 INFO: Test AUC: 0.572
+1:21:25.197284 INFO: Train AUC: 0.585
+1:21:25.197284 INFO: AUC difference: 2.23%
+1:21:25.437450 INFO: === FDR correction performed with classifier version 3 ===
+1:21:25.437450 PROGRESS: ============================= Precursor FDR =============================
+1:21:25.437450 PROGRESS: Total precursors accumulated: 452
+1:21:25.437450 PROGRESS: Target precursors: 411 (90.93%)
+1:21:25.437450 PROGRESS: Decoy precursors: 41 (9.07%)
+1:21:25.437450 PROGRESS: 
+1:21:25.437450 PROGRESS: Precursor Summary:
+1:21:25.444263 PROGRESS: Channel   0:	 0.05 FDR:   346; 0.01 FDR:   211; 0.001 FDR:   148
+1:21:25.444263 PROGRESS: 
+1:21:25.444263 PROGRESS: Protein Summary:
+1:21:25.444263 PROGRESS: Channel   0:	 0.05 FDR:   331; 0.01 FDR:   204; 0.001 FDR:   143
+1:21:25.444263 PROGRESS: =========================================================================
+1:21:25.469235 INFO: fragments_df_filtered: 1806
+1:21:25.928303 INFO: calibration group: precursor, fitting rt estimator 
+1:21:26.022470 INFO: calibration group: fragment, fitting mz estimator 
+1:21:26.680439 INFO: calibration group: precursor, predicting mz
+1:21:26.680439 WARNING: mz prediction was skipped as it has not been fitted yet
+1:21:26.680439 INFO: calibration group: precursor, predicting rt
+1:21:26.775002 INFO: calibration group: fragment, predicting mz
+1:21:27.141732 INFO: === checking if optimization conditions were reached ===
+1:21:27.143731 PROGRESS: ❌ ms2_error      : 10.0171 > 10.0000 or insufficient steps taken.
+1:21:27.143731 INFO: ==============================================
+1:21:27.143731 INFO: Starting optimization step 5.
+1:21:27.146790 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:21:27.146790 PROGRESS: Extracting batch of 110601 precursors
+1:21:27.191925 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:21:27.191925 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:21:27.191925 INFO: FWHM in RT is 19.49 seconds, sigma is 0.71
+1:21:27.191925 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:21:27.207568 INFO: Starting candidate selection
+1:22:24.314326 INFO: Starting candidate scoring
+1:22:28.393953 INFO: Finished candidate processing
+1:22:28.393953 INFO: Collecting candidate features
+1:22:28.720613 WARNING: intensity_correlation has 17 NaNs ( 0.01 % out of 220888)
+1:22:28.736359 INFO: Collecting fragment features
+1:22:28.887707 INFO: Finished candidate scoring
+1:22:28.960118 PROGRESS: === Extracted 220888 precursors and 1629984 fragments ===
+1:22:28.960118 INFO: performing precursor FDR with 47 features
+1:22:28.960118 INFO: Decoy channel: -1
+1:22:28.960118 INFO: Competetive: True
+1:22:29.099399 WARNING: dropped 6 target PSMs due to missing features
+1:22:29.099399 WARNING: dropped 11 decoy PSMs due to missing features
+1:22:31.328813 INFO: Test AUC: 0.571
+1:22:31.328813 INFO: Train AUC: 0.587
+1:22:31.328813 INFO: AUC difference: 2.72%
+1:22:31.426519 INFO: === FDR correction performed with classifier version 4 ===
+1:22:31.426519 PROGRESS: ============================= Precursor FDR =============================
+1:22:31.426519 PROGRESS: Total precursors accumulated: 566
+1:22:31.426519 PROGRESS: Target precursors: 515 (90.99%)
+1:22:31.426519 PROGRESS: Decoy precursors: 51 (9.01%)
+1:22:31.426519 PROGRESS: 
+1:22:31.426519 PROGRESS: Precursor Summary:
+1:22:31.426519 PROGRESS: Channel   0:	 0.05 FDR:   431; 0.01 FDR:   205; 0.001 FDR:   183
+1:22:31.426519 PROGRESS: 
+1:22:31.426519 PROGRESS: Protein Summary:
+1:22:31.426519 PROGRESS: Channel   0:	 0.05 FDR:   408; 0.01 FDR:   199; 0.001 FDR:   178
+1:22:31.426519 PROGRESS: =========================================================================
+1:22:31.442200 INFO: fragments_df_filtered: 1402
+1:22:31.658237 INFO: calibration group: precursor, fitting rt estimator 
+1:22:31.696929 INFO: calibration group: fragment, fitting mz estimator 
+1:22:31.844817 INFO: calibration group: precursor, predicting mz
+1:22:31.844817 WARNING: mz prediction was skipped as it has not been fitted yet
+1:22:31.844817 INFO: calibration group: precursor, predicting rt
+1:22:31.878070 INFO: calibration group: fragment, predicting mz
+1:22:32.031313 INFO: === checking if optimization conditions were reached ===
+1:22:32.031313 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+1:22:32.031313 INFO: ==============================================
+1:22:32.031313 PROGRESS: Optimization finished for ms2_error.
+1:22:32.224291 INFO: calibration group: precursor, predicting mz
+1:22:32.224291 WARNING: mz prediction was skipped as it has not been fitted yet
+1:22:32.224291 INFO: calibration group: precursor, predicting rt
+1:22:32.255594 INFO: calibration group: fragment, predicting mz
+1:22:32.432618 INFO: Starting optimization step 0.
+1:22:32.432618 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:22:32.432618 PROGRESS: Extracting batch of 110601 precursors
+1:22:32.448323 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:22:32.448323 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:22:32.448323 INFO: FWHM in RT is 17.60 seconds, sigma is 0.64
+1:22:32.448323 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:22:32.448323 INFO: Starting candidate selection
+1:23:17.127098 INFO: Starting candidate scoring
+1:23:25.723701 INFO: Finished candidate processing
+1:23:25.723701 INFO: Collecting candidate features
+1:23:27.101449 WARNING: intensity_correlation has 14 NaNs ( 0.01 % out of 220890)
+1:23:27.151078 INFO: Collecting fragment features
+1:23:27.824521 INFO: Finished candidate scoring
+1:23:28.366332 PROGRESS: === Extracted 220890 precursors and 1621344 fragments ===
+1:23:28.368329 INFO: performing precursor FDR with 47 features
+1:23:28.369334 INFO: Decoy channel: -1
+1:23:28.369462 INFO: Competetive: True
+1:23:28.986981 WARNING: dropped 6 target PSMs due to missing features
+1:23:28.986981 WARNING: dropped 8 decoy PSMs due to missing features
+1:23:38.583351 INFO: Test AUC: 0.575
+1:23:38.583351 INFO: Train AUC: 0.593
+1:23:38.583351 INFO: AUC difference: 3.15%
+1:23:39.099338 INFO: === FDR correction performed with classifier version 5 ===
+1:23:39.102335 PROGRESS: ============================= Precursor FDR =============================
+1:23:39.102335 PROGRESS: Total precursors accumulated: 584
+1:23:39.103851 PROGRESS: Target precursors: 532 (91.10%)
+1:23:39.103851 PROGRESS: Decoy precursors: 52 (8.90%)
+1:23:39.103851 PROGRESS: 
+1:23:39.103851 PROGRESS: Precursor Summary:
+1:23:39.112298 PROGRESS: Channel   0:	 0.05 FDR:   467; 0.01 FDR:   302; 0.001 FDR:   229
+1:23:39.113298 PROGRESS: 
+1:23:39.114526 PROGRESS: Protein Summary:
+1:23:39.127203 PROGRESS: Channel   0:	 0.05 FDR:   441; 0.01 FDR:   289; 0.001 FDR:   222
+1:23:39.128205 PROGRESS: =========================================================================
+1:23:39.145647 INFO: fragments_df_filtered: 1536
+1:23:40.032866 INFO: calibration group: precursor, fitting rt estimator 
+1:23:40.225522 INFO: calibration group: fragment, fitting mz estimator 
+1:23:40.903845 INFO: calibration group: precursor, predicting mz
+1:23:40.906360 WARNING: mz prediction was skipped as it has not been fitted yet
+1:23:40.906360 INFO: calibration group: precursor, predicting rt
+1:23:41.029739 INFO: calibration group: fragment, predicting mz
+1:23:41.613493 INFO: === checking if optimization conditions were reached ===
+1:23:41.614487 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+1:23:41.622339 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 818.6986.
+1:23:41.622339 INFO: ==============================================
+1:23:41.623355 INFO: Starting optimization step 1.
+1:23:41.624354 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:23:41.624354 PROGRESS: Extracting batch of 110601 precursors
+1:23:41.733195 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:23:41.733195 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:23:41.733195 INFO: FWHM in RT is 17.30 seconds, sigma is 0.63
+1:23:41.733195 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:23:41.733195 INFO: Starting candidate selection
+1:23:51.758008 INFO: Starting candidate scoring
+1:23:58.657535 INFO: Finished candidate processing
+1:23:58.657535 INFO: Collecting candidate features
+1:23:59.292247 WARNING: intensity_correlation has 311 NaNs ( 0.15 % out of 212744)
+1:23:59.327434 INFO: Collecting fragment features
+1:23:59.608662 INFO: Finished candidate scoring
+1:23:59.896096 PROGRESS: === Extracted 212744 precursors and 1330980 fragments ===
+1:23:59.898089 INFO: performing precursor FDR with 47 features
+1:23:59.898089 INFO: Decoy channel: -1
+1:23:59.898089 INFO: Competetive: True
+1:24:00.212173 WARNING: dropped 177 target PSMs due to missing features
+1:24:00.212173 WARNING: dropped 134 decoy PSMs due to missing features
+1:24:06.238866 INFO: Test AUC: 0.561
+1:24:06.238866 INFO: Train AUC: 0.580
+1:24:06.238866 INFO: AUC difference: 3.27%
+1:24:06.474660 INFO: === FDR correction performed with classifier version 5 ===
+1:24:06.479123 PROGRESS: ============================= Precursor FDR =============================
+1:24:06.482696 PROGRESS: Total precursors accumulated: 803
+1:24:06.482696 PROGRESS: Target precursors: 733 (91.28%)
+1:24:06.482696 PROGRESS: Decoy precursors: 70 (8.72%)
+1:24:06.482696 PROGRESS: 
+1:24:06.482696 PROGRESS: Precursor Summary:
+1:24:06.488351 PROGRESS: Channel   0:	 0.05 FDR:   580; 0.01 FDR:   337; 0.001 FDR:   178
+1:24:06.488351 PROGRESS: 
+1:24:06.488351 PROGRESS: Protein Summary:
+1:24:06.494519 PROGRESS: Channel   0:	 0.05 FDR:   546; 0.01 FDR:   320; 0.001 FDR:   173
+1:24:06.494519 PROGRESS: =========================================================================
+1:24:06.504003 INFO: fragments_df_filtered: 1636
+1:24:06.999817 INFO: calibration group: precursor, fitting rt estimator 
+1:24:07.125365 INFO: calibration group: fragment, fitting mz estimator 
+1:24:07.684918 INFO: calibration group: precursor, predicting mz
+1:24:07.684918 WARNING: mz prediction was skipped as it has not been fitted yet
+1:24:07.684918 INFO: calibration group: precursor, predicting rt
+1:24:07.763613 INFO: calibration group: fragment, predicting mz
+1:24:08.135536 INFO: === checking if optimization conditions were reached ===
+1:24:08.136545 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+1:24:08.140079 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 520.3276.
+1:24:08.141086 INFO: ==============================================
+1:24:08.141086 INFO: Starting optimization step 2.
+1:24:08.141086 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:24:08.142334 PROGRESS: Extracting batch of 110601 precursors
+1:24:08.198770 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:24:08.198770 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:24:08.198770 INFO: FWHM in RT is 17.47 seconds, sigma is 0.64
+1:24:08.198770 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:24:08.198770 INFO: Starting candidate selection
+1:24:21.471167 INFO: Starting candidate scoring
+1:24:27.116098 INFO: Finished candidate processing
+1:24:27.116098 INFO: Collecting candidate features
+1:24:27.727679 WARNING: intensity_correlation has 373 NaNs ( 0.18 % out of 209478)
+1:24:27.775279 INFO: Collecting fragment features
+1:24:28.101812 INFO: Finished candidate scoring
+1:24:28.221884 PROGRESS: === Extracted 209478 precursors and 1252718 fragments ===
+1:24:28.221884 INFO: performing precursor FDR with 47 features
+1:24:28.221884 INFO: Decoy channel: -1
+1:24:28.221884 INFO: Competetive: True
+1:24:28.415296 WARNING: dropped 201 target PSMs due to missing features
+1:24:28.415296 WARNING: dropped 172 decoy PSMs due to missing features
+1:24:33.501785 INFO: Test AUC: 0.558
+1:24:33.501785 INFO: Train AUC: 0.576
+1:24:33.501785 INFO: AUC difference: 3.11%
+1:24:33.774554 INFO: === FDR correction performed with classifier version 5 ===
+1:24:33.774554 PROGRESS: ============================= Precursor FDR =============================
+1:24:33.774554 PROGRESS: Total precursors accumulated: 853
+1:24:33.774554 PROGRESS: Target precursors: 778 (91.21%)
+1:24:33.774554 PROGRESS: Decoy precursors: 75 (8.79%)
+1:24:33.774554 PROGRESS: 
+1:24:33.774554 PROGRESS: Precursor Summary:
+1:24:33.774554 PROGRESS: Channel   0:	 0.05 FDR:   645; 0.01 FDR:   352; 0.001 FDR:   301
+1:24:33.774554 PROGRESS: 
+1:24:33.774554 PROGRESS: Protein Summary:
+1:24:33.788976 PROGRESS: Channel   0:	 0.05 FDR:   606; 0.01 FDR:   332; 0.001 FDR:   286
+1:24:33.789829 PROGRESS: =========================================================================
+1:24:33.804706 INFO: fragments_df_filtered: 1643
+1:24:34.285712 INFO: calibration group: precursor, fitting rt estimator 
+1:24:34.429264 INFO: calibration group: fragment, fitting mz estimator 
+1:24:34.900528 INFO: calibration group: precursor, predicting mz
+1:24:34.900528 WARNING: mz prediction was skipped as it has not been fitted yet
+1:24:34.900528 INFO: calibration group: precursor, predicting rt
+1:24:34.967673 INFO: calibration group: fragment, predicting mz
+1:24:35.333462 INFO: === checking if optimization conditions were reached ===
+1:24:35.333462 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+1:24:35.349600 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 500.5970.
+1:24:35.349600 INFO: ==============================================
+1:24:35.349600 INFO: Starting optimization step 3.
+1:24:35.350602 PROGRESS: === Extracting elution groups 0 to 56000 ===
+1:24:35.350602 PROGRESS: Extracting batch of 110601 precursors
+1:24:35.411433 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:24:35.411433 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:24:35.411433 INFO: FWHM in RT is 17.45 seconds, sigma is 0.64
+1:24:35.411433 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:24:35.411433 INFO: Starting candidate selection
+1:24:47.439124 INFO: Starting candidate scoring
+1:24:54.119674 INFO: Finished candidate processing
+1:24:54.119674 INFO: Collecting candidate features
+1:24:54.851270 WARNING: intensity_correlation has 365 NaNs ( 0.18 % out of 207811)
+1:24:54.870045 INFO: Collecting fragment features
+1:24:55.124210 INFO: Finished candidate scoring
+1:24:55.361390 PROGRESS: === Extracted 207811 precursors and 1232237 fragments ===
+1:24:55.363384 INFO: performing precursor FDR with 47 features
+1:24:55.363384 INFO: Decoy channel: -1
+1:24:55.363384 INFO: Competetive: True
+1:24:55.609746 WARNING: dropped 187 target PSMs due to missing features
+1:24:55.609746 WARNING: dropped 178 decoy PSMs due to missing features
+1:25:01.724690 INFO: Test AUC: 0.558
+1:25:01.724690 INFO: Train AUC: 0.575
+1:25:01.724690 INFO: AUC difference: 3.04%
+1:25:01.965857 INFO: === FDR correction performed with classifier version 5 ===
+1:25:01.981680 PROGRESS: ============================= Precursor FDR =============================
+1:25:01.981680 PROGRESS: Total precursors accumulated: 807
+1:25:01.981680 PROGRESS: Target precursors: 737 (91.33%)
+1:25:01.981680 PROGRESS: Decoy precursors: 70 (8.67%)
+1:25:01.981680 PROGRESS: 
+1:25:01.981680 PROGRESS: Precursor Summary:
+1:25:01.981680 PROGRESS: Channel   0:	 0.05 FDR:   630; 0.01 FDR:   432; 0.001 FDR:   258
+1:25:01.981680 PROGRESS: 
+1:25:01.981680 PROGRESS: Protein Summary:
+1:25:01.981680 PROGRESS: Channel   0:	 0.05 FDR:   589; 0.01 FDR:   406; 0.001 FDR:   244
+1:25:01.981680 PROGRESS: =========================================================================
+1:25:01.997360 INFO: fragments_df_filtered: 1765
+1:25:02.430329 INFO: calibration group: precursor, fitting rt estimator 
+1:25:02.536738 INFO: calibration group: fragment, fitting mz estimator 
+1:25:03.561992 INFO: calibration group: precursor, predicting mz
+1:25:03.561992 WARNING: mz prediction was skipped as it has not been fitted yet
+1:25:03.561992 INFO: calibration group: precursor, predicting rt
+1:25:03.627571 INFO: calibration group: fragment, predicting mz
+1:25:03.963100 INFO: === checking if optimization conditions were reached ===
+1:25:03.963100 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+1:25:03.963100 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 500.5970 found after 4 searches.
+1:25:03.963100 INFO: ==============================================
+1:25:03.963100 PROGRESS: Optimization finished for rt_error.
+1:25:04.387970 INFO: calibration group: precursor, predicting mz
+1:25:04.388965 WARNING: mz prediction was skipped as it has not been fitted yet
+1:25:04.388965 INFO: calibration group: precursor, predicting rt
+1:25:04.458481 INFO: calibration group: fragment, predicting mz
+1:25:04.866998 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+1:25:04.867997 PROGRESS: ==============================================
+1:25:04.867997 PROGRESS: ms2_error      : 10.0000
+1:25:04.867997 PROGRESS: rt_error       : 500.5970
+1:25:04.867997 PROGRESS: ==============================================
+1:25:04.872611 INFO: calibration group: precursor, predicting mz
+1:25:04.872611 WARNING: mz prediction was skipped as it has not been fitted yet
+1:25:04.872611 INFO: calibration group: precursor, predicting rt
+1:25:12.092944 INFO: calibration group: fragment, predicting mz
+1:25:46.269877 PROGRESS: Extracting batch of 10640830 precursors
+1:25:49.025175 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+1:25:49.025175 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+1:25:49.025175 INFO: FWHM in RT is 17.40 seconds, sigma is 0.63
+1:25:49.025175 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+1:25:49.025175 INFO: Starting candidate selection
+1:52:10.054483 INFO: Applying score cutoff of 69.96586288452148
+1:52:11.072933 INFO: Removed 14741319 precursors with score below cutoff
+1:52:17.168040 INFO: Starting candidate scoring
+1:57:05.736297 INFO: Finished candidate processing
+1:57:05.736297 INFO: Collecting candidate features
+1:57:30.870845 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 6347656)
+1:57:31.730188 INFO: Collecting fragment features
+1:57:42.931040 INFO: Finished candidate scoring
+1:57:54.876776 INFO: === FDR correction performed with classifier version 9 ===
+1:57:54.876776 INFO: performing precursor FDR with 47 features
+1:57:54.876776 INFO: Decoy channel: -1
+1:57:54.876776 INFO: Competetive: True
+1:58:02.280416 WARNING: dropped 1 decoy PSMs due to missing features
+2:01:45.035381 INFO: Test AUC: 0.583
+2:01:45.035381 INFO: Train AUC: 0.586
+2:01:45.035381 INFO: AUC difference: 0.48%
+2:01:46.128181 INFO: Removing fragments below FDR threshold
+2:01:47.168574 PROGRESS: ============================= Precursor FDR =============================
+2:01:47.168574 PROGRESS: Total precursors accumulated: 52,899
+2:01:47.168574 PROGRESS: Target precursors: 52,376 (99.01%)
+2:01:47.168574 PROGRESS: Decoy precursors: 523 (0.99%)
+2:01:47.168574 PROGRESS: 
+2:01:47.168574 PROGRESS: Precursor Summary:
+2:01:47.222775 PROGRESS: Channel   0:	 0.05 FDR: 52,376; 0.01 FDR: 52,376; 0.001 FDR: 35,431
+2:01:47.222775 PROGRESS: 
+2:01:47.222775 PROGRESS: Protein Summary:
+2:01:47.333078 PROGRESS: Channel   0:	 0.05 FDR: 8,884; 0.01 FDR: 8,884; 0.001 FDR: 6,691
+2:01:47.333078 PROGRESS: =========================================================================
+2:01:49.048861 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+2:01:50.908121 PROGRESS: Loading raw file 2/6: LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+2:01:50.908121 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+2:03:01.674623 INFO: Determining DIA cycle
+2:03:01.705871 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+2:03:01.721494 INFO: Determining DIA cycle
+2:03:01.755455 INFO: Found cycle with start 0.00 min and length 151.
+2:03:01.942229 INFO: ============ Raw file stats ============
+2:03:01.942229 INFO: RT (min)            : 0.0 - 150.0
+2:03:01.942229 INFO: RT duration (sec)   : 8999.7
+2:03:01.942229 INFO: RT duration (min)   : 150.0
+2:03:01.942229 INFO: Cycle len (scans)   : 151
+2:03:01.942229 INFO: Cycle len (sec)     : 5.84
+2:03:01.942229 INFO: Number of cycles    : 1542
+2:03:01.942229 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+2:03:01.942229 INFO: ========================================
+2:03:10.138680 INFO: Initializing CalibrationManager
+2:03:10.138680 INFO: Loading calibration config
+2:03:10.138680 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated'], 'function': LOESSRegression()}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated'], 'function': LOESSRegression(n_kernels=2)}]}]
+2:03:10.138680 INFO: Calibration group :fragment, found 1 estimator(s)
+2:03:10.138680 INFO: Calibration group :precursor, found 3 estimator(s)
+2:03:10.138680 INFO: Disabling ion mobility calibration
+2:03:10.138680 INFO: removed mobility estimator from group precursor
+2:03:10.138680 INFO: Initializing OptimizationManager
+2:03:10.138680 INFO: initial parameter: ms1_error = 30
+2:03:10.138680 INFO: initial parameter: ms2_error = 30
+2:03:10.138680 INFO: initial parameter: rt_error = 4499.99560546875
+2:03:10.138680 INFO: initial parameter: mobility_error = 0.1
+2:03:10.138680 INFO: initial parameter: column_type = library
+2:03:10.138680 INFO: initial parameter: num_candidates = 1
+2:03:10.154323 INFO: initial parameter: classifier_version = -1
+2:03:10.154323 INFO: initial parameter: fwhm_rt = 5
+2:03:10.154834 INFO: initial parameter: fwhm_mobility = 0.01
+2:03:10.154834 INFO: initial parameter: score_cutoff = 0
+2:03:10.154834 INFO: Initializing TimingManager
+2:03:10.154834 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+2:03:10.154834 INFO: Initializing FDRManager
+2:03:10.154834 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+2:03:13.442248 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+2:03:18.175461 PROGRESS: Starting initial search for precursors.
+2:03:18.918153 INFO: Starting optimization step 0.
+2:03:18.918153 PROGRESS: === Extracting elution groups 0 to 8000 ===
+2:03:18.918153 PROGRESS: Extracting batch of 15803 precursors
+2:03:18.937533 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:03:18.937533 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:03:18.937533 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:03:18.937533 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:03:18.937533 INFO: Starting candidate selection
+2:03:31.141790 INFO: Starting candidate scoring
+2:03:31.812359 INFO: Finished candidate processing
+2:03:31.812359 INFO: Collecting candidate features
+2:03:31.918563 INFO: Collecting fragment features
+2:03:31.978198 INFO: Finished candidate scoring
+2:03:31.999165 PROGRESS: === Extracted 15796 precursors and 140309 fragments ===
+2:03:31.999165 INFO: performing precursor FDR with 47 features
+2:03:31.999165 INFO: Decoy channel: -1
+2:03:31.999165 INFO: Competetive: True
+2:03:32.491536 INFO: Test AUC: 0.491
+2:03:32.491536 INFO: Train AUC: 0.500
+2:03:32.491536 INFO: AUC difference: 1.82%
+2:03:32.724079 INFO: === FDR correction performed with classifier version -1 ===
+2:03:32.724079 PROGRESS: ============================= Precursor FDR =============================
+2:03:32.724079 PROGRESS: Total precursors accumulated: 2
+2:03:32.724079 PROGRESS: Target precursors: 2 (100.00%)
+2:03:32.724079 PROGRESS: Decoy precursors: 0 (0.00%)
+2:03:32.724079 PROGRESS: 
+2:03:32.724079 PROGRESS: Precursor Summary:
+2:03:32.724079 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+2:03:32.724079 PROGRESS: 
+2:03:32.724079 PROGRESS: Protein Summary:
+2:03:32.724079 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+2:03:32.724079 PROGRESS: =========================================================================
+2:03:33.000341 INFO: Starting optimization step 1.
+2:03:33.000341 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+2:03:33.000341 PROGRESS: Extracting batch of 31592 precursors
+2:03:33.039293 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:03:33.039293 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:03:33.039293 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:03:33.039293 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:03:33.039293 INFO: Starting candidate selection
+2:03:58.279043 INFO: Starting candidate scoring
+2:03:59.837951 INFO: Finished candidate processing
+2:03:59.837951 INFO: Collecting candidate features
+2:04:00.070784 INFO: Collecting fragment features
+2:04:00.165389 INFO: Finished candidate scoring
+2:04:00.259617 PROGRESS: === Extracted 47346 precursors and 421538 fragments ===
+2:04:00.276317 INFO: performing precursor FDR with 47 features
+2:04:00.276317 INFO: Decoy channel: -1
+2:04:00.276317 INFO: Competetive: True
+2:04:01.855734 INFO: Test AUC: 0.542
+2:04:01.855734 INFO: Train AUC: 0.550
+2:04:01.855734 INFO: AUC difference: 1.45%
+2:04:02.091687 INFO: === FDR correction performed with classifier version -1 ===
+2:04:02.091687 PROGRESS: ============================= Precursor FDR =============================
+2:04:02.091687 PROGRESS: Total precursors accumulated: 1
+2:04:02.091687 PROGRESS: Target precursors: 1 (100.00%)
+2:04:02.091687 PROGRESS: Decoy precursors: 0 (0.00%)
+2:04:02.091687 PROGRESS: 
+2:04:02.091687 PROGRESS: Precursor Summary:
+2:04:02.091687 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+2:04:02.091687 PROGRESS: 
+2:04:02.091687 PROGRESS: Protein Summary:
+2:04:02.107348 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+2:04:02.107348 PROGRESS: =========================================================================
+2:04:02.471232 INFO: Starting optimization step 2.
+2:04:02.471232 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+2:04:02.471232 PROGRESS: Extracting batch of 63206 precursors
+2:04:02.525296 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:04:02.525296 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:04:02.525296 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:04:02.525296 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:04:02.525296 INFO: Starting candidate selection
+2:04:51.937980 INFO: Starting candidate scoring
+2:04:54.697021 INFO: Finished candidate processing
+2:04:54.697021 INFO: Collecting candidate features
+2:04:55.033960 INFO: Collecting fragment features
+2:04:55.221335 INFO: Finished candidate scoring
+2:04:55.426382 PROGRESS: === Extracted 110503 precursors and 985014 fragments ===
+2:04:55.473818 INFO: performing precursor FDR with 47 features
+2:04:55.473818 INFO: Decoy channel: -1
+2:04:55.473818 INFO: Competetive: True
+2:04:59.245520 INFO: Test AUC: 0.562
+2:04:59.245520 INFO: Train AUC: 0.568
+2:04:59.245520 INFO: AUC difference: 0.97%
+2:04:59.481654 INFO: === FDR correction performed with classifier version -1 ===
+2:04:59.481654 PROGRESS: ============================= Precursor FDR =============================
+2:04:59.481654 PROGRESS: Total precursors accumulated: 143
+2:04:59.481654 PROGRESS: Target precursors: 131 (91.61%)
+2:04:59.481654 PROGRESS: Decoy precursors: 12 (8.39%)
+2:04:59.481654 PROGRESS: 
+2:04:59.481654 PROGRESS: Precursor Summary:
+2:04:59.481654 PROGRESS: Channel   0:	 0.05 FDR:    25; 0.01 FDR:    19; 0.001 FDR:    19
+2:04:59.481654 PROGRESS: 
+2:04:59.481654 PROGRESS: Protein Summary:
+2:04:59.492886 PROGRESS: Channel   0:	 0.05 FDR:    25; 0.01 FDR:    19; 0.001 FDR:    19
+2:04:59.492886 PROGRESS: =========================================================================
+2:05:00.048480 INFO: Starting optimization step 3.
+2:05:00.048480 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+2:05:00.048480 PROGRESS: Extracting batch of 126403 precursors
+2:05:00.127373 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:05:00.127373 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:05:00.127373 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:05:00.127373 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:05:00.127373 INFO: Starting candidate selection
+2:06:26.172458 INFO: Starting candidate scoring
+2:06:31.806249 INFO: Finished candidate processing
+2:06:31.806249 INFO: Collecting candidate features
+2:06:32.405901 INFO: Collecting fragment features
+2:06:32.657711 INFO: Finished candidate scoring
+2:06:33.019262 PROGRESS: === Extracted 236800 precursors and 2111207 fragments ===
+2:06:33.097791 INFO: performing precursor FDR with 47 features
+2:06:33.097791 INFO: Decoy channel: -1
+2:06:33.097791 INFO: Competetive: True
+2:06:41.730662 INFO: Test AUC: 0.569
+2:06:41.730662 INFO: Train AUC: 0.578
+2:06:41.730662 INFO: AUC difference: 1.56%
+2:06:42.029625 INFO: === FDR correction performed with classifier version -1 ===
+2:06:42.029625 PROGRESS: ============================= Precursor FDR =============================
+2:06:42.029625 PROGRESS: Total precursors accumulated: 1,016
+2:06:42.029625 PROGRESS: Target precursors: 927 (91.24%)
+2:06:42.029625 PROGRESS: Decoy precursors: 89 (8.76%)
+2:06:42.029625 PROGRESS: 
+2:06:42.029625 PROGRESS: Precursor Summary:
+2:06:42.045245 PROGRESS: Channel   0:	 0.05 FDR:   749; 0.01 FDR:   367; 0.001 FDR:   247
+2:06:42.045245 PROGRESS: 
+2:06:42.045245 PROGRESS: Protein Summary:
+2:06:42.045245 PROGRESS: Channel   0:	 0.05 FDR:   658; 0.01 FDR:   336; 0.001 FDR:   234
+2:06:42.045245 PROGRESS: =========================================================================
+2:06:42.108503 INFO: fragments_df_filtered: 3227
+2:06:43.192472 INFO: calibration group: precursor, fitting rt estimator 
+2:06:43.350299 INFO: calibration group: fragment, fitting mz estimator 
+2:06:45.035289 INFO: calibration group: precursor, predicting mz
+2:06:45.035289 WARNING: mz prediction was skipped as it has not been fitted yet
+2:06:45.035289 INFO: calibration group: precursor, predicting rt
+2:06:45.239750 INFO: calibration group: fragment, predicting mz
+2:06:46.121083 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+2:06:46.121083 INFO: Starting optimization step 4.
+2:06:46.121083 PROGRESS: === Extracting elution groups 0 to 120000 ===
+2:06:46.134742 PROGRESS: Extracting batch of 237004 precursors
+2:06:46.262448 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:06:46.262448 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:06:46.262448 INFO: FWHM in RT is 20.21 seconds, sigma is 0.74
+2:06:46.262448 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:06:46.262448 INFO: Starting candidate selection
+2:08:17.923274 INFO: Starting candidate scoring
+2:08:28.441115 INFO: Finished candidate processing
+2:08:28.441115 INFO: Collecting candidate features
+2:08:29.778857 WARNING: intensity_correlation has 6 NaNs ( 0.00 % out of 473647)
+2:08:29.835404 INFO: Collecting fragment features
+2:08:30.436568 INFO: Finished candidate scoring
+2:08:30.839572 PROGRESS: === Extracted 473647 precursors and 4352329 fragments ===
+2:08:30.839572 INFO: performing precursor FDR with 47 features
+2:08:30.839572 INFO: Decoy channel: -1
+2:08:30.839572 INFO: Competetive: True
+2:08:31.294593 WARNING: dropped 2 target PSMs due to missing features
+2:08:31.294593 WARNING: dropped 4 decoy PSMs due to missing features
+2:08:40.042972 INFO: Test AUC: 0.575
+2:08:40.042972 INFO: Train AUC: 0.581
+2:08:40.042972 INFO: AUC difference: 1.04%
+2:08:40.460223 INFO: === FDR correction performed with classifier version 3 ===
+2:08:40.475853 PROGRESS: ============================= Precursor FDR =============================
+2:08:40.475853 PROGRESS: Total precursors accumulated: 1,168
+2:08:40.475853 PROGRESS: Target precursors: 1,063 (91.01%)
+2:08:40.475853 PROGRESS: Decoy precursors: 105 (8.99%)
+2:08:40.475853 PROGRESS: 
+2:08:40.475853 PROGRESS: Precursor Summary:
+2:08:40.491469 PROGRESS: Channel   0:	 0.05 FDR:   868; 0.01 FDR:   570; 0.001 FDR:   451
+2:08:40.491469 PROGRESS: 
+2:08:40.491469 PROGRESS: Protein Summary:
+2:08:40.507257 PROGRESS: Channel   0:	 0.05 FDR:   757; 0.01 FDR:   512; 0.001 FDR:   406
+2:08:40.507257 PROGRESS: =========================================================================
+2:08:40.554797 INFO: fragments_df_filtered: 4144
+2:08:41.473337 INFO: calibration group: precursor, fitting rt estimator 
+2:08:41.713737 INFO: calibration group: fragment, fitting mz estimator 
+2:08:45.747713 INFO: calibration group: precursor, predicting mz
+2:08:45.748411 WARNING: mz prediction was skipped as it has not been fitted yet
+2:08:45.748411 INFO: calibration group: precursor, predicting rt
+2:08:45.814733 INFO: calibration group: fragment, predicting mz
+2:08:46.423709 INFO: === checking if optimization conditions were reached ===
+2:08:46.423709 PROGRESS: ❌ ms2_error      : 10.1500 > 10.0000 or insufficient steps taken.
+2:08:46.423709 INFO: ==============================================
+2:08:46.423709 INFO: Starting optimization step 5.
+2:08:46.423709 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:08:46.423709 PROGRESS: Extracting batch of 110601 precursors
+2:08:46.587834 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:08:46.589089 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:08:46.589089 INFO: FWHM in RT is 20.62 seconds, sigma is 0.75
+2:08:46.589089 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:08:46.589089 INFO: Starting candidate selection
+2:10:22.108122 INFO: Starting candidate scoring
+2:10:30.371129 INFO: Finished candidate processing
+2:10:30.371129 INFO: Collecting candidate features
+2:10:31.014343 WARNING: intensity_correlation has 22 NaNs ( 0.01 % out of 220947)
+2:10:31.046659 INFO: Collecting fragment features
+2:10:31.333012 INFO: Finished candidate scoring
+2:10:31.522504 PROGRESS: === Extracted 220947 precursors and 1711763 fragments ===
+2:10:31.522504 INFO: performing precursor FDR with 47 features
+2:10:31.522504 INFO: Decoy channel: -1
+2:10:31.522504 INFO: Competetive: True
+2:10:31.761610 WARNING: dropped 9 target PSMs due to missing features
+2:10:31.761610 WARNING: dropped 13 decoy PSMs due to missing features
+2:10:36.624278 INFO: Test AUC: 0.573
+2:10:36.624278 INFO: Train AUC: 0.587
+2:10:36.624278 INFO: AUC difference: 2.44%
+2:10:36.844455 INFO: === FDR correction performed with classifier version 4 ===
+2:10:36.860048 PROGRESS: ============================= Precursor FDR =============================
+2:10:36.860048 PROGRESS: Total precursors accumulated: 604
+2:10:36.860048 PROGRESS: Target precursors: 549 (90.89%)
+2:10:36.860048 PROGRESS: Decoy precursors: 55 (9.11%)
+2:10:36.860048 PROGRESS: 
+2:10:36.860048 PROGRESS: Precursor Summary:
+2:10:36.860048 PROGRESS: Channel   0:	 0.05 FDR:   451; 0.01 FDR:   324; 0.001 FDR:   180
+2:10:36.860048 PROGRESS: 
+2:10:36.860048 PROGRESS: Protein Summary:
+2:10:36.860048 PROGRESS: Channel   0:	 0.05 FDR:   425; 0.01 FDR:   306; 0.001 FDR:   175
+2:10:36.860048 PROGRESS: =========================================================================
+2:10:36.875674 INFO: fragments_df_filtered: 1619
+2:10:37.252969 INFO: calibration group: precursor, fitting rt estimator 
+2:10:37.362907 INFO: calibration group: fragment, fitting mz estimator 
+2:10:38.056051 INFO: calibration group: precursor, predicting mz
+2:10:38.056051 WARNING: mz prediction was skipped as it has not been fitted yet
+2:10:38.056051 INFO: calibration group: precursor, predicting rt
+2:10:38.150664 INFO: calibration group: fragment, predicting mz
+2:10:38.574984 INFO: === checking if optimization conditions were reached ===
+2:10:38.574984 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+2:10:38.590610 INFO: ==============================================
+2:10:38.590610 PROGRESS: Optimization finished for ms2_error.
+2:10:39.380034 INFO: calibration group: precursor, predicting mz
+2:10:39.380034 WARNING: mz prediction was skipped as it has not been fitted yet
+2:10:39.380034 INFO: calibration group: precursor, predicting rt
+2:10:39.538291 INFO: calibration group: fragment, predicting mz
+2:10:40.041978 INFO: Starting optimization step 0.
+2:10:40.041978 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:10:40.041978 PROGRESS: Extracting batch of 110601 precursors
+2:10:40.168228 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:10:40.168228 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:10:40.168228 INFO: FWHM in RT is 18.20 seconds, sigma is 0.66
+2:10:40.168228 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:10:40.168228 INFO: Starting candidate selection
+2:12:18.765261 INFO: Starting candidate scoring
+2:12:25.174484 INFO: Finished candidate processing
+2:12:25.174484 INFO: Collecting candidate features
+2:12:25.850080 WARNING: intensity_correlation has 14 NaNs ( 0.01 % out of 220946)
+2:12:25.881338 INFO: Collecting fragment features
+2:12:26.196555 INFO: Finished candidate scoring
+2:12:26.369022 PROGRESS: === Extracted 220946 precursors and 1702594 fragments ===
+2:12:26.369022 INFO: performing precursor FDR with 47 features
+2:12:26.369022 INFO: Decoy channel: -1
+2:12:26.369022 INFO: Competetive: True
+2:12:26.635855 WARNING: dropped 6 target PSMs due to missing features
+2:12:26.635855 WARNING: dropped 8 decoy PSMs due to missing features
+2:12:31.591030 INFO: Test AUC: 0.583
+2:12:31.591030 INFO: Train AUC: 0.591
+2:12:31.591030 INFO: AUC difference: 1.36%
+2:12:32.600269 INFO: === FDR correction performed with classifier version 5 ===
+2:12:32.600269 PROGRESS: ============================= Precursor FDR =============================
+2:12:32.600269 PROGRESS: Total precursors accumulated: 659
+2:12:32.600269 PROGRESS: Target precursors: 598 (90.74%)
+2:12:32.600269 PROGRESS: Decoy precursors: 61 (9.26%)
+2:12:32.600269 PROGRESS: 
+2:12:32.600269 PROGRESS: Precursor Summary:
+2:12:32.615895 PROGRESS: Channel   0:	 0.05 FDR:   473; 0.01 FDR:   372; 0.001 FDR:   237
+2:12:32.615895 PROGRESS: 
+2:12:32.615895 PROGRESS: Protein Summary:
+2:12:32.615895 PROGRESS: Channel   0:	 0.05 FDR:   446; 0.01 FDR:   349; 0.001 FDR:   228
+2:12:32.615895 PROGRESS: =========================================================================
+2:12:32.642576 INFO: fragments_df_filtered: 1643
+2:12:33.071856 INFO: calibration group: precursor, fitting rt estimator 
+2:12:33.182584 INFO: calibration group: fragment, fitting mz estimator 
+2:12:33.967939 INFO: calibration group: precursor, predicting mz
+2:12:33.967939 WARNING: mz prediction was skipped as it has not been fitted yet
+2:12:33.967939 INFO: calibration group: precursor, predicting rt
+2:12:34.062384 INFO: calibration group: fragment, predicting mz
+2:12:34.518653 INFO: === checking if optimization conditions were reached ===
+2:12:34.518653 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+2:12:34.534564 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 616.7899.
+2:12:34.534564 INFO: ==============================================
+2:12:34.534564 INFO: Starting optimization step 1.
+2:12:34.534564 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:12:34.534564 PROGRESS: Extracting batch of 110601 precursors
+2:12:34.629494 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:12:34.631176 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:12:34.631176 INFO: FWHM in RT is 18.01 seconds, sigma is 0.66
+2:12:34.631176 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:12:34.631745 INFO: Starting candidate selection
+2:12:53.848276 INFO: Starting candidate scoring
+2:13:02.536511 INFO: Finished candidate processing
+2:13:02.536511 INFO: Collecting candidate features
+2:13:04.098637 WARNING: intensity_correlation has 319 NaNs ( 0.15 % out of 212354)
+2:13:04.177221 INFO: Collecting fragment features
+2:13:04.903215 INFO: Finished candidate scoring
+2:13:05.579458 PROGRESS: === Extracted 212354 precursors and 1380531 fragments ===
+2:13:05.579458 INFO: performing precursor FDR with 47 features
+2:13:05.579458 INFO: Decoy channel: -1
+2:13:05.579458 INFO: Competetive: True
+2:13:06.399449 WARNING: dropped 171 target PSMs due to missing features
+2:13:06.399449 WARNING: dropped 148 decoy PSMs due to missing features
+2:13:11.586009 INFO: Test AUC: 0.561
+2:13:11.586009 INFO: Train AUC: 0.576
+2:13:11.586009 INFO: AUC difference: 2.59%
+2:13:11.903570 INFO: === FDR correction performed with classifier version 5 ===
+2:13:11.903570 PROGRESS: ============================= Precursor FDR =============================
+2:13:11.903570 PROGRESS: Total precursors accumulated: 718
+2:13:11.903570 PROGRESS: Target precursors: 652 (90.81%)
+2:13:11.903570 PROGRESS: Decoy precursors: 66 (9.19%)
+2:13:11.903570 PROGRESS: 
+2:13:11.903570 PROGRESS: Precursor Summary:
+2:13:11.918773 PROGRESS: Channel   0:	 0.05 FDR:   546; 0.01 FDR:   408; 0.001 FDR:   355
+2:13:11.918773 PROGRESS: 
+2:13:11.918773 PROGRESS: Protein Summary:
+2:13:11.918773 PROGRESS: Channel   0:	 0.05 FDR:   512; 0.01 FDR:   382; 0.001 FDR:   334
+2:13:11.918773 PROGRESS: =========================================================================
+2:13:11.934414 INFO: fragments_df_filtered: 1719
+2:13:12.532176 INFO: calibration group: precursor, fitting rt estimator 
+2:13:12.690152 INFO: calibration group: fragment, fitting mz estimator 
+2:13:13.396335 INFO: calibration group: precursor, predicting mz
+2:13:13.396335 WARNING: mz prediction was skipped as it has not been fitted yet
+2:13:13.396335 INFO: calibration group: precursor, predicting rt
+2:13:13.490582 INFO: calibration group: fragment, predicting mz
+2:13:13.947776 INFO: === checking if optimization conditions were reached ===
+2:13:13.947776 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+2:13:13.947776 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 478.0389.
+2:13:13.947776 INFO: ==============================================
+2:13:13.963874 INFO: Starting optimization step 2.
+2:13:13.963874 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:13:13.963874 PROGRESS: Extracting batch of 110601 precursors
+2:13:14.027267 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:13:14.027267 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:13:14.027267 INFO: FWHM in RT is 18.11 seconds, sigma is 0.66
+2:13:14.027267 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:13:14.027267 INFO: Starting candidate selection
+2:13:26.287827 INFO: Starting candidate scoring
+2:13:31.940816 INFO: Finished candidate processing
+2:13:31.940816 INFO: Collecting candidate features
+2:13:33.231195 WARNING: intensity_correlation has 327 NaNs ( 0.16 % out of 209741)
+2:13:33.294163 INFO: Collecting fragment features
+2:13:33.894866 INFO: Finished candidate scoring
+2:13:34.474196 PROGRESS: === Extracted 209741 precursors and 1332321 fragments ===
+2:13:34.474196 INFO: performing precursor FDR with 47 features
+2:13:34.474196 INFO: Decoy channel: -1
+2:13:34.474196 INFO: Competetive: True
+2:13:35.205683 WARNING: dropped 169 target PSMs due to missing features
+2:13:35.205683 WARNING: dropped 158 decoy PSMs due to missing features
+2:13:44.641085 INFO: Test AUC: 0.562
+2:13:44.641085 INFO: Train AUC: 0.575
+2:13:44.641085 INFO: AUC difference: 2.33%
+2:13:45.163182 INFO: === FDR correction performed with classifier version 5 ===
+2:13:45.163182 PROGRESS: ============================= Precursor FDR =============================
+2:13:45.178843 PROGRESS: Total precursors accumulated: 747
+2:13:45.178843 PROGRESS: Target precursors: 680 (91.03%)
+2:13:45.178843 PROGRESS: Decoy precursors: 67 (8.97%)
+2:13:45.178843 PROGRESS: 
+2:13:45.178843 PROGRESS: Precursor Summary:
+2:13:45.182360 PROGRESS: Channel   0:	 0.05 FDR:   583; 0.01 FDR:   357; 0.001 FDR:   298
+2:13:45.182360 PROGRESS: 
+2:13:45.182360 PROGRESS: Protein Summary:
+2:13:45.194874 PROGRESS: Channel   0:	 0.05 FDR:   548; 0.01 FDR:   334; 0.001 FDR:   281
+2:13:45.198667 PROGRESS: =========================================================================
+2:13:45.228983 INFO: fragments_df_filtered: 1686
+2:13:46.442679 INFO: calibration group: precursor, fitting rt estimator 
+2:13:46.662599 INFO: calibration group: fragment, fitting mz estimator 
+2:13:47.496365 INFO: calibration group: precursor, predicting mz
+2:13:47.496365 WARNING: mz prediction was skipped as it has not been fitted yet
+2:13:47.496365 INFO: calibration group: precursor, predicting rt
+2:13:47.669635 INFO: calibration group: fragment, predicting mz
+2:13:48.268807 INFO: === checking if optimization conditions were reached ===
+2:13:48.268807 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+2:13:48.284508 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 450.0291.
+2:13:48.284508 INFO: ==============================================
+2:13:48.284508 INFO: Starting optimization step 3.
+2:13:48.284508 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:13:48.284508 PROGRESS: Extracting batch of 110601 precursors
+2:13:48.442340 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:13:48.442340 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:13:48.442340 INFO: FWHM in RT is 18.01 seconds, sigma is 0.66
+2:13:48.442340 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:13:48.442340 INFO: Starting candidate selection
+2:14:03.283301 INFO: Starting candidate scoring
+2:14:10.054238 INFO: Finished candidate processing
+2:14:10.054238 INFO: Collecting candidate features
+2:14:10.905416 WARNING: intensity_correlation has 345 NaNs ( 0.16 % out of 209231)
+2:14:10.936735 INFO: Collecting fragment features
+2:14:11.204246 INFO: Finished candidate scoring
+2:14:11.393418 PROGRESS: === Extracted 209231 precursors and 1316575 fragments ===
+2:14:11.393418 INFO: performing precursor FDR with 47 features
+2:14:11.393418 INFO: Decoy channel: -1
+2:14:11.393418 INFO: Competetive: True
+2:14:11.645104 WARNING: dropped 176 target PSMs due to missing features
+2:14:11.645104 WARNING: dropped 169 decoy PSMs due to missing features
+2:14:16.699426 INFO: Test AUC: 0.556
+2:14:16.699426 INFO: Train AUC: 0.578
+2:14:16.699426 INFO: AUC difference: 3.76%
+2:14:16.949385 INFO: === FDR correction performed with classifier version 5 ===
+2:14:16.949385 PROGRESS: ============================= Precursor FDR =============================
+2:14:16.949385 PROGRESS: Total precursors accumulated: 798
+2:14:16.949385 PROGRESS: Target precursors: 726 (90.98%)
+2:14:16.949385 PROGRESS: Decoy precursors: 72 (9.02%)
+2:14:16.949385 PROGRESS: 
+2:14:16.949385 PROGRESS: Precursor Summary:
+2:14:16.949385 PROGRESS: Channel   0:	 0.05 FDR:   612; 0.01 FDR:   328; 0.001 FDR:   272
+2:14:16.949385 PROGRESS: 
+2:14:16.949385 PROGRESS: Protein Summary:
+2:14:16.949385 PROGRESS: Channel   0:	 0.05 FDR:   574; 0.01 FDR:   306; 0.001 FDR:   258
+2:14:16.949385 PROGRESS: =========================================================================
+2:14:16.964456 INFO: fragments_df_filtered: 1671
+2:14:17.386804 INFO: calibration group: precursor, fitting rt estimator 
+2:14:17.503860 INFO: calibration group: fragment, fitting mz estimator 
+2:14:18.296626 INFO: calibration group: precursor, predicting mz
+2:14:18.296626 WARNING: mz prediction was skipped as it has not been fitted yet
+2:14:18.296626 INFO: calibration group: precursor, predicting rt
+2:14:18.386602 INFO: calibration group: fragment, predicting mz
+2:14:18.709568 INFO: === checking if optimization conditions were reached ===
+2:14:18.709568 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+2:14:18.709568 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 445.7574.
+2:14:18.709568 INFO: ==============================================
+2:14:18.709568 INFO: Starting optimization step 4.
+2:14:18.709568 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:14:18.709568 PROGRESS: Extracting batch of 110601 precursors
+2:14:18.741224 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:14:18.741224 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:14:18.741224 INFO: FWHM in RT is 18.08 seconds, sigma is 0.66
+2:14:18.741224 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:14:18.741224 INFO: Starting candidate selection
+2:14:27.023797 INFO: Starting candidate scoring
+2:14:32.173709 INFO: Finished candidate processing
+2:14:32.173709 INFO: Collecting candidate features
+2:14:32.786890 WARNING: intensity_correlation has 343 NaNs ( 0.16 % out of 209179)
+2:14:32.799869 INFO: Collecting fragment features
+2:14:33.060686 INFO: Finished candidate scoring
+2:14:33.250425 PROGRESS: === Extracted 209179 precursors and 1316467 fragments ===
+2:14:33.250425 INFO: performing precursor FDR with 47 features
+2:14:33.250425 INFO: Decoy channel: -1
+2:14:33.250425 INFO: Competetive: True
+2:14:33.457133 WARNING: dropped 178 target PSMs due to missing features
+2:14:33.457133 WARNING: dropped 165 decoy PSMs due to missing features
+2:14:38.105697 INFO: Test AUC: 0.556
+2:14:38.105697 INFO: Train AUC: 0.576
+2:14:38.105697 INFO: AUC difference: 3.60%
+2:14:38.304954 INFO: === FDR correction performed with classifier version 5 ===
+2:14:38.320572 PROGRESS: ============================= Precursor FDR =============================
+2:14:38.320572 PROGRESS: Total precursors accumulated: 781
+2:14:38.320572 PROGRESS: Target precursors: 711 (91.04%)
+2:14:38.320572 PROGRESS: Decoy precursors: 70 (8.96%)
+2:14:38.320572 PROGRESS: 
+2:14:38.320572 PROGRESS: Precursor Summary:
+2:14:38.320572 PROGRESS: Channel   0:	 0.05 FDR:   606; 0.01 FDR:   405; 0.001 FDR:   360
+2:14:38.320572 PROGRESS: 
+2:14:38.320572 PROGRESS: Protein Summary:
+2:14:38.324122 PROGRESS: Channel   0:	 0.05 FDR:   571; 0.01 FDR:   379; 0.001 FDR:   336
+2:14:38.324122 PROGRESS: =========================================================================
+2:14:38.324122 INFO: fragments_df_filtered: 1700
+2:14:38.686683 INFO: calibration group: precursor, fitting rt estimator 
+2:14:38.813539 INFO: calibration group: fragment, fitting mz estimator 
+2:14:39.528058 INFO: calibration group: precursor, predicting mz
+2:14:39.528058 WARNING: mz prediction was skipped as it has not been fitted yet
+2:14:39.528058 INFO: calibration group: precursor, predicting rt
+2:14:39.621825 INFO: calibration group: fragment, predicting mz
+2:14:39.983060 INFO: === checking if optimization conditions were reached ===
+2:14:39.983060 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+2:14:39.983060 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 445.7574 found after 5 searches.
+2:14:39.983060 INFO: ==============================================
+2:14:39.983060 PROGRESS: Optimization finished for rt_error.
+2:14:40.333027 INFO: calibration group: precursor, predicting mz
+2:14:40.333027 WARNING: mz prediction was skipped as it has not been fitted yet
+2:14:40.333027 INFO: calibration group: precursor, predicting rt
+2:14:40.408353 INFO: calibration group: fragment, predicting mz
+2:14:40.618638 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+2:14:40.618638 PROGRESS: ==============================================
+2:14:40.618638 PROGRESS: ms2_error      : 10.0000
+2:14:40.618638 PROGRESS: rt_error       : 445.7574
+2:14:40.618638 PROGRESS: ==============================================
+2:14:40.662638 INFO: calibration group: precursor, predicting mz
+2:14:40.662638 WARNING: mz prediction was skipped as it has not been fitted yet
+2:14:40.662638 INFO: calibration group: precursor, predicting rt
+2:14:44.998484 INFO: calibration group: fragment, predicting mz
+2:15:15.605464 PROGRESS: Extracting batch of 10640830 precursors
+2:15:18.000052 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:15:18.000052 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:15:18.000052 INFO: FWHM in RT is 18.12 seconds, sigma is 0.66
+2:15:18.000052 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:15:18.000052 INFO: Starting candidate selection
+2:34:20.994321 INFO: Applying score cutoff of 80.17851248168945
+2:34:21.715071 INFO: Removed 16341084 precursors with score below cutoff
+2:34:27.262132 INFO: Starting candidate scoring
+2:37:51.023457 INFO: Finished candidate processing
+2:37:51.023457 INFO: Collecting candidate features
+2:38:11.456198 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 4673523)
+2:38:12.346627 INFO: Collecting fragment features
+2:38:23.445028 INFO: Finished candidate scoring
+2:38:34.419601 INFO: === FDR correction performed with classifier version 10 ===
+2:38:34.419601 INFO: performing precursor FDR with 47 features
+2:38:34.419601 INFO: Decoy channel: -1
+2:38:34.419601 INFO: Competetive: True
+2:38:40.910322 WARNING: dropped 1 target PSMs due to missing features
+2:42:35.239322 INFO: Test AUC: 0.583
+2:42:35.239322 INFO: Train AUC: 0.586
+2:42:35.239322 INFO: AUC difference: 0.48%
+2:42:36.418108 INFO: Removing fragments below FDR threshold
+2:42:37.420982 PROGRESS: ============================= Precursor FDR =============================
+2:42:37.420982 PROGRESS: Total precursors accumulated: 53,302
+2:42:37.420982 PROGRESS: Target precursors: 52,775 (99.01%)
+2:42:37.420982 PROGRESS: Decoy precursors: 527 (0.99%)
+2:42:37.421979 PROGRESS: 
+2:42:37.421979 PROGRESS: Precursor Summary:
+2:42:37.499670 PROGRESS: Channel   0:	 0.05 FDR: 52,775; 0.01 FDR: 52,775; 0.001 FDR: 33,705
+2:42:37.499670 PROGRESS: 
+2:42:37.500660 PROGRESS: Protein Summary:
+2:42:37.603189 PROGRESS: Channel   0:	 0.05 FDR: 8,907; 0.01 FDR: 8,907; 0.001 FDR: 6,512
+2:42:37.603189 PROGRESS: =========================================================================
+2:42:39.228438 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+2:42:41.388493 PROGRESS: Loading raw file 3/6: LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+2:42:41.389491 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+2:43:40.517130 INFO: Determining DIA cycle
+2:43:40.530130 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+2:43:40.537130 INFO: Determining DIA cycle
+2:43:40.549259 INFO: Found cycle with start 0.00 min and length 151.
+2:43:40.644009 INFO: ============ Raw file stats ============
+2:43:40.645009 INFO: RT (min)            : 0.0 - 150.0
+2:43:40.645009 INFO: RT duration (sec)   : 8999.7
+2:43:40.645009 INFO: RT duration (min)   : 150.0
+2:43:40.646009 INFO: Cycle len (scans)   : 151
+2:43:40.646009 INFO: Cycle len (sec)     : 5.84
+2:43:40.646009 INFO: Number of cycles    : 1542
+2:43:40.646009 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+2:43:40.646009 INFO: ========================================
+2:43:48.601701 INFO: Initializing CalibrationManager
+2:43:48.603702 INFO: Loading calibration config
+2:43:48.606710 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated'], 'function': LOESSRegression()}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated'], 'function': LOESSRegression(n_kernels=2)}]}]
+2:43:48.607891 INFO: Calibration group :fragment, found 1 estimator(s)
+2:43:48.608899 INFO: Calibration group :precursor, found 3 estimator(s)
+2:43:48.609898 INFO: Disabling ion mobility calibration
+2:43:48.609898 INFO: removed mobility estimator from group precursor
+2:43:48.610894 INFO: Initializing OptimizationManager
+2:43:48.612898 INFO: initial parameter: ms1_error = 30
+2:43:48.613897 INFO: initial parameter: ms2_error = 30
+2:43:48.613897 INFO: initial parameter: rt_error = 4500.001953125
+2:43:48.614897 INFO: initial parameter: mobility_error = 0.1
+2:43:48.614897 INFO: initial parameter: column_type = library
+2:43:48.615901 INFO: initial parameter: num_candidates = 1
+2:43:48.616900 INFO: initial parameter: classifier_version = -1
+2:43:48.617904 INFO: initial parameter: fwhm_rt = 5
+2:43:48.617904 INFO: initial parameter: fwhm_mobility = 0.01
+2:43:48.618896 INFO: initial parameter: score_cutoff = 0
+2:43:48.618896 INFO: Initializing TimingManager
+2:43:48.619897 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+2:43:48.620899 INFO: Initializing FDRManager
+2:43:48.620899 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+2:43:54.120219 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+2:44:01.332646 PROGRESS: Starting initial search for precursors.
+2:44:01.939123 INFO: Starting optimization step 0.
+2:44:01.986227 PROGRESS: === Extracting elution groups 0 to 8000 ===
+2:44:01.991233 PROGRESS: Extracting batch of 15803 precursors
+2:44:02.035023 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:44:02.036022 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:44:02.036022 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:44:02.036022 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:44:02.036022 INFO: Starting candidate selection
+2:44:15.758254 INFO: Starting candidate scoring
+2:44:16.672097 INFO: Finished candidate processing
+2:44:16.672097 INFO: Collecting candidate features
+2:44:16.923500 INFO: Collecting fragment features
+2:44:17.065293 INFO: Finished candidate scoring
+2:44:17.147363 PROGRESS: === Extracted 15795 precursors and 133329 fragments ===
+2:44:17.149360 INFO: performing precursor FDR with 47 features
+2:44:17.149360 INFO: Decoy channel: -1
+2:44:17.149360 INFO: Competetive: True
+2:44:17.525715 INFO: Test AUC: 0.506
+2:44:17.525715 INFO: Train AUC: 0.530
+2:44:17.525715 INFO: AUC difference: 4.47%
+2:44:17.604304 INFO: === FDR correction performed with classifier version -1 ===
+2:44:17.605304 PROGRESS: ============================= Precursor FDR =============================
+2:44:17.605304 PROGRESS: Total precursors accumulated: 3
+2:44:17.605304 PROGRESS: Target precursors: 3 (100.00%)
+2:44:17.605304 PROGRESS: Decoy precursors: 0 (0.00%)
+2:44:17.605304 PROGRESS: 
+2:44:17.606304 PROGRESS: Precursor Summary:
+2:44:17.606304 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+2:44:17.607305 PROGRESS: 
+2:44:17.607305 PROGRESS: Protein Summary:
+2:44:17.608304 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+2:44:17.608304 PROGRESS: =========================================================================
+2:44:17.730453 INFO: Starting optimization step 1.
+2:44:17.730453 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+2:44:17.730973 PROGRESS: Extracting batch of 31592 precursors
+2:44:17.740978 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:44:17.740978 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:44:17.740978 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:44:17.740978 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:44:17.740978 INFO: Starting candidate selection
+2:44:29.763852 INFO: Starting candidate scoring
+2:44:30.961856 INFO: Finished candidate processing
+2:44:30.961856 INFO: Collecting candidate features
+2:44:31.180134 INFO: Collecting fragment features
+2:44:31.264986 INFO: Finished candidate scoring
+2:44:31.363973 PROGRESS: === Extracted 47346 precursors and 400518 fragments ===
+2:44:31.386964 INFO: performing precursor FDR with 47 features
+2:44:31.386964 INFO: Decoy channel: -1
+2:44:31.386964 INFO: Competetive: True
+2:44:32.564995 INFO: Test AUC: 0.544
+2:44:32.565108 INFO: Train AUC: 0.560
+2:44:32.565108 INFO: AUC difference: 2.76%
+2:44:32.753058 INFO: === FDR correction performed with classifier version -1 ===
+2:44:32.754057 PROGRESS: ============================= Precursor FDR =============================
+2:44:32.755056 PROGRESS: Total precursors accumulated: 4
+2:44:32.755056 PROGRESS: Target precursors: 4 (100.00%)
+2:44:32.755056 PROGRESS: Decoy precursors: 0 (0.00%)
+2:44:32.755056 PROGRESS: 
+2:44:32.755056 PROGRESS: Precursor Summary:
+2:44:32.757059 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+2:44:32.757059 PROGRESS: 
+2:44:32.757059 PROGRESS: Protein Summary:
+2:44:32.759058 PROGRESS: Channel   0:	 0.05 FDR:     4; 0.01 FDR:     4; 0.001 FDR:     4
+2:44:32.759058 PROGRESS: =========================================================================
+2:44:33.134326 INFO: Starting optimization step 2.
+2:44:33.134326 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+2:44:33.135324 PROGRESS: Extracting batch of 63206 precursors
+2:44:33.183151 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:44:33.184147 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:44:33.184147 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:44:33.184147 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:44:33.184147 INFO: Starting candidate selection
+2:45:16.367948 INFO: Starting candidate scoring
+2:45:18.951083 INFO: Finished candidate processing
+2:45:18.951083 INFO: Collecting candidate features
+2:45:19.270172 INFO: Collecting fragment features
+2:45:19.379080 INFO: Finished candidate scoring
+2:45:19.580458 PROGRESS: === Extracted 110502 precursors and 936398 fragments ===
+2:45:19.617060 INFO: performing precursor FDR with 47 features
+2:45:19.617060 INFO: Decoy channel: -1
+2:45:19.617060 INFO: Competetive: True
+2:45:20.998287 INFO: Test AUC: 0.561
+2:45:20.998287 INFO: Train AUC: 0.576
+2:45:20.998287 INFO: AUC difference: 2.53%
+2:45:21.095205 INFO: === FDR correction performed with classifier version -1 ===
+2:45:21.096221 PROGRESS: ============================= Precursor FDR =============================
+2:45:21.096221 PROGRESS: Total precursors accumulated: 389
+2:45:21.096221 PROGRESS: Target precursors: 354 (91.00%)
+2:45:21.096221 PROGRESS: Decoy precursors: 35 (9.00%)
+2:45:21.096221 PROGRESS: 
+2:45:21.097127 PROGRESS: Precursor Summary:
+2:45:21.098223 PROGRESS: Channel   0:	 0.05 FDR:   248; 0.01 FDR:    36; 0.001 FDR:    36
+2:45:21.098223 PROGRESS: 
+2:45:21.098223 PROGRESS: Protein Summary:
+2:45:21.099127 PROGRESS: Channel   0:	 0.05 FDR:   240; 0.01 FDR:    36; 0.001 FDR:    36
+2:45:21.099127 PROGRESS: =========================================================================
+2:45:21.362256 INFO: Starting optimization step 3.
+2:45:21.362256 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+2:45:21.362256 PROGRESS: Extracting batch of 126403 precursors
+2:45:21.390376 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:45:21.390376 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:45:21.390376 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+2:45:21.390376 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+2:45:21.390376 INFO: Starting candidate selection
+2:46:55.843538 INFO: Starting candidate scoring
+2:47:02.161052 INFO: Finished candidate processing
+2:47:02.161052 INFO: Collecting candidate features
+2:47:02.968501 INFO: Collecting fragment features
+2:47:03.293236 INFO: Finished candidate scoring
+2:47:03.816144 PROGRESS: === Extracted 236805 precursors and 2006112 fragments ===
+2:47:03.938484 INFO: performing precursor FDR with 47 features
+2:47:03.938484 INFO: Decoy channel: -1
+2:47:03.938484 INFO: Competetive: True
+2:47:12.701278 INFO: Test AUC: 0.566
+2:47:12.701278 INFO: Train AUC: 0.579
+2:47:12.701278 INFO: AUC difference: 2.33%
+2:47:13.057260 INFO: === FDR correction performed with classifier version -1 ===
+2:47:13.057260 PROGRESS: ============================= Precursor FDR =============================
+2:47:13.073396 PROGRESS: Total precursors accumulated: 1,137
+2:47:13.073396 PROGRESS: Target precursors: 1,036 (91.12%)
+2:47:13.073396 PROGRESS: Decoy precursors: 101 (8.88%)
+2:47:13.073396 PROGRESS: 
+2:47:13.073396 PROGRESS: Precursor Summary:
+2:47:13.073396 PROGRESS: Channel   0:	 0.05 FDR:   871; 0.01 FDR:   661; 0.001 FDR:   445
+2:47:13.073396 PROGRESS: 
+2:47:13.073396 PROGRESS: Protein Summary:
+2:47:13.073396 PROGRESS: Channel   0:	 0.05 FDR:   755; 0.01 FDR:   586; 0.001 FDR:   409
+2:47:13.073396 PROGRESS: =========================================================================
+2:47:13.151871 INFO: fragments_df_filtered: 3967
+2:47:13.790608 INFO: calibration group: precursor, fitting rt estimator 
+2:47:14.022881 INFO: calibration group: fragment, fitting mz estimator 
+2:47:18.277637 INFO: calibration group: precursor, predicting mz
+2:47:18.293259 WARNING: mz prediction was skipped as it has not been fitted yet
+2:47:18.293259 INFO: calibration group: precursor, predicting rt
+2:47:18.416704 INFO: calibration group: fragment, predicting mz
+2:47:18.874610 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+2:47:18.874610 INFO: Starting optimization step 4.
+2:47:18.874610 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:47:18.874610 PROGRESS: Extracting batch of 110601 precursors
+2:47:18.955022 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:47:18.955022 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:47:18.955022 INFO: FWHM in RT is 18.94 seconds, sigma is 0.69
+2:47:18.955022 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:47:18.955022 INFO: Starting candidate selection
+2:49:20.010847 INFO: Starting candidate scoring
+2:49:29.308735 INFO: Finished candidate processing
+2:49:29.308735 INFO: Collecting candidate features
+2:49:30.272991 WARNING: intensity_correlation has 2 NaNs ( 0.00 % out of 221024)
+2:49:30.304646 INFO: Collecting fragment features
+2:49:30.798531 INFO: Finished candidate scoring
+2:49:31.133856 PROGRESS: === Extracted 221024 precursors and 1929872 fragments ===
+2:49:31.133856 INFO: performing precursor FDR with 47 features
+2:49:31.133856 INFO: Decoy channel: -1
+2:49:31.133856 INFO: Competetive: True
+2:49:31.544894 WARNING: dropped 2 decoy PSMs due to missing features
+2:49:39.013422 INFO: Test AUC: 0.572
+2:49:39.013422 INFO: Train AUC: 0.582
+2:49:39.013422 INFO: AUC difference: 1.86%
+2:49:39.347018 INFO: === FDR correction performed with classifier version 3 ===
+2:49:39.350018 PROGRESS: ============================= Precursor FDR =============================
+2:49:39.350018 PROGRESS: Total precursors accumulated: 528
+2:49:39.351017 PROGRESS: Target precursors: 482 (91.29%)
+2:49:39.351017 PROGRESS: Decoy precursors: 46 (8.71%)
+2:49:39.351017 PROGRESS: 
+2:49:39.351017 PROGRESS: Precursor Summary:
+2:49:39.355021 PROGRESS: Channel   0:	 0.05 FDR:   372; 0.01 FDR:   272; 0.001 FDR:   135
+2:49:39.356022 PROGRESS: 
+2:49:39.356022 PROGRESS: Protein Summary:
+2:49:39.360072 PROGRESS: Channel   0:	 0.05 FDR:   351; 0.01 FDR:   261; 0.001 FDR:   133
+2:49:39.360072 PROGRESS: =========================================================================
+2:49:39.380835 INFO: fragments_df_filtered: 1899
+2:49:40.103924 INFO: calibration group: precursor, fitting rt estimator 
+2:49:40.231146 INFO: calibration group: fragment, fitting mz estimator 
+2:49:41.301225 INFO: calibration group: precursor, predicting mz
+2:49:41.301225 WARNING: mz prediction was skipped as it has not been fitted yet
+2:49:41.301225 INFO: calibration group: precursor, predicting rt
+2:49:41.425519 INFO: calibration group: fragment, predicting mz
+2:49:41.775192 INFO: === checking if optimization conditions were reached ===
+2:49:41.775192 PROGRESS: ❌ ms2_error      : 10.3350 > 10.0000 or insufficient steps taken.
+2:49:41.775192 INFO: ==============================================
+2:49:41.775192 INFO: Starting optimization step 5.
+2:49:41.775192 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:49:41.775192 PROGRESS: Extracting batch of 110601 precursors
+2:49:41.821996 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:49:41.821996 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:49:41.821996 INFO: FWHM in RT is 19.52 seconds, sigma is 0.71
+2:49:41.821996 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:49:41.821996 INFO: Starting candidate selection
+2:51:10.547936 INFO: Starting candidate scoring
+2:51:19.098112 INFO: Finished candidate processing
+2:51:19.098112 INFO: Collecting candidate features
+2:51:19.964567 WARNING: intensity_correlation has 22 NaNs ( 0.01 % out of 220899)
+2:51:20.011445 INFO: Collecting fragment features
+2:51:20.283230 INFO: Finished candidate scoring
+2:51:20.573066 PROGRESS: === Extracted 220899 precursors and 1589671 fragments ===
+2:51:20.573066 INFO: performing precursor FDR with 47 features
+2:51:20.573066 INFO: Decoy channel: -1
+2:51:20.573066 INFO: Competetive: True
+2:51:20.960623 WARNING: dropped 12 target PSMs due to missing features
+2:51:20.960623 WARNING: dropped 10 decoy PSMs due to missing features
+2:51:28.442199 INFO: Test AUC: 0.571
+2:51:28.442199 INFO: Train AUC: 0.587
+2:51:28.443711 INFO: AUC difference: 2.76%
+2:51:28.757376 INFO: === FDR correction performed with classifier version 4 ===
+2:51:28.773017 PROGRESS: ============================= Precursor FDR =============================
+2:51:28.773017 PROGRESS: Total precursors accumulated: 676
+2:51:28.773017 PROGRESS: Target precursors: 614 (90.83%)
+2:51:28.773017 PROGRESS: Decoy precursors: 62 (9.17%)
+2:51:28.773017 PROGRESS: 
+2:51:28.773017 PROGRESS: Precursor Summary:
+2:51:28.773017 PROGRESS: Channel   0:	 0.05 FDR:   448; 0.01 FDR:   313; 0.001 FDR:   193
+2:51:28.773017 PROGRESS: 
+2:51:28.773017 PROGRESS: Protein Summary:
+2:51:28.788646 PROGRESS: Channel   0:	 0.05 FDR:   421; 0.01 FDR:   295; 0.001 FDR:   188
+2:51:28.788646 PROGRESS: =========================================================================
+2:51:28.804267 INFO: fragments_df_filtered: 1515
+2:51:29.423082 INFO: calibration group: precursor, fitting rt estimator 
+2:51:29.564539 INFO: calibration group: fragment, fitting mz estimator 
+2:51:30.303595 INFO: calibration group: precursor, predicting mz
+2:51:30.303595 WARNING: mz prediction was skipped as it has not been fitted yet
+2:51:30.303595 INFO: calibration group: precursor, predicting rt
+2:51:30.423513 INFO: calibration group: fragment, predicting mz
+2:51:30.873930 INFO: === checking if optimization conditions were reached ===
+2:51:30.873930 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+2:51:30.873930 INFO: ==============================================
+2:51:30.873930 PROGRESS: Optimization finished for ms2_error.
+2:51:31.453285 INFO: calibration group: precursor, predicting mz
+2:51:31.453285 WARNING: mz prediction was skipped as it has not been fitted yet
+2:51:31.453285 INFO: calibration group: precursor, predicting rt
+2:51:31.577127 INFO: calibration group: fragment, predicting mz
+2:51:32.047379 INFO: Starting optimization step 0.
+2:51:32.047379 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:51:32.047379 PROGRESS: Extracting batch of 110601 precursors
+2:51:32.110294 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:51:32.110294 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:51:32.125919 INFO: FWHM in RT is 17.09 seconds, sigma is 0.62
+2:51:32.125919 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:51:32.125919 INFO: Starting candidate selection
+2:53:34.929878 INFO: Starting candidate scoring
+2:53:45.030562 INFO: Finished candidate processing
+2:53:45.030562 INFO: Collecting candidate features
+2:53:46.039983 WARNING: intensity_correlation has 13 NaNs ( 0.01 % out of 220908)
+2:53:46.086857 INFO: Collecting fragment features
+2:53:46.522138 INFO: Finished candidate scoring
+2:53:46.862359 PROGRESS: === Extracted 220908 precursors and 1581510 fragments ===
+2:53:46.863359 INFO: performing precursor FDR with 47 features
+2:53:46.863359 INFO: Decoy channel: -1
+2:53:46.863359 INFO: Competetive: True
+2:53:47.286476 WARNING: dropped 6 target PSMs due to missing features
+2:53:47.286476 WARNING: dropped 7 decoy PSMs due to missing features
+2:53:55.082407 INFO: Test AUC: 0.578
+2:53:55.082407 INFO: Train AUC: 0.592
+2:53:55.082407 INFO: AUC difference: 2.28%
+2:53:55.400604 INFO: === FDR correction performed with classifier version 5 ===
+2:53:55.402607 PROGRESS: ============================= Precursor FDR =============================
+2:53:55.403605 PROGRESS: Total precursors accumulated: 660
+2:53:55.403605 PROGRESS: Target precursors: 600 (90.91%)
+2:53:55.404606 PROGRESS: Decoy precursors: 60 (9.09%)
+2:53:55.404606 PROGRESS: 
+2:53:55.404606 PROGRESS: Precursor Summary:
+2:53:55.409133 PROGRESS: Channel   0:	 0.05 FDR:   462; 0.01 FDR:   335; 0.001 FDR:   229
+2:53:55.410151 PROGRESS: 
+2:53:55.410151 PROGRESS: Protein Summary:
+2:53:55.412244 PROGRESS: Channel   0:	 0.05 FDR:   434; 0.01 FDR:   314; 0.001 FDR:   218
+2:53:55.412244 PROGRESS: =========================================================================
+2:53:55.427888 INFO: fragments_df_filtered: 1536
+2:53:56.067850 INFO: calibration group: precursor, fitting rt estimator 
+2:53:56.224926 INFO: calibration group: fragment, fitting mz estimator 
+2:53:56.955126 INFO: calibration group: precursor, predicting mz
+2:53:56.955126 WARNING: mz prediction was skipped as it has not been fitted yet
+2:53:56.955126 INFO: calibration group: precursor, predicting rt
+2:53:57.080539 INFO: calibration group: fragment, predicting mz
+2:53:57.531462 INFO: === checking if optimization conditions were reached ===
+2:53:57.531462 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+2:53:57.531462 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 785.3768.
+2:53:57.531462 INFO: ==============================================
+2:53:57.531462 INFO: Starting optimization step 1.
+2:53:57.531462 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:53:57.531462 PROGRESS: Extracting batch of 110601 precursors
+2:53:57.612132 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:53:57.612132 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:53:57.612132 INFO: FWHM in RT is 17.03 seconds, sigma is 0.62
+2:53:57.612132 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:53:57.612132 INFO: Starting candidate selection
+2:54:26.460137 INFO: Starting candidate scoring
+2:54:35.534166 INFO: Finished candidate processing
+2:54:35.534166 INFO: Collecting candidate features
+2:54:36.491544 WARNING: intensity_correlation has 291 NaNs ( 0.14 % out of 213236)
+2:54:36.538418 INFO: Collecting fragment features
+2:54:36.926938 INFO: Finished candidate scoring
+2:54:37.232341 PROGRESS: === Extracted 213236 precursors and 1275890 fragments ===
+2:54:37.232341 INFO: performing precursor FDR with 47 features
+2:54:37.232341 INFO: Decoy channel: -1
+2:54:37.232341 INFO: Competetive: True
+2:54:37.657967 WARNING: dropped 162 target PSMs due to missing features
+2:54:37.657967 WARNING: dropped 129 decoy PSMs due to missing features
+2:54:42.931690 INFO: Test AUC: 0.562
+2:54:42.931690 INFO: Train AUC: 0.579
+2:54:42.931690 INFO: AUC difference: 2.99%
+2:54:43.247609 INFO: === FDR correction performed with classifier version 5 ===
+2:54:43.247609 PROGRESS: ============================= Precursor FDR =============================
+2:54:43.247609 PROGRESS: Total precursors accumulated: 774
+2:54:43.247609 PROGRESS: Target precursors: 703 (90.83%)
+2:54:43.247609 PROGRESS: Decoy precursors: 71 (9.17%)
+2:54:43.247609 PROGRESS: 
+2:54:43.247609 PROGRESS: Precursor Summary:
+2:54:43.267256 PROGRESS: Channel   0:	 0.05 FDR:   547; 0.01 FDR:   352; 0.001 FDR:   103
+2:54:43.267256 PROGRESS: 
+2:54:43.267256 PROGRESS: Protein Summary:
+2:54:43.267256 PROGRESS: Channel   0:	 0.05 FDR:   514; 0.01 FDR:   332; 0.001 FDR:   101
+2:54:43.267256 PROGRESS: =========================================================================
+2:54:43.294928 INFO: fragments_df_filtered: 1535
+2:54:43.900820 INFO: calibration group: precursor, fitting rt estimator 
+2:54:44.059261 INFO: calibration group: fragment, fitting mz estimator 
+2:54:44.801551 INFO: calibration group: precursor, predicting mz
+2:54:44.801551 WARNING: mz prediction was skipped as it has not been fitted yet
+2:54:44.801551 INFO: calibration group: precursor, predicting rt
+2:54:44.928941 INFO: calibration group: fragment, predicting mz
+2:54:45.383160 INFO: === checking if optimization conditions were reached ===
+2:54:45.383160 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+2:54:45.383160 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 491.3373.
+2:54:45.383160 INFO: ==============================================
+2:54:45.383160 INFO: Starting optimization step 2.
+2:54:45.383160 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:54:45.383160 PROGRESS: Extracting batch of 110601 precursors
+2:54:45.470164 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:54:45.470164 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:54:45.470164 INFO: FWHM in RT is 16.91 seconds, sigma is 0.62
+2:54:45.470164 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:54:45.470164 INFO: Starting candidate selection
+2:55:00.820972 INFO: Starting candidate scoring
+2:55:08.660118 INFO: Finished candidate processing
+2:55:08.660118 INFO: Collecting candidate features
+2:55:09.575974 WARNING: intensity_correlation has 309 NaNs ( 0.15 % out of 208144)
+2:55:09.618106 INFO: Collecting fragment features
+2:55:09.982151 INFO: Finished candidate scoring
+2:55:10.300248 PROGRESS: === Extracted 208144 precursors and 1181631 fragments ===
+2:55:10.300248 INFO: performing precursor FDR with 47 features
+2:55:10.300248 INFO: Decoy channel: -1
+2:55:10.300248 INFO: Competetive: True
+2:55:10.731855 WARNING: dropped 178 target PSMs due to missing features
+2:55:10.731855 WARNING: dropped 131 decoy PSMs due to missing features
+2:55:18.048605 INFO: Test AUC: 0.558
+2:55:18.048605 INFO: Train AUC: 0.577
+2:55:18.048605 INFO: AUC difference: 3.19%
+2:55:18.365097 INFO: === FDR correction performed with classifier version 5 ===
+2:55:18.369089 PROGRESS: ============================= Precursor FDR =============================
+2:55:18.369089 PROGRESS: Total precursors accumulated: 767
+2:55:18.370090 PROGRESS: Target precursors: 695 (90.61%)
+2:55:18.370090 PROGRESS: Decoy precursors: 72 (9.39%)
+2:55:18.370090 PROGRESS: 
+2:55:18.371091 PROGRESS: Precursor Summary:
+2:55:18.372079 PROGRESS: Channel   0:	 0.05 FDR:   557; 0.01 FDR:   377; 0.001 FDR:   252
+2:55:18.372079 PROGRESS: 
+2:55:18.372079 PROGRESS: Protein Summary:
+2:55:18.372079 PROGRESS: Channel   0:	 0.05 FDR:   524; 0.01 FDR:   355; 0.001 FDR:   240
+2:55:18.372079 PROGRESS: =========================================================================
+2:55:18.387104 INFO: fragments_df_filtered: 1596
+2:55:18.986143 INFO: calibration group: precursor, fitting rt estimator 
+2:55:19.143254 INFO: calibration group: fragment, fitting mz estimator 
+2:55:19.941008 INFO: calibration group: precursor, predicting mz
+2:55:19.941008 WARNING: mz prediction was skipped as it has not been fitted yet
+2:55:19.941008 INFO: calibration group: precursor, predicting rt
+2:55:20.062902 INFO: calibration group: fragment, predicting mz
+2:55:20.526819 INFO: === checking if optimization conditions were reached ===
+2:55:20.526819 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+2:55:20.526819 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 485.5165.
+2:55:20.526819 INFO: ==============================================
+2:55:20.526819 INFO: Starting optimization step 3.
+2:55:20.526819 PROGRESS: === Extracting elution groups 0 to 56000 ===
+2:55:20.526819 PROGRESS: Extracting batch of 110601 precursors
+2:55:20.605386 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:55:20.605386 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:55:20.605386 INFO: FWHM in RT is 16.93 seconds, sigma is 0.62
+2:55:20.605386 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:55:20.605386 INFO: Starting candidate selection
+2:55:35.698733 INFO: Starting candidate scoring
+2:55:43.527884 INFO: Finished candidate processing
+2:55:43.527884 INFO: Collecting candidate features
+2:55:44.454657 WARNING: intensity_correlation has 312 NaNs ( 0.15 % out of 208384)
+2:55:44.501543 INFO: Collecting fragment features
+2:55:44.875348 INFO: Finished candidate scoring
+2:55:45.179136 PROGRESS: === Extracted 208384 precursors and 1183148 fragments ===
+2:55:45.179136 INFO: performing precursor FDR with 47 features
+2:55:45.179136 INFO: Decoy channel: -1
+2:55:45.179136 INFO: Competetive: True
+2:55:45.596527 WARNING: dropped 170 target PSMs due to missing features
+2:55:45.596527 WARNING: dropped 142 decoy PSMs due to missing features
+2:55:52.754343 INFO: Test AUC: 0.556
+2:55:52.754343 INFO: Train AUC: 0.576
+2:55:52.754343 INFO: AUC difference: 3.39%
+2:55:53.077365 INFO: === FDR correction performed with classifier version 5 ===
+2:55:53.077365 PROGRESS: ============================= Precursor FDR =============================
+2:55:53.077365 PROGRESS: Total precursors accumulated: 782
+2:55:53.077365 PROGRESS: Target precursors: 713 (91.18%)
+2:55:53.077365 PROGRESS: Decoy precursors: 69 (8.82%)
+2:55:53.092991 PROGRESS: 
+2:55:53.092991 PROGRESS: Precursor Summary:
+2:55:53.092991 PROGRESS: Channel   0:	 0.05 FDR:   556; 0.01 FDR:   378; 0.001 FDR:   270
+2:55:53.092991 PROGRESS: 
+2:55:53.092991 PROGRESS: Protein Summary:
+2:55:53.092991 PROGRESS: Channel   0:	 0.05 FDR:   520; 0.01 FDR:   355; 0.001 FDR:   257
+2:55:53.092991 PROGRESS: =========================================================================
+2:55:53.124239 INFO: fragments_df_filtered: 1610
+2:55:53.736454 INFO: calibration group: precursor, fitting rt estimator 
+2:55:53.889793 INFO: calibration group: fragment, fitting mz estimator 
+2:55:54.682177 INFO: calibration group: precursor, predicting mz
+2:55:54.682177 WARNING: mz prediction was skipped as it has not been fitted yet
+2:55:54.682177 INFO: calibration group: precursor, predicting rt
+2:55:54.817393 INFO: calibration group: fragment, predicting mz
+2:55:55.267802 INFO: === checking if optimization conditions were reached ===
+2:55:55.267802 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+2:55:55.283442 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 485.5165 found after 4 searches.
+2:55:55.283442 INFO: ==============================================
+2:55:55.283442 PROGRESS: Optimization finished for rt_error.
+2:55:55.864665 INFO: calibration group: precursor, predicting mz
+2:55:55.864665 WARNING: mz prediction was skipped as it has not been fitted yet
+2:55:55.864665 INFO: calibration group: precursor, predicting rt
+2:55:55.983478 INFO: calibration group: fragment, predicting mz
+2:55:56.512497 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+2:55:56.528121 PROGRESS: ==============================================
+2:55:56.528121 PROGRESS: ms2_error      : 10.0000
+2:55:56.528121 PROGRESS: rt_error       : 485.5165
+2:55:56.528121 PROGRESS: ==============================================
+2:55:56.543745 INFO: calibration group: precursor, predicting mz
+2:55:56.543745 WARNING: mz prediction was skipped as it has not been fitted yet
+2:55:56.543745 INFO: calibration group: precursor, predicting rt
+2:56:06.358941 INFO: calibration group: fragment, predicting mz
+2:56:55.007019 PROGRESS: Extracting batch of 10640830 precursors
+2:56:59.701874 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+2:56:59.701874 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+2:56:59.701874 INFO: FWHM in RT is 16.95 seconds, sigma is 0.62
+2:56:59.701874 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+2:56:59.701874 INFO: Starting candidate selection
+3:18:15.985690 INFO: Applying score cutoff of 68.0940083694458
+3:18:16.465856 INFO: Removed 15536815 precursors with score below cutoff
+3:18:19.574358 INFO: Starting candidate scoring
+3:20:42.310696 INFO: Finished candidate processing
+3:20:42.310696 INFO: Collecting candidate features
+3:21:00.061808 INFO: Collecting fragment features
+3:21:07.883496 INFO: Finished candidate scoring
+3:21:16.884581 INFO: === FDR correction performed with classifier version 9 ===
+3:21:16.884581 INFO: performing precursor FDR with 47 features
+3:21:16.884581 INFO: Decoy channel: -1
+3:21:16.884581 INFO: Competetive: True
+3:23:28.102842 INFO: Test AUC: 0.581
+3:23:28.102842 INFO: Train AUC: 0.583
+3:23:28.102842 INFO: AUC difference: 0.41%
+3:23:29.164620 INFO: Removing fragments below FDR threshold
+3:23:29.915045 PROGRESS: ============================= Precursor FDR =============================
+3:23:29.915045 PROGRESS: Total precursors accumulated: 51,312
+3:23:29.915045 PROGRESS: Target precursors: 50,804 (99.01%)
+3:23:29.916041 PROGRESS: Decoy precursors: 508 (0.99%)
+3:23:29.916041 PROGRESS: 
+3:23:29.916041 PROGRESS: Precursor Summary:
+3:23:29.981894 PROGRESS: Channel   0:	 0.05 FDR: 50,804; 0.01 FDR: 50,804; 0.001 FDR: 36,176
+3:23:29.981894 PROGRESS: 
+3:23:29.981894 PROGRESS: Protein Summary:
+3:23:30.045270 PROGRESS: Channel   0:	 0.05 FDR: 8,754; 0.01 FDR: 8,754; 0.001 FDR: 6,785
+3:23:30.045270 PROGRESS: =========================================================================
+3:23:31.276971 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+3:23:32.069190 PROGRESS: Loading raw file 4/6: LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+3:23:32.069190 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+3:24:05.745998 INFO: Determining DIA cycle
+3:24:05.781884 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+3:24:05.781884 INFO: Determining DIA cycle
+3:24:05.820087 INFO: Found cycle with start 0.00 min and length 151.
+3:24:05.936609 INFO: ============ Raw file stats ============
+3:24:05.937609 INFO: RT (min)            : 0.0 - 150.0
+3:24:05.937609 INFO: RT duration (sec)   : 8999.7
+3:24:05.937609 INFO: RT duration (min)   : 150.0
+3:24:05.937609 INFO: Cycle len (scans)   : 151
+3:24:05.937609 INFO: Cycle len (sec)     : 5.83
+3:24:05.937609 INFO: Number of cycles    : 1542
+3:24:05.937609 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+3:24:05.937609 INFO: ========================================
+3:24:08.569178 INFO: Initializing CalibrationManager
+3:24:08.569178 INFO: Loading calibration config
+3:24:08.571040 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated'], 'function': LOESSRegression()}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated'], 'function': LOESSRegression(n_kernels=2)}]}]
+3:24:08.571040 INFO: Calibration group :fragment, found 1 estimator(s)
+3:24:08.571040 INFO: Calibration group :precursor, found 3 estimator(s)
+3:24:08.571040 INFO: Disabling ion mobility calibration
+3:24:08.571040 INFO: removed mobility estimator from group precursor
+3:24:08.571040 INFO: Initializing OptimizationManager
+3:24:08.571040 INFO: initial parameter: ms1_error = 30
+3:24:08.571040 INFO: initial parameter: ms2_error = 30
+3:24:08.571040 INFO: initial parameter: rt_error = 4500.00048828125
+3:24:08.571040 INFO: initial parameter: mobility_error = 0.1
+3:24:08.571040 INFO: initial parameter: column_type = library
+3:24:08.571040 INFO: initial parameter: num_candidates = 1
+3:24:08.571040 INFO: initial parameter: classifier_version = -1
+3:24:08.571040 INFO: initial parameter: fwhm_rt = 5
+3:24:08.571040 INFO: initial parameter: fwhm_mobility = 0.01
+3:24:08.571040 INFO: initial parameter: score_cutoff = 0
+3:24:08.571040 INFO: Initializing TimingManager
+3:24:08.571040 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+3:24:08.571040 INFO: Initializing FDRManager
+3:24:08.571040 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+3:24:10.892034 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+3:24:13.968780 PROGRESS: Starting initial search for precursors.
+3:24:14.383351 INFO: Starting optimization step 0.
+3:24:14.384332 PROGRESS: === Extracting elution groups 0 to 8000 ===
+3:24:14.384473 PROGRESS: Extracting batch of 15803 precursors
+3:24:14.400144 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:24:14.400144 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:24:14.400144 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:24:14.400144 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:24:14.400144 INFO: Starting candidate selection
+3:24:20.918459 INFO: Starting candidate scoring
+3:24:21.240324 INFO: Finished candidate processing
+3:24:21.240324 INFO: Collecting candidate features
+3:24:21.298442 INFO: Collecting fragment features
+3:24:21.317886 INFO: Finished candidate scoring
+3:24:21.349878 PROGRESS: === Extracted 15796 precursors and 134316 fragments ===
+3:24:21.350946 INFO: performing precursor FDR with 47 features
+3:24:21.350946 INFO: Decoy channel: -1
+3:24:21.350946 INFO: Competetive: True
+3:24:21.573745 INFO: Test AUC: 0.514
+3:24:21.573745 INFO: Train AUC: 0.517
+3:24:21.573745 INFO: AUC difference: 0.59%
+3:24:21.688654 INFO: === FDR correction performed with classifier version -1 ===
+3:24:21.688654 PROGRESS: ============================= Precursor FDR =============================
+3:24:21.688654 PROGRESS: Total precursors accumulated: 3
+3:24:21.688654 PROGRESS: Target precursors: 3 (100.00%)
+3:24:21.688654 PROGRESS: Decoy precursors: 0 (0.00%)
+3:24:21.688654 PROGRESS: 
+3:24:21.688654 PROGRESS: Precursor Summary:
+3:24:21.688654 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+3:24:21.688654 PROGRESS: 
+3:24:21.688654 PROGRESS: Protein Summary:
+3:24:21.704216 PROGRESS: Channel   0:	 0.05 FDR:     3; 0.01 FDR:     3; 0.001 FDR:     3
+3:24:21.704216 PROGRESS: =========================================================================
+3:24:21.885293 INFO: Starting optimization step 1.
+3:24:21.885293 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+3:24:21.885293 PROGRESS: Extracting batch of 31592 precursors
+3:24:21.906366 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:24:21.907368 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:24:21.907368 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:24:21.907368 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:24:21.907368 INFO: Starting candidate selection
+3:24:34.685515 INFO: Starting candidate scoring
+3:24:35.282599 INFO: Finished candidate processing
+3:24:35.282599 INFO: Collecting candidate features
+3:24:35.380182 INFO: Collecting fragment features
+3:24:35.427166 INFO: Finished candidate scoring
+3:24:35.492651 PROGRESS: === Extracted 47342 precursors and 403372 fragments ===
+3:24:35.508264 INFO: performing precursor FDR with 47 features
+3:24:35.508264 INFO: Decoy channel: -1
+3:24:35.508264 INFO: Competetive: True
+3:24:36.459564 INFO: Test AUC: 0.565
+3:24:36.459564 INFO: Train AUC: 0.565
+3:24:36.459564 INFO: AUC difference: 0.00%
+3:24:36.621321 INFO: === FDR correction performed with classifier version -1 ===
+3:24:36.621321 PROGRESS: ============================= Precursor FDR =============================
+3:24:36.621321 PROGRESS: Total precursors accumulated: 6
+3:24:36.621321 PROGRESS: Target precursors: 6 (100.00%)
+3:24:36.621321 PROGRESS: Decoy precursors: 0 (0.00%)
+3:24:36.621321 PROGRESS: 
+3:24:36.621321 PROGRESS: Precursor Summary:
+3:24:36.621321 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+3:24:36.621321 PROGRESS: 
+3:24:36.621321 PROGRESS: Protein Summary:
+3:24:36.621321 PROGRESS: Channel   0:	 0.05 FDR:     6; 0.01 FDR:     6; 0.001 FDR:     6
+3:24:36.621321 PROGRESS: =========================================================================
+3:24:36.877681 INFO: Starting optimization step 2.
+3:24:36.877681 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+3:24:36.877681 PROGRESS: Extracting batch of 63206 precursors
+3:24:36.908874 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:24:36.908874 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:24:36.908874 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:24:36.908874 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:24:36.908874 INFO: Starting candidate selection
+3:25:02.561800 INFO: Starting candidate scoring
+3:25:03.755412 INFO: Finished candidate processing
+3:25:03.755412 INFO: Collecting candidate features
+3:25:03.975242 INFO: Collecting fragment features
+3:25:04.085217 INFO: Finished candidate scoring
+3:25:04.211439 PROGRESS: === Extracted 110493 precursors and 941603 fragments ===
+3:25:04.258531 INFO: performing precursor FDR with 47 features
+3:25:04.258531 INFO: Decoy channel: -1
+3:25:04.258531 INFO: Competetive: True
+3:25:06.553205 INFO: Test AUC: 0.560
+3:25:06.553205 INFO: Train AUC: 0.579
+3:25:06.553205 INFO: AUC difference: 3.37%
+3:25:06.714933 INFO: === FDR correction performed with classifier version -1 ===
+3:25:06.714933 PROGRESS: ============================= Precursor FDR =============================
+3:25:06.714933 PROGRESS: Total precursors accumulated: 390
+3:25:06.714933 PROGRESS: Target precursors: 357 (91.54%)
+3:25:06.714933 PROGRESS: Decoy precursors: 33 (8.46%)
+3:25:06.714933 PROGRESS: 
+3:25:06.714933 PROGRESS: Precursor Summary:
+3:25:06.714933 PROGRESS: Channel   0:	 0.05 FDR:   267; 0.01 FDR:   221; 0.001 FDR:    49
+3:25:06.714933 PROGRESS: 
+3:25:06.714933 PROGRESS: Protein Summary:
+3:25:06.714933 PROGRESS: Channel   0:	 0.05 FDR:   257; 0.01 FDR:   216; 0.001 FDR:    49
+3:25:06.714933 PROGRESS: =========================================================================
+3:25:06.746297 INFO: fragments_df_filtered: 1596
+3:25:07.102270 INFO: calibration group: precursor, fitting rt estimator 
+3:25:07.196678 INFO: calibration group: fragment, fitting mz estimator 
+3:25:07.742357 INFO: calibration group: precursor, predicting mz
+3:25:07.742357 WARNING: mz prediction was skipped as it has not been fitted yet
+3:25:07.742357 INFO: calibration group: precursor, predicting rt
+3:25:07.822194 INFO: calibration group: fragment, predicting mz
+3:25:08.130581 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+3:25:08.130581 INFO: Starting optimization step 3.
+3:25:08.130581 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:25:08.130581 PROGRESS: Extracting batch of 110601 precursors
+3:25:08.161833 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:25:08.161833 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:25:08.161833 INFO: FWHM in RT is 18.03 seconds, sigma is 0.66
+3:25:08.161833 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:25:08.161833 INFO: Starting candidate selection
+3:25:54.745620 INFO: Starting candidate scoring
+3:25:59.383438 INFO: Finished candidate processing
+3:25:59.383438 INFO: Collecting candidate features
+3:25:59.972597 WARNING: intensity_correlation has 3 NaNs ( 0.00 % out of 221021)
+3:26:00.004316 INFO: Collecting fragment features
+3:26:00.300216 INFO: Finished candidate scoring
+3:26:00.471833 PROGRESS: === Extracted 221021 precursors and 1938830 fragments ===
+3:26:00.471833 INFO: performing precursor FDR with 47 features
+3:26:00.471833 INFO: Decoy channel: -1
+3:26:00.471833 INFO: Competetive: True
+3:26:00.723421 WARNING: dropped 1 target PSMs due to missing features
+3:26:00.723421 WARNING: dropped 2 decoy PSMs due to missing features
+3:26:05.016202 INFO: Test AUC: 0.569
+3:26:05.016202 INFO: Train AUC: 0.583
+3:26:05.016202 INFO: AUC difference: 2.38%
+3:26:05.241029 INFO: === FDR correction performed with classifier version 2 ===
+3:26:05.241029 PROGRESS: ============================= Precursor FDR =============================
+3:26:05.241029 PROGRESS: Total precursors accumulated: 465
+3:26:05.241029 PROGRESS: Target precursors: 426 (91.61%)
+3:26:05.241029 PROGRESS: Decoy precursors: 39 (8.39%)
+3:26:05.241029 PROGRESS: 
+3:26:05.241029 PROGRESS: Precursor Summary:
+3:26:05.241029 PROGRESS: Channel   0:	 0.05 FDR:   352; 0.01 FDR:   259; 0.001 FDR:   179
+3:26:05.241029 PROGRESS: 
+3:26:05.241029 PROGRESS: Protein Summary:
+3:26:05.241029 PROGRESS: Channel   0:	 0.05 FDR:   336; 0.01 FDR:   251; 0.001 FDR:   176
+3:26:05.241029 PROGRESS: =========================================================================
+3:26:05.272277 INFO: fragments_df_filtered: 1718
+3:26:05.638843 INFO: calibration group: precursor, fitting rt estimator 
+3:26:05.717632 INFO: calibration group: fragment, fitting mz estimator 
+3:26:06.412202 INFO: calibration group: precursor, predicting mz
+3:26:06.414751 WARNING: mz prediction was skipped as it has not been fitted yet
+3:26:06.414751 INFO: calibration group: precursor, predicting rt
+3:26:06.479619 INFO: calibration group: fragment, predicting mz
+3:26:06.798890 INFO: === checking if optimization conditions were reached ===
+3:26:06.798890 PROGRESS: ❌ ms2_error      : 10.3235 > 10.0000 or insufficient steps taken.
+3:26:06.798890 INFO: ==============================================
+3:26:06.798890 INFO: Starting optimization step 4.
+3:26:06.798890 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:26:06.798890 PROGRESS: Extracting batch of 110601 precursors
+3:26:06.857399 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:26:06.857399 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:26:06.857399 INFO: FWHM in RT is 18.95 seconds, sigma is 0.69
+3:26:06.857399 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:26:06.858428 INFO: Starting candidate selection
+3:26:52.116708 INFO: Starting candidate scoring
+3:26:56.329773 INFO: Finished candidate processing
+3:26:56.329773 INFO: Collecting candidate features
+3:26:56.947161 WARNING: intensity_correlation has 20 NaNs ( 0.01 % out of 220855)
+3:26:56.963229 INFO: Collecting fragment features
+3:26:57.231692 INFO: Finished candidate scoring
+3:26:57.412495 PROGRESS: === Extracted 220855 precursors and 1598432 fragments ===
+3:26:57.412495 INFO: performing precursor FDR with 47 features
+3:26:57.412495 INFO: Decoy channel: -1
+3:26:57.412495 INFO: Competetive: True
+3:26:57.664794 WARNING: dropped 10 target PSMs due to missing features
+3:26:57.664794 WARNING: dropped 10 decoy PSMs due to missing features
+3:27:01.941835 INFO: Test AUC: 0.572
+3:27:01.941835 INFO: Train AUC: 0.586
+3:27:01.941835 INFO: AUC difference: 2.43%
+3:27:02.130748 INFO: === FDR correction performed with classifier version 3 ===
+3:27:02.146418 PROGRESS: ============================= Precursor FDR =============================
+3:27:02.146418 PROGRESS: Total precursors accumulated: 617
+3:27:02.146418 PROGRESS: Target precursors: 564 (91.41%)
+3:27:02.146418 PROGRESS: Decoy precursors: 53 (8.59%)
+3:27:02.146418 PROGRESS: 
+3:27:02.146418 PROGRESS: Precursor Summary:
+3:27:02.146418 PROGRESS: Channel   0:	 0.05 FDR:   439; 0.01 FDR:   306; 0.001 FDR:   136
+3:27:02.146418 PROGRESS: 
+3:27:02.146418 PROGRESS: Protein Summary:
+3:27:02.146418 PROGRESS: Channel   0:	 0.05 FDR:   416; 0.01 FDR:   292; 0.001 FDR:   131
+3:27:02.146418 PROGRESS: =========================================================================
+3:27:02.161989 INFO: fragments_df_filtered: 1321
+3:27:02.550304 INFO: calibration group: precursor, fitting rt estimator 
+3:27:02.644589 INFO: calibration group: fragment, fitting mz estimator 
+3:27:03.089583 INFO: calibration group: precursor, predicting mz
+3:27:03.089583 WARNING: mz prediction was skipped as it has not been fitted yet
+3:27:03.089583 INFO: calibration group: precursor, predicting rt
+3:27:03.164617 INFO: calibration group: fragment, predicting mz
+3:27:03.456578 INFO: === checking if optimization conditions were reached ===
+3:27:03.456578 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+3:27:03.472139 INFO: ==============================================
+3:27:03.472139 PROGRESS: Optimization finished for ms2_error.
+3:27:03.805928 INFO: calibration group: precursor, predicting mz
+3:27:03.805928 WARNING: mz prediction was skipped as it has not been fitted yet
+3:27:03.805928 INFO: calibration group: precursor, predicting rt
+3:27:03.906878 INFO: calibration group: fragment, predicting mz
+3:27:04.206404 INFO: Starting optimization step 0.
+3:27:04.206404 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:27:04.206404 PROGRESS: Extracting batch of 110601 precursors
+3:27:04.253284 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:27:04.253284 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:27:04.253284 INFO: FWHM in RT is 17.59 seconds, sigma is 0.64
+3:27:04.253284 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:27:04.253284 INFO: Starting candidate selection
+3:27:49.428432 INFO: Starting candidate scoring
+3:27:53.927391 INFO: Finished candidate processing
+3:27:53.927391 INFO: Collecting candidate features
+3:27:54.496225 WARNING: intensity_correlation has 15 NaNs ( 0.01 % out of 220870)
+3:27:54.511850 INFO: Collecting fragment features
+3:27:54.781838 INFO: Finished candidate scoring
+3:27:54.952662 PROGRESS: === Extracted 220870 precursors and 1593687 fragments ===
+3:27:54.952662 INFO: performing precursor FDR with 47 features
+3:27:54.952662 INFO: Decoy channel: -1
+3:27:54.952662 INFO: Competetive: True
+3:27:55.193346 WARNING: dropped 7 target PSMs due to missing features
+3:27:55.193346 WARNING: dropped 8 decoy PSMs due to missing features
+3:27:59.662542 INFO: Test AUC: 0.572
+3:27:59.662542 INFO: Train AUC: 0.591
+3:27:59.662542 INFO: AUC difference: 3.35%
+3:27:59.860881 INFO: === FDR correction performed with classifier version 4 ===
+3:27:59.862876 PROGRESS: ============================= Precursor FDR =============================
+3:27:59.862876 PROGRESS: Total precursors accumulated: 657
+3:27:59.863876 PROGRESS: Target precursors: 604 (91.93%)
+3:27:59.863876 PROGRESS: Decoy precursors: 53 (8.07%)
+3:27:59.863876 PROGRESS: 
+3:27:59.863876 PROGRESS: Precursor Summary:
+3:27:59.866892 PROGRESS: Channel   0:	 0.05 FDR:   455; 0.01 FDR:   349; 0.001 FDR:   176
+3:27:59.866892 PROGRESS: 
+3:27:59.866892 PROGRESS: Protein Summary:
+3:27:59.869884 PROGRESS: Channel   0:	 0.05 FDR:   431; 0.01 FDR:   332; 0.001 FDR:   171
+3:27:59.869884 PROGRESS: =========================================================================
+3:27:59.880400 INFO: fragments_df_filtered: 1433
+3:28:00.260790 INFO: calibration group: precursor, fitting rt estimator 
+3:28:00.354519 INFO: calibration group: fragment, fitting mz estimator 
+3:28:00.840693 INFO: calibration group: precursor, predicting mz
+3:28:00.840693 WARNING: mz prediction was skipped as it has not been fitted yet
+3:28:00.840693 INFO: calibration group: precursor, predicting rt
+3:28:00.909103 INFO: calibration group: fragment, predicting mz
+3:28:01.238498 INFO: === checking if optimization conditions were reached ===
+3:28:01.254115 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+3:28:01.254115 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 775.4718.
+3:28:01.254115 INFO: ==============================================
+3:28:01.254115 INFO: Starting optimization step 1.
+3:28:01.254115 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:28:01.254115 PROGRESS: Extracting batch of 110601 precursors
+3:28:01.285785 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:28:01.301434 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:28:01.301434 INFO: FWHM in RT is 17.37 seconds, sigma is 0.63
+3:28:01.301434 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:28:01.301434 INFO: Starting candidate selection
+3:28:11.710570 INFO: Starting candidate scoring
+3:28:15.365312 INFO: Finished candidate processing
+3:28:15.365312 INFO: Collecting candidate features
+3:28:15.926876 WARNING: intensity_correlation has 339 NaNs ( 0.16 % out of 212512)
+3:28:15.971735 INFO: Collecting fragment features
+3:28:16.208675 INFO: Finished candidate scoring
+3:28:16.399362 PROGRESS: === Extracted 212512 precursors and 1292818 fragments ===
+3:28:16.401246 INFO: performing precursor FDR with 47 features
+3:28:16.401246 INFO: Decoy channel: -1
+3:28:16.401246 INFO: Competetive: True
+3:28:16.650005 WARNING: dropped 166 target PSMs due to missing features
+3:28:16.650005 WARNING: dropped 173 decoy PSMs due to missing features
+3:28:20.669051 INFO: Test AUC: 0.561
+3:28:20.669051 INFO: Train AUC: 0.577
+3:28:20.669051 INFO: AUC difference: 2.69%
+3:28:20.863167 INFO: === FDR correction performed with classifier version 4 ===
+3:28:20.863167 PROGRESS: ============================= Precursor FDR =============================
+3:28:20.863167 PROGRESS: Total precursors accumulated: 680
+3:28:20.863167 PROGRESS: Target precursors: 622 (91.47%)
+3:28:20.863167 PROGRESS: Decoy precursors: 58 (8.53%)
+3:28:20.863167 PROGRESS: 
+3:28:20.863167 PROGRESS: Precursor Summary:
+3:28:20.863167 PROGRESS: Channel   0:	 0.05 FDR:   570; 0.01 FDR:   430; 0.001 FDR:   268
+3:28:20.863167 PROGRESS: 
+3:28:20.863167 PROGRESS: Protein Summary:
+3:28:20.880401 PROGRESS: Channel   0:	 0.05 FDR:   538; 0.01 FDR:   409; 0.001 FDR:   257
+3:28:20.880401 PROGRESS: =========================================================================
+3:28:20.880401 INFO: fragments_df_filtered: 1509
+3:28:21.259499 INFO: calibration group: precursor, fitting rt estimator 
+3:28:21.368587 INFO: calibration group: fragment, fitting mz estimator 
+3:28:21.846422 INFO: calibration group: precursor, predicting mz
+3:28:21.846422 WARNING: mz prediction was skipped as it has not been fitted yet
+3:28:21.846422 INFO: calibration group: precursor, predicting rt
+3:28:21.910671 INFO: calibration group: fragment, predicting mz
+3:28:22.227260 INFO: === checking if optimization conditions were reached ===
+3:28:22.227260 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+3:28:22.227260 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 709.1761.
+3:28:22.227260 INFO: ==============================================
+3:28:22.227260 INFO: Starting optimization step 2.
+3:28:22.227260 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:28:22.227260 PROGRESS: Extracting batch of 110601 precursors
+3:28:22.274174 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:28:22.274174 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:28:22.274174 INFO: FWHM in RT is 17.46 seconds, sigma is 0.64
+3:28:22.274174 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:28:22.274174 INFO: Starting candidate selection
+3:28:31.866514 INFO: Starting candidate scoring
+3:28:35.825042 INFO: Finished candidate processing
+3:28:35.825042 INFO: Collecting candidate features
+3:28:36.409602 WARNING: intensity_correlation has 347 NaNs ( 0.16 % out of 212008)
+3:28:36.434091 INFO: Collecting fragment features
+3:28:36.766126 INFO: Finished candidate scoring
+3:28:36.992676 PROGRESS: === Extracted 212008 precursors and 1282442 fragments ===
+3:28:36.992676 INFO: performing precursor FDR with 47 features
+3:28:36.992676 INFO: Decoy channel: -1
+3:28:36.992676 INFO: Competetive: True
+3:28:37.395242 WARNING: dropped 171 target PSMs due to missing features
+3:28:37.395242 WARNING: dropped 176 decoy PSMs due to missing features
+3:28:41.428376 INFO: Test AUC: 0.561
+3:28:41.428376 INFO: Train AUC: 0.577
+3:28:41.428376 INFO: AUC difference: 2.84%
+3:28:41.622426 INFO: === FDR correction performed with classifier version 4 ===
+3:28:41.622426 PROGRESS: ============================= Precursor FDR =============================
+3:28:41.622426 PROGRESS: Total precursors accumulated: 725
+3:28:41.638173 PROGRESS: Target precursors: 663 (91.45%)
+3:28:41.638173 PROGRESS: Decoy precursors: 62 (8.55%)
+3:28:41.638173 PROGRESS: 
+3:28:41.638173 PROGRESS: Precursor Summary:
+3:28:41.638173 PROGRESS: Channel   0:	 0.05 FDR:   543; 0.01 FDR:   363; 0.001 FDR:   342
+3:28:41.638173 PROGRESS: 
+3:28:41.638173 PROGRESS: Protein Summary:
+3:28:41.643754 PROGRESS: Channel   0:	 0.05 FDR:   511; 0.01 FDR:   347; 0.001 FDR:   327
+3:28:41.643754 PROGRESS: =========================================================================
+3:28:41.654361 INFO: fragments_df_filtered: 1471
+3:28:42.022696 INFO: calibration group: precursor, fitting rt estimator 
+3:28:42.149114 INFO: calibration group: fragment, fitting mz estimator 
+3:28:42.662098 INFO: calibration group: precursor, predicting mz
+3:28:42.662098 WARNING: mz prediction was skipped as it has not been fitted yet
+3:28:42.662098 INFO: calibration group: precursor, predicting rt
+3:28:42.745346 INFO: calibration group: fragment, predicting mz
+3:28:43.049705 INFO: === checking if optimization conditions were reached ===
+3:28:43.049705 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+3:28:43.049705 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 567.3309.
+3:28:43.049705 INFO: ==============================================
+3:28:43.049705 INFO: Starting optimization step 3.
+3:28:43.049705 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:28:43.049705 PROGRESS: Extracting batch of 110601 precursors
+3:28:43.096713 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:28:43.096713 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:28:43.096713 INFO: FWHM in RT is 17.50 seconds, sigma is 0.64
+3:28:43.096713 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:28:43.096713 INFO: Starting candidate selection
+3:28:52.102182 INFO: Starting candidate scoring
+3:28:55.731591 INFO: Finished candidate processing
+3:28:55.731591 INFO: Collecting candidate features
+3:28:56.264787 WARNING: intensity_correlation has 401 NaNs ( 0.19 % out of 209743)
+3:28:56.295135 INFO: Collecting fragment features
+3:28:56.530399 INFO: Finished candidate scoring
+3:28:56.690262 PROGRESS: === Extracted 209743 precursors and 1236833 fragments ===
+3:28:56.690262 INFO: performing precursor FDR with 47 features
+3:28:56.690262 INFO: Decoy channel: -1
+3:28:56.690262 INFO: Competetive: True
+3:28:56.935574 WARNING: dropped 202 target PSMs due to missing features
+3:28:56.935574 WARNING: dropped 199 decoy PSMs due to missing features
+3:29:01.062530 INFO: Test AUC: 0.549
+3:29:01.062530 INFO: Train AUC: 0.576
+3:29:01.062530 INFO: AUC difference: 4.65%
+3:29:01.242776 INFO: === FDR correction performed with classifier version 4 ===
+3:29:01.242776 PROGRESS: ============================= Precursor FDR =============================
+3:29:01.242776 PROGRESS: Total precursors accumulated: 679
+3:29:01.242776 PROGRESS: Target precursors: 619 (91.16%)
+3:29:01.242776 PROGRESS: Decoy precursors: 60 (8.84%)
+3:29:01.242776 PROGRESS: 
+3:29:01.242776 PROGRESS: Precursor Summary:
+3:29:01.258395 PROGRESS: Channel   0:	 0.05 FDR:   545; 0.01 FDR:   425; 0.001 FDR:   265
+3:29:01.258395 PROGRESS: 
+3:29:01.258395 PROGRESS: Protein Summary:
+3:29:01.258395 PROGRESS: Channel   0:	 0.05 FDR:   513; 0.01 FDR:   406; 0.001 FDR:   253
+3:29:01.258395 PROGRESS: =========================================================================
+3:29:01.274521 INFO: fragments_df_filtered: 1548
+3:29:01.604828 INFO: calibration group: precursor, fitting rt estimator 
+3:29:01.698642 INFO: calibration group: fragment, fitting mz estimator 
+3:29:02.228740 INFO: calibration group: precursor, predicting mz
+3:29:02.228740 WARNING: mz prediction was skipped as it has not been fitted yet
+3:29:02.228740 INFO: calibration group: precursor, predicting rt
+3:29:02.291370 INFO: calibration group: fragment, predicting mz
+3:29:02.600784 INFO: === checking if optimization conditions were reached ===
+3:29:02.600784 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+3:29:02.600784 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 502.4584.
+3:29:02.600784 INFO: ==============================================
+3:29:02.600784 INFO: Starting optimization step 4.
+3:29:02.600784 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:29:02.600784 PROGRESS: Extracting batch of 110601 precursors
+3:29:02.648491 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:29:02.648491 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:29:02.648491 INFO: FWHM in RT is 17.50 seconds, sigma is 0.64
+3:29:02.648491 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:29:02.648491 INFO: Starting candidate selection
+3:29:10.694094 INFO: Starting candidate scoring
+3:29:14.385178 INFO: Finished candidate processing
+3:29:14.385178 INFO: Collecting candidate features
+3:29:14.945870 WARNING: intensity_correlation has 399 NaNs ( 0.19 % out of 206582)
+3:29:14.961482 INFO: Collecting fragment features
+3:29:15.191972 INFO: Finished candidate scoring
+3:29:15.380813 PROGRESS: === Extracted 206582 precursors and 1194494 fragments ===
+3:29:15.380813 INFO: performing precursor FDR with 47 features
+3:29:15.380813 INFO: Decoy channel: -1
+3:29:15.380813 INFO: Competetive: True
+3:29:15.618556 WARNING: dropped 204 target PSMs due to missing features
+3:29:15.618556 WARNING: dropped 195 decoy PSMs due to missing features
+3:29:19.648855 INFO: Test AUC: 0.555
+3:29:19.648855 INFO: Train AUC: 0.575
+3:29:19.648855 INFO: AUC difference: 3.46%
+3:29:19.828396 INFO: === FDR correction performed with classifier version 4 ===
+3:29:19.844572 PROGRESS: ============================= Precursor FDR =============================
+3:29:19.844572 PROGRESS: Total precursors accumulated: 720
+3:29:19.844572 PROGRESS: Target precursors: 658 (91.39%)
+3:29:19.845628 PROGRESS: Decoy precursors: 62 (8.61%)
+3:29:19.845628 PROGRESS: 
+3:29:19.845628 PROGRESS: Precursor Summary:
+3:29:19.848619 PROGRESS: Channel   0:	 0.05 FDR:   567; 0.01 FDR:   422; 0.001 FDR:   319
+3:29:19.849614 PROGRESS: 
+3:29:19.849614 PROGRESS: Protein Summary:
+3:29:19.852617 PROGRESS: Channel   0:	 0.05 FDR:   533; 0.01 FDR:   403; 0.001 FDR:   307
+3:29:19.852617 PROGRESS: =========================================================================
+3:29:19.861805 INFO: fragments_df_filtered: 1541
+3:29:20.217807 INFO: calibration group: precursor, fitting rt estimator 
+3:29:20.328711 INFO: calibration group: fragment, fitting mz estimator 
+3:29:20.913064 INFO: calibration group: precursor, predicting mz
+3:29:20.913064 WARNING: mz prediction was skipped as it has not been fitted yet
+3:29:20.913064 INFO: calibration group: precursor, predicting rt
+3:29:21.007451 INFO: calibration group: fragment, predicting mz
+3:29:21.306510 INFO: === checking if optimization conditions were reached ===
+3:29:21.322185 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+3:29:21.325432 PROGRESS: ❌ rt_error       : optimization incomplete after 5 search(es). Will search with parameter 506.7820.
+3:29:21.325432 INFO: ==============================================
+3:29:21.325432 INFO: Starting optimization step 5.
+3:29:21.326330 PROGRESS: === Extracting elution groups 0 to 56000 ===
+3:29:21.326330 PROGRESS: Extracting batch of 110601 precursors
+3:29:21.362552 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:29:21.362552 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:29:21.362552 INFO: FWHM in RT is 17.45 seconds, sigma is 0.63
+3:29:21.362552 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:29:21.362552 INFO: Starting candidate selection
+3:29:29.432432 INFO: Starting candidate scoring
+3:29:33.044792 INFO: Finished candidate processing
+3:29:33.044792 INFO: Collecting candidate features
+3:29:33.588964 WARNING: intensity_correlation has 422 NaNs ( 0.20 % out of 207346)
+3:29:33.604070 INFO: Collecting fragment features
+3:29:33.843008 INFO: Finished candidate scoring
+3:29:34.005927 PROGRESS: === Extracted 207346 precursors and 1201338 fragments ===
+3:29:34.005927 INFO: performing precursor FDR with 47 features
+3:29:34.005927 INFO: Decoy channel: -1
+3:29:34.005927 INFO: Competetive: True
+3:29:34.242413 WARNING: dropped 210 target PSMs due to missing features
+3:29:34.242413 WARNING: dropped 212 decoy PSMs due to missing features
+3:29:38.228483 INFO: Test AUC: 0.556
+3:29:38.228483 INFO: Train AUC: 0.576
+3:29:38.228483 INFO: AUC difference: 3.37%
+3:29:38.428942 INFO: === FDR correction performed with classifier version 4 ===
+3:29:38.428942 PROGRESS: ============================= Precursor FDR =============================
+3:29:38.428942 PROGRESS: Total precursors accumulated: 725
+3:29:38.428942 PROGRESS: Target precursors: 661 (91.17%)
+3:29:38.428942 PROGRESS: Decoy precursors: 64 (8.83%)
+3:29:38.428942 PROGRESS: 
+3:29:38.428942 PROGRESS: Precursor Summary:
+3:29:38.428942 PROGRESS: Channel   0:	 0.05 FDR:   569; 0.01 FDR:   428; 0.001 FDR:   357
+3:29:38.428942 PROGRESS: 
+3:29:38.428942 PROGRESS: Protein Summary:
+3:29:38.428942 PROGRESS: Channel   0:	 0.05 FDR:   536; 0.01 FDR:   407; 0.001 FDR:   340
+3:29:38.428942 PROGRESS: =========================================================================
+3:29:38.443948 INFO: fragments_df_filtered: 1549
+3:29:38.827265 INFO: calibration group: precursor, fitting rt estimator 
+3:29:38.930249 INFO: calibration group: fragment, fitting mz estimator 
+3:29:39.489418 INFO: calibration group: precursor, predicting mz
+3:29:39.489418 WARNING: mz prediction was skipped as it has not been fitted yet
+3:29:39.489418 INFO: calibration group: precursor, predicting rt
+3:29:39.572623 INFO: calibration group: fragment, predicting mz
+3:29:39.890755 INFO: === checking if optimization conditions were reached ===
+3:29:39.890755 PROGRESS: === Optimization of rt_error has been performed 6 time(s); minimum number is 2 ===
+3:29:39.890755 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 502.4584 found after 6 searches.
+3:29:39.890755 INFO: ==============================================
+3:29:39.890755 PROGRESS: Optimization finished for rt_error.
+3:29:40.231545 INFO: calibration group: precursor, predicting mz
+3:29:40.236106 WARNING: mz prediction was skipped as it has not been fitted yet
+3:29:40.236106 INFO: calibration group: precursor, predicting rt
+3:29:40.325008 INFO: calibration group: fragment, predicting mz
+3:29:40.680946 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+3:29:40.680946 PROGRESS: ==============================================
+3:29:40.680946 PROGRESS: ms2_error      : 10.0000
+3:29:40.680946 PROGRESS: rt_error       : 502.4584
+3:29:40.680946 PROGRESS: ==============================================
+3:29:40.775300 INFO: calibration group: precursor, predicting mz
+3:29:40.775300 WARNING: mz prediction was skipped as it has not been fitted yet
+3:29:40.775300 INFO: calibration group: precursor, predicting rt
+3:29:47.621953 INFO: calibration group: fragment, predicting mz
+3:30:19.235584 PROGRESS: Extracting batch of 10640830 precursors
+3:30:21.515821 INFO: Duty cycle consists of 151 frames, 5.83 seconds cycle time
+3:30:21.515821 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:30:21.515821 INFO: FWHM in RT is 17.45 seconds, sigma is 0.63
+3:30:21.515821 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+3:30:21.515821 INFO: Starting candidate selection
+3:42:52.046100 INFO: Applying score cutoff of 71.76372343444824
+3:42:52.515627 INFO: Removed 15821556 precursors with score below cutoff
+3:42:55.629804 INFO: Starting candidate scoring
+3:44:41.865476 INFO: Finished candidate processing
+3:44:41.865476 INFO: Collecting candidate features
+3:44:57.433254 INFO: Collecting fragment features
+3:45:04.306756 INFO: Finished candidate scoring
+3:45:14.295992 INFO: === FDR correction performed with classifier version 9 ===
+3:45:14.295992 INFO: performing precursor FDR with 47 features
+3:45:14.295992 INFO: Decoy channel: -1
+3:45:14.295992 INFO: Competetive: True
+3:47:26.100909 INFO: Test AUC: 0.581
+3:47:26.100909 INFO: Train AUC: 0.585
+3:47:26.100909 INFO: AUC difference: 0.57%
+3:47:27.138561 INFO: Removing fragments below FDR threshold
+3:47:27.956106 PROGRESS: ============================= Precursor FDR =============================
+3:47:27.956106 PROGRESS: Total precursors accumulated: 47,388
+3:47:27.957058 PROGRESS: Target precursors: 46,919 (99.01%)
+3:47:27.957058 PROGRESS: Decoy precursors: 469 (0.99%)
+3:47:27.957058 PROGRESS: 
+3:47:27.957058 PROGRESS: Precursor Summary:
+3:47:28.027256 PROGRESS: Channel   0:	 0.05 FDR: 46,919; 0.01 FDR: 46,919; 0.001 FDR: 33,220
+3:47:28.027256 PROGRESS: 
+3:47:28.027256 PROGRESS: Protein Summary:
+3:47:28.104326 PROGRESS: Channel   0:	 0.05 FDR: 8,540; 0.01 FDR: 8,540; 0.001 FDR: 6,724
+3:47:28.104326 PROGRESS: =========================================================================
+3:47:29.132055 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+3:47:30.008942 PROGRESS: Loading raw file 5/6: LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+3:47:30.008942 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+3:48:03.969436 INFO: Determining DIA cycle
+3:48:03.984949 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+3:48:04.000583 INFO: Determining DIA cycle
+3:48:04.031836 INFO: Found cycle with start 0.00 min and length 151.
+3:48:04.204646 INFO: ============ Raw file stats ============
+3:48:04.204646 INFO: RT (min)            : 0.0 - 150.0
+3:48:04.204646 INFO: RT duration (sec)   : 8999.7
+3:48:04.204646 INFO: RT duration (min)   : 150.0
+3:48:04.204646 INFO: Cycle len (scans)   : 151
+3:48:04.204646 INFO: Cycle len (sec)     : 5.84
+3:48:04.204646 INFO: Number of cycles    : 1541
+3:48:04.204646 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+3:48:04.204646 INFO: ========================================
+3:48:06.282202 INFO: Initializing CalibrationManager
+3:48:06.282202 INFO: Loading calibration config
+3:48:06.282202 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated'], 'function': LOESSRegression()}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated'], 'function': LOESSRegression(n_kernels=2)}]}]
+3:48:06.282202 INFO: Calibration group :fragment, found 1 estimator(s)
+3:48:06.282202 INFO: Calibration group :precursor, found 3 estimator(s)
+3:48:06.282202 INFO: Disabling ion mobility calibration
+3:48:06.282202 INFO: removed mobility estimator from group precursor
+3:48:06.282202 INFO: Initializing OptimizationManager
+3:48:06.282202 INFO: initial parameter: ms1_error = 30
+3:48:06.282202 INFO: initial parameter: ms2_error = 30
+3:48:06.282202 INFO: initial parameter: rt_error = 4499.99609375
+3:48:06.282202 INFO: initial parameter: mobility_error = 0.1
+3:48:06.282202 INFO: initial parameter: column_type = library
+3:48:06.282202 INFO: initial parameter: num_candidates = 1
+3:48:06.282202 INFO: initial parameter: classifier_version = -1
+3:48:06.282202 INFO: initial parameter: fwhm_rt = 5
+3:48:06.282202 INFO: initial parameter: fwhm_mobility = 0.01
+3:48:06.282202 INFO: initial parameter: score_cutoff = 0
+3:48:06.282202 INFO: Initializing TimingManager
+3:48:06.282202 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+3:48:06.282202 INFO: Initializing FDRManager
+3:48:06.282202 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+3:48:08.693701 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+3:48:11.804444 PROGRESS: Starting initial search for precursors.
+3:48:12.224418 INFO: Starting optimization step 0.
+3:48:12.224418 PROGRESS: === Extracting elution groups 0 to 8000 ===
+3:48:12.240035 PROGRESS: Extracting batch of 15803 precursors
+3:48:12.240035 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:48:12.240035 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:48:12.240035 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:48:12.240035 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:48:12.240035 INFO: Starting candidate selection
+3:48:18.933222 INFO: Starting candidate scoring
+3:48:19.247665 INFO: Finished candidate processing
+3:48:19.247665 INFO: Collecting candidate features
+3:48:19.301342 INFO: Collecting fragment features
+3:48:19.331178 INFO: Finished candidate scoring
+3:48:19.346809 PROGRESS: === Extracted 15796 precursors and 140000 fragments ===
+3:48:19.346809 INFO: performing precursor FDR with 47 features
+3:48:19.346809 INFO: Decoy channel: -1
+3:48:19.346809 INFO: Competetive: True
+3:48:19.679298 INFO: Test AUC: 0.505
+3:48:19.679298 INFO: Train AUC: 0.518
+3:48:19.679298 INFO: AUC difference: 2.57%
+3:48:19.830780 INFO: === FDR correction performed with classifier version -1 ===
+3:48:19.855878 PROGRESS: ============================= Precursor FDR =============================
+3:48:19.855878 PROGRESS: Total precursors accumulated: 7,994
+3:48:19.855878 PROGRESS: Target precursors: 4,255 (53.23%)
+3:48:19.856879 PROGRESS: Decoy precursors: 3,739 (46.77%)
+3:48:19.856879 PROGRESS: 
+3:48:19.856879 PROGRESS: Precursor Summary:
+3:48:19.859878 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:48:19.859878 PROGRESS: 
+3:48:19.859878 PROGRESS: Protein Summary:
+3:48:19.862870 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:48:19.862870 PROGRESS: =========================================================================
+3:48:20.042053 INFO: Starting optimization step 1.
+3:48:20.042053 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+3:48:20.057692 PROGRESS: Extracting batch of 31592 precursors
+3:48:20.073302 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:48:20.073302 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:48:20.073302 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:48:20.073302 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:48:20.073302 INFO: Starting candidate selection
+3:48:32.999630 INFO: Starting candidate scoring
+3:48:33.600217 INFO: Finished candidate processing
+3:48:33.600217 INFO: Collecting candidate features
+3:48:33.704426 INFO: Collecting fragment features
+3:48:33.767487 INFO: Finished candidate scoring
+3:48:33.850956 PROGRESS: === Extracted 47346 precursors and 420294 fragments ===
+3:48:33.872508 INFO: performing precursor FDR with 47 features
+3:48:33.872508 INFO: Decoy channel: -1
+3:48:33.872508 INFO: Competetive: True
+3:48:34.769949 INFO: Test AUC: 0.500
+3:48:34.769949 INFO: Train AUC: 0.500
+3:48:34.769949 INFO: AUC difference: 0.01%
+3:48:34.910119 INFO: === FDR correction performed with classifier version -1 ===
+3:48:34.911123 PROGRESS: ============================= Precursor FDR =============================
+3:48:34.912133 PROGRESS: Total precursors accumulated: 1
+3:48:34.912133 PROGRESS: Target precursors: 1 (100.00%)
+3:48:34.912133 PROGRESS: Decoy precursors: 0 (0.00%)
+3:48:34.912133 PROGRESS: 
+3:48:34.912133 PROGRESS: Precursor Summary:
+3:48:34.913227 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:48:34.913227 PROGRESS: 
+3:48:34.913227 PROGRESS: Protein Summary:
+3:48:34.914232 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:48:34.914232 PROGRESS: =========================================================================
+3:48:35.179654 INFO: Starting optimization step 2.
+3:48:35.179654 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+3:48:35.195349 PROGRESS: Extracting batch of 63206 precursors
+3:48:35.210993 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:48:35.210993 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:48:35.210993 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:48:35.210993 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:48:35.210993 INFO: Starting candidate selection
+3:49:01.262119 INFO: Starting candidate scoring
+3:49:02.460432 INFO: Finished candidate processing
+3:49:02.460432 INFO: Collecting candidate features
+3:49:02.666720 INFO: Collecting fragment features
+3:49:02.784045 INFO: Finished candidate scoring
+3:49:02.926306 PROGRESS: === Extracted 110506 precursors and 981591 fragments ===
+3:49:02.959493 INFO: performing precursor FDR with 47 features
+3:49:02.959493 INFO: Decoy channel: -1
+3:49:02.959493 INFO: Competetive: True
+3:49:05.128046 INFO: Test AUC: 0.558
+3:49:05.128046 INFO: Train AUC: 0.564
+3:49:05.128046 INFO: AUC difference: 1.14%
+3:49:05.305170 INFO: === FDR correction performed with classifier version -1 ===
+3:49:05.305170 PROGRESS: ============================= Precursor FDR =============================
+3:49:05.305170 PROGRESS: Total precursors accumulated: 1
+3:49:05.305170 PROGRESS: Target precursors: 1 (100.00%)
+3:49:05.305170 PROGRESS: Decoy precursors: 0 (0.00%)
+3:49:05.305170 PROGRESS: 
+3:49:05.305170 PROGRESS: Precursor Summary:
+3:49:05.305170 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:49:05.305170 PROGRESS: 
+3:49:05.320799 PROGRESS: Protein Summary:
+3:49:05.322894 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+3:49:05.322894 PROGRESS: =========================================================================
+3:49:05.738785 INFO: Starting optimization step 3.
+3:49:05.738785 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+3:49:05.738785 PROGRESS: Extracting batch of 126403 precursors
+3:49:05.790329 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:49:05.790329 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:49:05.790329 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:49:05.790329 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:49:05.790329 INFO: Starting candidate selection
+3:49:57.368807 INFO: Starting candidate scoring
+3:50:00.390762 INFO: Finished candidate processing
+3:50:00.390762 INFO: Collecting candidate features
+3:50:00.856245 INFO: Collecting fragment features
+3:50:01.040956 INFO: Finished candidate scoring
+3:50:01.277043 PROGRESS: === Extracted 236806 precursors and 2102170 fragments ===
+3:50:01.359091 INFO: performing precursor FDR with 47 features
+3:50:01.360086 INFO: Decoy channel: -1
+3:50:01.360086 INFO: Competetive: True
+3:50:06.265032 INFO: Test AUC: 0.564
+3:50:06.265032 INFO: Train AUC: 0.577
+3:50:06.265032 INFO: AUC difference: 2.23%
+3:50:06.448990 INFO: === FDR correction performed with classifier version -1 ===
+3:50:06.464715 PROGRESS: ============================= Precursor FDR =============================
+3:50:06.464715 PROGRESS: Total precursors accumulated: 8
+3:50:06.464715 PROGRESS: Target precursors: 8 (100.00%)
+3:50:06.464715 PROGRESS: Decoy precursors: 0 (0.00%)
+3:50:06.464715 PROGRESS: 
+3:50:06.464715 PROGRESS: Precursor Summary:
+3:50:06.464715 PROGRESS: Channel   0:	 0.05 FDR:     8; 0.01 FDR:     8; 0.001 FDR:     8
+3:50:06.464715 PROGRESS: 
+3:50:06.464715 PROGRESS: Protein Summary:
+3:50:06.464715 PROGRESS: Channel   0:	 0.05 FDR:     8; 0.01 FDR:     8; 0.001 FDR:     8
+3:50:06.464715 PROGRESS: =========================================================================
+3:50:07.094409 INFO: Starting optimization step 4.
+3:50:07.094409 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+3:50:07.094409 PROGRESS: Extracting batch of 252949 precursors
+3:50:07.169147 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:50:07.177658 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:50:07.177658 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:50:07.177658 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:50:07.177658 INFO: Starting candidate selection
+3:53:13.585517 INFO: Starting candidate scoring
+3:53:19.768247 INFO: Finished candidate processing
+3:53:19.768247 INFO: Collecting candidate features
+3:53:20.570453 INFO: Collecting fragment features
+3:53:20.929494 INFO: Finished candidate scoring
+3:53:21.456831 PROGRESS: === Extracted 489535 precursors and 4342589 fragments ===
+3:53:21.572178 INFO: performing precursor FDR with 47 features
+3:53:21.572178 INFO: Decoy channel: -1
+3:53:21.572178 INFO: Competetive: True
+3:53:32.011382 INFO: Test AUC: 0.570
+3:53:32.011382 INFO: Train AUC: 0.583
+3:53:32.011382 INFO: AUC difference: 2.39%
+3:53:32.295205 INFO: === FDR correction performed with classifier version -1 ===
+3:53:32.295205 PROGRESS: ============================= Precursor FDR =============================
+3:53:32.295205 PROGRESS: Total precursors accumulated: 2
+3:53:32.295205 PROGRESS: Target precursors: 2 (100.00%)
+3:53:32.295205 PROGRESS: Decoy precursors: 0 (0.00%)
+3:53:32.295205 PROGRESS: 
+3:53:32.295205 PROGRESS: Precursor Summary:
+3:53:32.295205 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+3:53:32.295205 PROGRESS: 
+3:53:32.295205 PROGRESS: Protein Summary:
+3:53:32.295205 PROGRESS: Channel   0:	 0.05 FDR:     2; 0.01 FDR:     2; 0.001 FDR:     2
+3:53:32.295205 PROGRESS: =========================================================================
+3:53:33.343378 INFO: Starting optimization step 5.
+3:53:33.343378 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+3:53:33.344525 PROGRESS: Extracting batch of 505702 precursors
+3:53:33.491797 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:53:33.491797 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:53:33.491797 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:53:33.491797 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:53:33.491797 INFO: Starting candidate selection
+3:56:59.527295 INFO: Starting candidate scoring
+3:57:08.796430 INFO: Finished candidate processing
+3:57:08.796430 INFO: Collecting candidate features
+3:57:10.373145 INFO: Collecting fragment features
+3:57:11.062182 INFO: Finished candidate scoring
+3:57:12.030791 PROGRESS: === Extracted 994819 precursors and 8825768 fragments ===
+3:57:12.235042 INFO: performing precursor FDR with 47 features
+3:57:12.235042 INFO: Decoy channel: -1
+3:57:12.235042 INFO: Competetive: True
+3:57:34.441232 INFO: Test AUC: 0.575
+3:57:34.441232 INFO: Train AUC: 0.583
+3:57:34.441232 INFO: AUC difference: 1.37%
+3:57:34.840238 INFO: === FDR correction performed with classifier version -1 ===
+3:57:34.856246 PROGRESS: ============================= Precursor FDR =============================
+3:57:34.856614 PROGRESS: Total precursors accumulated: 4,561
+3:57:34.856614 PROGRESS: Target precursors: 4,163 (91.27%)
+3:57:34.856614 PROGRESS: Decoy precursors: 398 (8.73%)
+3:57:34.856614 PROGRESS: 
+3:57:34.857616 PROGRESS: Precursor Summary:
+3:57:34.859622 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+3:57:34.859622 PROGRESS: 
+3:57:34.859622 PROGRESS: Protein Summary:
+3:57:34.861622 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+3:57:34.861622 PROGRESS: =========================================================================
+3:57:36.717051 INFO: Starting optimization step 6.
+3:57:36.717051 PROGRESS: === Extracting elution groups 504000 to 1016000 ===
+3:57:36.717051 PROGRESS: Extracting batch of 1011429 precursors
+3:57:37.007010 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+3:57:37.007010 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+3:57:37.007010 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+3:57:37.007010 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+3:57:37.007010 INFO: Starting candidate selection
+4:04:26.008527 INFO: Starting candidate scoring
+4:04:46.193240 INFO: Finished candidate processing
+4:04:46.193240 INFO: Collecting candidate features
+4:04:49.261396 INFO: Collecting fragment features
+4:04:50.606736 INFO: Finished candidate scoring
+4:04:52.872104 PROGRESS: === Extracted 2005479 precursors and 17793117 fragments ===
+4:04:53.283998 INFO: performing precursor FDR with 47 features
+4:04:53.283998 INFO: Decoy channel: -1
+4:04:53.283998 INFO: Competetive: True
+4:05:50.922648 INFO: Test AUC: 0.578
+4:05:50.922648 INFO: Train AUC: 0.583
+4:05:50.922648 INFO: AUC difference: 0.91%
+4:05:52.481908 INFO: === FDR correction performed with classifier version -1 ===
+4:05:52.497468 PROGRESS: ============================= Precursor FDR =============================
+4:05:52.497468 PROGRESS: Total precursors accumulated: 11,011
+4:05:52.497468 PROGRESS: Target precursors: 10,054 (91.31%)
+4:05:52.497468 PROGRESS: Decoy precursors: 957 (8.69%)
+4:05:52.497468 PROGRESS: 
+4:05:52.497468 PROGRESS: Precursor Summary:
+4:05:52.497468 PROGRESS: Channel   0:	 0.05 FDR: 8,238; 0.01 FDR:    18; 0.001 FDR:    18
+4:05:52.497468 PROGRESS: 
+4:05:52.497468 PROGRESS: Protein Summary:
+4:05:52.513054 PROGRESS: Channel   0:	 0.05 FDR: 4,305; 0.01 FDR:    18; 0.001 FDR:    18
+4:05:52.513054 PROGRESS: =========================================================================
+4:05:55.765723 INFO: Starting optimization step 7.
+4:05:55.765723 PROGRESS: === Extracting elution groups 1016000 to 2040000 ===
+4:05:55.765723 PROGRESS: Extracting batch of 2023223 precursors
+4:05:56.246990 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+4:05:56.246990 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+4:05:56.246990 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+4:05:56.246990 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+4:05:56.246990 INFO: Starting candidate selection
+4:19:44.827657 INFO: Starting candidate scoring
+4:20:29.157004 INFO: Finished candidate processing
+4:20:29.157004 INFO: Collecting candidate features
+4:20:35.368240 INFO: Collecting fragment features
+4:20:38.152928 INFO: Finished candidate scoring
+4:20:43.583602 PROGRESS: === Extracted 4027142 precursors and 35721118 fragments ===
+4:20:44.356248 INFO: performing precursor FDR with 47 features
+4:20:44.356248 INFO: Decoy channel: -1
+4:20:44.356248 INFO: Competetive: True
+4:23:27.332571 INFO: Test AUC: 0.581
+4:23:27.332571 INFO: Train AUC: 0.585
+4:23:27.332571 INFO: AUC difference: 0.66%
+4:23:28.462856 INFO: === FDR correction performed with classifier version -1 ===
+4:23:28.478599 PROGRESS: ============================= Precursor FDR =============================
+4:23:28.478599 PROGRESS: Total precursors accumulated: 24,390
+4:23:28.478599 PROGRESS: Target precursors: 22,324 (91.53%)
+4:23:28.478599 PROGRESS: Decoy precursors: 2,066 (8.47%)
+4:23:28.478599 PROGRESS: 
+4:23:28.478599 PROGRESS: Precursor Summary:
+4:23:28.478599 PROGRESS: Channel   0:	 0.05 FDR: 18,425; 0.01 FDR:     5; 0.001 FDR:     5
+4:23:28.478599 PROGRESS: 
+4:23:28.478599 PROGRESS: Protein Summary:
+4:23:28.494123 PROGRESS: Channel   0:	 0.05 FDR: 6,864; 0.01 FDR:     5; 0.001 FDR:     5
+4:23:28.494123 PROGRESS: =========================================================================
+4:23:34.617695 INFO: Starting optimization step 8.
+4:23:34.617695 PROGRESS: === Extracting elution groups 2040000 to 4088000 ===
+4:23:34.617695 PROGRESS: Extracting batch of 4046233 precursors
+4:23:35.587129 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+4:23:35.587129 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+4:23:35.587129 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+4:23:35.587129 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+4:23:35.587129 INFO: Starting candidate selection
+4:51:13.569319 INFO: Starting candidate scoring
+4:52:32.715981 INFO: Finished candidate processing
+4:52:32.715981 INFO: Collecting candidate features
+4:52:44.097289 WARNING: intensity_correlation has 1 NaNs ( 0.00 % out of 4043123)
+4:52:44.584640 INFO: Collecting fragment features
+4:52:50.077013 INFO: Finished candidate scoring
+4:53:02.324225 PROGRESS: === Extracted 8070265 precursors and 71585809 fragments ===
+4:53:03.890074 INFO: performing precursor FDR with 47 features
+4:53:03.890074 INFO: Decoy channel: -1
+4:53:03.890074 INFO: Competetive: True
+4:53:13.433232 WARNING: dropped 1 decoy PSMs due to missing features
+5:00:22.495732 INFO: Test AUC: 0.584
+5:00:22.495732 INFO: Train AUC: 0.586
+5:00:22.495732 INFO: AUC difference: 0.44%
+5:00:24.471616 INFO: === FDR correction performed with classifier version -1 ===
+5:00:24.518498 PROGRESS: ============================= Precursor FDR =============================
+5:00:24.518498 PROGRESS: Total precursors accumulated: 55,700
+5:00:24.518498 PROGRESS: Target precursors: 51,246 (92.00%)
+5:00:24.518498 PROGRESS: Decoy precursors: 4,454 (8.00%)
+5:00:24.518498 PROGRESS: 
+5:00:24.518498 PROGRESS: Precursor Summary:
+5:00:24.550353 PROGRESS: Channel   0:	 0.05 FDR: 42,389; 0.01 FDR: 31,311; 0.001 FDR:    18
+5:00:24.550353 PROGRESS: 
+5:00:24.550353 PROGRESS: Protein Summary:
+5:00:24.588136 PROGRESS: Channel   0:	 0.05 FDR: 11,412; 0.01 FDR: 7,167; 0.001 FDR:    18
+5:00:24.588136 PROGRESS: =========================================================================
+5:00:25.972640 INFO: fragments_df_filtered: 5000
+5:00:27.155870 INFO: calibration group: precursor, fitting rt estimator 
+5:03:43.109938 INFO: calibration group: fragment, fitting mz estimator 
+5:03:48.183292 INFO: calibration group: precursor, predicting mz
+5:03:48.183292 WARNING: mz prediction was skipped as it has not been fitted yet
+5:03:48.183292 INFO: calibration group: precursor, predicting rt
+5:03:48.277683 INFO: calibration group: fragment, predicting mz
+5:03:48.589065 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+5:03:48.589065 INFO: Starting optimization step 9.
+5:03:48.589065 PROGRESS: === Extracting elution groups 0 to 56000 ===
+5:03:48.589065 PROGRESS: Extracting batch of 110601 precursors
+5:03:48.620329 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:03:48.620329 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:03:48.620329 INFO: FWHM in RT is 20.16 seconds, sigma is 0.73
+5:03:48.620329 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:03:48.620329 INFO: Starting candidate selection
+5:04:36.259161 INFO: Starting candidate scoring
+5:04:40.740236 INFO: Finished candidate processing
+5:04:40.740236 INFO: Collecting candidate features
+5:04:41.406961 INFO: Collecting fragment features
+5:04:41.710428 INFO: Finished candidate scoring
+5:04:41.892083 PROGRESS: === Extracted 221021 precursors and 2022896 fragments ===
+5:04:41.892083 INFO: performing precursor FDR with 47 features
+5:04:41.892083 INFO: Decoy channel: -1
+5:04:41.892083 INFO: Competetive: True
+5:04:46.615846 INFO: Test AUC: 0.580
+5:04:46.615846 INFO: Train AUC: 0.604
+5:04:46.615846 INFO: AUC difference: 4.07%
+5:04:46.804670 INFO: === FDR correction performed with classifier version 8 ===
+5:04:46.804670 PROGRESS: ============================= Precursor FDR =============================
+5:04:46.804670 PROGRESS: Total precursors accumulated: 1,094
+5:04:46.804670 PROGRESS: Target precursors: 1,001 (91.50%)
+5:04:46.804670 PROGRESS: Decoy precursors: 93 (8.50%)
+5:04:46.804670 PROGRESS: 
+5:04:46.804670 PROGRESS: Precursor Summary:
+5:04:46.804670 PROGRESS: Channel   0:	 0.05 FDR:   711; 0.01 FDR:   423; 0.001 FDR:   102
+5:04:46.804670 PROGRESS: 
+5:04:46.804670 PROGRESS: Protein Summary:
+5:04:46.804670 PROGRESS: Channel   0:	 0.05 FDR:   676; 0.01 FDR:   395; 0.001 FDR:   101
+5:04:46.804670 PROGRESS: =========================================================================
+5:04:46.835613 INFO: fragments_df_filtered: 2124
+5:04:47.218327 INFO: calibration group: precursor, fitting rt estimator 
+5:04:47.346510 INFO: calibration group: fragment, fitting mz estimator 
+5:04:48.029680 INFO: calibration group: precursor, predicting mz
+5:04:48.029680 WARNING: mz prediction was skipped as it has not been fitted yet
+5:04:48.029680 INFO: calibration group: precursor, predicting rt
+5:04:48.108471 INFO: calibration group: fragment, predicting mz
+5:04:48.433949 INFO: === checking if optimization conditions were reached ===
+5:04:48.436044 PROGRESS: ❌ ms2_error      : 11.0692 > 10.0000 or insufficient steps taken.
+5:04:48.437042 INFO: ==============================================
+5:04:48.437042 INFO: Starting optimization step 10.
+5:04:48.438067 PROGRESS: === Extracting elution groups 0 to 56000 ===
+5:04:48.438067 PROGRESS: Extracting batch of 110601 precursors
+5:04:48.482691 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:04:48.482691 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:04:48.482691 INFO: FWHM in RT is 20.58 seconds, sigma is 0.75
+5:04:48.482691 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:04:48.482691 INFO: Starting candidate selection
+5:05:36.533197 INFO: Starting candidate scoring
+5:05:40.832665 INFO: Finished candidate processing
+5:05:40.832665 INFO: Collecting candidate features
+5:05:41.419218 WARNING: intensity_correlation has 24 NaNs ( 0.01 % out of 220971)
+5:05:41.469177 INFO: Collecting fragment features
+5:05:41.737778 INFO: Finished candidate scoring
+5:05:41.918758 PROGRESS: === Extracted 220971 precursors and 1727973 fragments ===
+5:05:41.918758 INFO: performing precursor FDR with 47 features
+5:05:41.918758 INFO: Decoy channel: -1
+5:05:41.918758 INFO: Competetive: True
+5:05:42.201468 WARNING: dropped 14 target PSMs due to missing features
+5:05:42.201468 WARNING: dropped 10 decoy PSMs due to missing features
+5:05:46.498267 INFO: Test AUC: 0.579
+5:05:46.498267 INFO: Train AUC: 0.605
+5:05:46.498267 INFO: AUC difference: 4.26%
+5:05:46.707488 INFO: === FDR correction performed with classifier version 9 ===
+5:05:46.723060 PROGRESS: ============================= Precursor FDR =============================
+5:05:46.723060 PROGRESS: Total precursors accumulated: 1,195
+5:05:46.723060 PROGRESS: Target precursors: 1,091 (91.30%)
+5:05:46.723060 PROGRESS: Decoy precursors: 104 (8.70%)
+5:05:46.723060 PROGRESS: 
+5:05:46.723060 PROGRESS: Precursor Summary:
+5:05:46.723060 PROGRESS: Channel   0:	 0.05 FDR:   669; 0.01 FDR:    25; 0.001 FDR:    25
+5:05:46.723060 PROGRESS: 
+5:05:46.723060 PROGRESS: Protein Summary:
+5:05:46.723060 PROGRESS: Channel   0:	 0.05 FDR:   625; 0.01 FDR:    25; 0.001 FDR:    25
+5:05:46.723060 PROGRESS: =========================================================================
+5:05:47.121607 INFO: calibration group: precursor, predicting mz
+5:05:47.121607 WARNING: mz prediction was skipped as it has not been fitted yet
+5:05:47.121607 INFO: calibration group: precursor, predicting rt
+5:05:47.216017 INFO: calibration group: fragment, predicting mz
+5:05:47.589236 INFO: === skipping optimization until target number of precursors are found ===
+5:05:47.589236 INFO: Starting optimization step 11.
+5:05:47.589236 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+5:05:47.589236 PROGRESS: Extracting batch of 126403 precursors
+5:05:47.636233 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:05:47.636233 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:05:47.636233 INFO: FWHM in RT is 20.58 seconds, sigma is 0.75
+5:05:47.636233 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:05:47.636233 INFO: Starting candidate selection
+5:06:42.590212 INFO: Starting candidate scoring
+5:06:48.328036 INFO: Finished candidate processing
+5:06:48.328714 INFO: Collecting candidate features
+5:06:48.992639 WARNING: intensity_correlation has 10 NaNs ( 0.00 % out of 252558)
+5:06:49.039604 INFO: Collecting fragment features
+5:06:49.350310 INFO: Finished candidate scoring
+5:06:49.826465 PROGRESS: === Extracted 473529 precursors and 3702615 fragments ===
+5:06:49.914889 INFO: performing precursor FDR with 47 features
+5:06:49.914889 INFO: Decoy channel: -1
+5:06:49.914889 INFO: Competetive: True
+5:06:50.584319 WARNING: dropped 15 target PSMs due to missing features
+5:06:50.584319 WARNING: dropped 19 decoy PSMs due to missing features
+5:06:59.860958 INFO: Test AUC: 0.581
+5:06:59.860958 INFO: Train AUC: 0.597
+5:06:59.860958 INFO: AUC difference: 2.66%
+5:07:00.149875 INFO: === FDR correction performed with classifier version 9 ===
+5:07:00.149875 PROGRESS: ============================= Precursor FDR =============================
+5:07:00.149875 PROGRESS: Total precursors accumulated: 2,268
+5:07:00.149875 PROGRESS: Target precursors: 2,068 (91.18%)
+5:07:00.149875 PROGRESS: Decoy precursors: 200 (8.82%)
+5:07:00.149875 PROGRESS: 
+5:07:00.149875 PROGRESS: Precursor Summary:
+5:07:00.165400 PROGRESS: Channel   0:	 0.05 FDR: 1,472; 0.01 FDR:    16; 0.001 FDR:    16
+5:07:00.165400 PROGRESS: 
+5:07:00.165400 PROGRESS: Protein Summary:
+5:07:00.165400 PROGRESS: Channel   0:	 0.05 FDR: 1,289; 0.01 FDR:    16; 0.001 FDR:    16
+5:07:00.165400 PROGRESS: =========================================================================
+5:07:00.772092 INFO: calibration group: precursor, predicting mz
+5:07:00.772092 WARNING: mz prediction was skipped as it has not been fitted yet
+5:07:00.772092 INFO: calibration group: precursor, predicting rt
+5:07:00.925964 INFO: calibration group: fragment, predicting mz
+5:07:01.669287 INFO: === skipping optimization until target number of precursors are found ===
+5:07:01.669287 INFO: Starting optimization step 12.
+5:07:01.669287 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+5:07:01.669287 PROGRESS: Extracting batch of 252949 precursors
+5:07:01.751354 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:07:01.751354 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:07:01.751354 INFO: FWHM in RT is 20.58 seconds, sigma is 0.75
+5:07:01.751354 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:07:01.751354 INFO: Starting candidate selection
+5:08:50.801695 INFO: Starting candidate scoring
+5:09:00.868805 INFO: Finished candidate processing
+5:09:00.868805 INFO: Collecting candidate features
+5:09:02.163646 WARNING: intensity_correlation has 32 NaNs ( 0.01 % out of 505393)
+5:09:02.242186 INFO: Collecting fragment features
+5:09:02.858696 INFO: Finished candidate scoring
+5:09:03.891350 PROGRESS: === Extracted 978922 precursors and 7648191 fragments ===
+5:09:04.083084 INFO: performing precursor FDR with 47 features
+5:09:04.083084 INFO: Decoy channel: -1
+5:09:04.083084 INFO: Competetive: True
+5:09:05.314866 WARNING: dropped 30 target PSMs due to missing features
+5:09:05.314866 WARNING: dropped 36 decoy PSMs due to missing features
+5:09:25.367485 INFO: Test AUC: 0.580
+5:09:25.367485 INFO: Train AUC: 0.592
+5:09:25.367485 INFO: AUC difference: 1.91%
+5:09:25.778651 INFO: === FDR correction performed with classifier version 9 ===
+5:09:25.782782 PROGRESS: ============================= Precursor FDR =============================
+5:09:25.782782 PROGRESS: Total precursors accumulated: 4,147
+5:09:25.782782 PROGRESS: Target precursors: 3,777 (91.08%)
+5:09:25.782782 PROGRESS: Decoy precursors: 370 (8.92%)
+5:09:25.782782 PROGRESS: 
+5:09:25.782782 PROGRESS: Precursor Summary:
+5:09:25.782782 PROGRESS: Channel   0:	 0.05 FDR: 2,968; 0.01 FDR: 2,082; 0.001 FDR:    26
+5:09:25.782782 PROGRESS: 
+5:09:25.782782 PROGRESS: Protein Summary:
+5:09:25.782782 PROGRESS: Channel   0:	 0.05 FDR: 2,284; 0.01 FDR: 1,573; 0.001 FDR:    26
+5:09:25.782782 PROGRESS: =========================================================================
+5:09:25.917300 INFO: fragments_df_filtered: 5000
+5:09:26.315704 INFO: calibration group: precursor, fitting rt estimator 
+5:09:27.026527 INFO: calibration group: fragment, fitting mz estimator 
+5:09:31.981184 INFO: calibration group: precursor, predicting mz
+5:09:31.981184 WARNING: mz prediction was skipped as it has not been fitted yet
+5:09:31.981184 INFO: calibration group: precursor, predicting rt
+5:09:32.012483 INFO: calibration group: fragment, predicting mz
+5:09:32.153787 INFO: === checking if optimization conditions were reached ===
+5:09:32.153787 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+5:09:32.153787 INFO: ==============================================
+5:09:32.153787 PROGRESS: Optimization finished for ms2_error.
+5:09:32.416651 INFO: calibration group: precursor, predicting mz
+5:09:32.416651 WARNING: mz prediction was skipped as it has not been fitted yet
+5:09:32.416651 INFO: calibration group: precursor, predicting rt
+5:09:32.469966 INFO: calibration group: fragment, predicting mz
+5:09:32.622745 INFO: Starting optimization step 0.
+5:09:32.622745 PROGRESS: === Extracting elution groups 0 to 24000 ===
+5:09:32.622745 PROGRESS: Extracting batch of 47395 precursors
+5:09:32.653985 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:09:32.653985 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:09:32.653985 INFO: FWHM in RT is 18.60 seconds, sigma is 0.68
+5:09:32.653985 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:09:32.653985 INFO: Starting candidate selection
+5:09:53.043477 INFO: Starting candidate scoring
+5:09:54.839886 INFO: Finished candidate processing
+5:09:54.839886 INFO: Collecting candidate features
+5:09:55.109200 WARNING: intensity_correlation has 9 NaNs ( 0.01 % out of 94685)
+5:09:55.121811 INFO: Collecting fragment features
+5:09:55.253283 INFO: Finished candidate scoring
+5:09:55.330939 PROGRESS: === Extracted 94685 precursors and 723840 fragments ===
+5:09:55.330939 INFO: performing precursor FDR with 47 features
+5:09:55.330939 INFO: Decoy channel: -1
+5:09:55.330939 INFO: Competetive: True
+5:09:55.445283 WARNING: dropped 4 target PSMs due to missing features
+5:09:55.445283 WARNING: dropped 5 decoy PSMs due to missing features
+5:09:57.312817 INFO: Test AUC: 0.582
+5:09:57.312817 INFO: Train AUC: 0.617
+5:09:57.312817 INFO: AUC difference: 5.70%
+5:09:57.312817 WARNING: AUC difference > 5%. This may indicate overfitting.
+5:09:57.493365 INFO: === FDR correction performed with classifier version 12 ===
+5:09:57.493365 PROGRESS: ============================= Precursor FDR =============================
+5:09:57.493365 PROGRESS: Total precursors accumulated: 500
+5:09:57.493365 PROGRESS: Target precursors: 454 (90.80%)
+5:09:57.493365 PROGRESS: Decoy precursors: 46 (9.20%)
+5:09:57.493365 PROGRESS: 
+5:09:57.493365 PROGRESS: Precursor Summary:
+5:09:57.508929 PROGRESS: Channel   0:	 0.05 FDR:   306; 0.01 FDR:     8; 0.001 FDR:     8
+5:09:57.508929 PROGRESS: 
+5:09:57.508929 PROGRESS: Protein Summary:
+5:09:57.513558 PROGRESS: Channel   0:	 0.05 FDR:   299; 0.01 FDR:     8; 0.001 FDR:     8
+5:09:57.513558 PROGRESS: =========================================================================
+5:09:57.807229 INFO: calibration group: precursor, predicting mz
+5:09:57.807229 WARNING: mz prediction was skipped as it has not been fitted yet
+5:09:57.807229 INFO: calibration group: precursor, predicting rt
+5:09:57.844492 INFO: calibration group: fragment, predicting mz
+5:09:58.022489 INFO: === skipping optimization until target number of precursors are found ===
+5:09:58.022489 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+5:09:58.022489 INFO: Starting optimization step 1.
+5:09:58.022489 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+5:09:58.022489 PROGRESS: Extracting batch of 63206 precursors
+5:09:58.053749 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:09:58.053749 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:09:58.053749 INFO: FWHM in RT is 18.60 seconds, sigma is 0.68
+5:09:58.053749 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:09:58.053749 INFO: Starting candidate selection
+5:10:24.708491 INFO: Starting candidate scoring
+5:10:27.329509 INFO: Finished candidate processing
+5:10:27.329509 INFO: Collecting candidate features
+5:10:27.720134 WARNING: intensity_correlation has 9 NaNs ( 0.01 % out of 126271)
+5:10:27.735875 INFO: Collecting fragment features
+5:10:27.921354 INFO: Finished candidate scoring
+5:10:28.142365 PROGRESS: === Extracted 220956 precursors and 1690081 fragments ===
+5:10:28.189902 INFO: performing precursor FDR with 47 features
+5:10:28.189902 INFO: Decoy channel: -1
+5:10:28.189902 INFO: Competetive: True
+5:10:28.503910 WARNING: dropped 8 target PSMs due to missing features
+5:10:28.503910 WARNING: dropped 10 decoy PSMs due to missing features
+5:10:32.690402 INFO: Test AUC: 0.583
+5:10:32.690402 INFO: Train AUC: 0.610
+5:10:32.690402 INFO: AUC difference: 4.47%
+5:10:32.903702 INFO: === FDR correction performed with classifier version 12 ===
+5:10:32.903702 PROGRESS: ============================= Precursor FDR =============================
+5:10:32.903702 PROGRESS: Total precursors accumulated: 1,271
+5:10:32.903702 PROGRESS: Target precursors: 1,156 (90.95%)
+5:10:32.903702 PROGRESS: Decoy precursors: 115 (9.05%)
+5:10:32.903702 PROGRESS: 
+5:10:32.903702 PROGRESS: Precursor Summary:
+5:10:32.919364 PROGRESS: Channel   0:	 0.05 FDR:   694; 0.01 FDR:     0; 0.001 FDR:     0
+5:10:32.919364 PROGRESS: 
+5:10:33.595497 PROGRESS: Protein Summary:
+5:10:33.611886 PROGRESS: Channel   0:	 0.05 FDR:   658; 0.01 FDR:     0; 0.001 FDR:     0
+5:10:33.611886 PROGRESS: =========================================================================
+5:10:34.013096 INFO: calibration group: precursor, predicting mz
+5:10:34.013096 WARNING: mz prediction was skipped as it has not been fitted yet
+5:10:34.013096 INFO: calibration group: precursor, predicting rt
+5:10:34.107487 INFO: calibration group: fragment, predicting mz
+5:10:34.497389 INFO: === skipping optimization until target number of precursors are found ===
+5:10:34.497389 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+5:10:34.497389 INFO: Starting optimization step 2.
+5:10:34.497389 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+5:10:34.497389 PROGRESS: Extracting batch of 126403 precursors
+5:10:34.559896 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:10:34.559896 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:10:34.559896 INFO: FWHM in RT is 18.60 seconds, sigma is 0.68
+5:10:34.559896 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:10:34.559896 INFO: Starting candidate selection
+5:11:27.681057 INFO: Starting candidate scoring
+5:11:32.910857 INFO: Finished candidate processing
+5:11:32.910857 INFO: Collecting candidate features
+5:11:33.581756 WARNING: intensity_correlation has 11 NaNs ( 0.00 % out of 252534)
+5:11:33.617320 INFO: Collecting fragment features
+5:11:33.923198 INFO: Finished candidate scoring
+5:11:34.375980 PROGRESS: === Extracted 473490 precursors and 3620315 fragments ===
+5:11:34.472459 INFO: performing precursor FDR with 47 features
+5:11:34.484019 INFO: Decoy channel: -1
+5:11:34.484019 INFO: Competetive: True
+5:11:35.129361 WARNING: dropped 13 target PSMs due to missing features
+5:11:35.129361 WARNING: dropped 16 decoy PSMs due to missing features
+5:11:44.944175 INFO: Test AUC: 0.583
+5:11:44.944175 INFO: Train AUC: 0.600
+5:11:44.945076 INFO: AUC difference: 2.93%
+5:11:45.235751 INFO: === FDR correction performed with classifier version 12 ===
+5:11:45.235751 PROGRESS: ============================= Precursor FDR =============================
+5:11:45.235751 PROGRESS: Total precursors accumulated: 2,507
+5:11:45.235751 PROGRESS: Target precursors: 2,286 (91.18%)
+5:11:45.235751 PROGRESS: Decoy precursors: 221 (8.82%)
+5:11:45.235751 PROGRESS: 
+5:11:45.235751 PROGRESS: Precursor Summary:
+5:11:45.235751 PROGRESS: Channel   0:	 0.05 FDR: 1,615; 0.01 FDR:    14; 0.001 FDR:    14
+5:11:45.235751 PROGRESS: 
+5:11:45.235751 PROGRESS: Protein Summary:
+5:11:45.251312 PROGRESS: Channel   0:	 0.05 FDR: 1,426; 0.01 FDR:    14; 0.001 FDR:    14
+5:11:45.251312 PROGRESS: =========================================================================
+5:11:45.848536 INFO: calibration group: precursor, predicting mz
+5:11:45.848536 WARNING: mz prediction was skipped as it has not been fitted yet
+5:11:45.848536 INFO: calibration group: precursor, predicting rt
+5:11:46.012591 INFO: calibration group: fragment, predicting mz
+5:11:46.780814 INFO: === skipping optimization until target number of precursors are found ===
+5:11:46.780814 PROGRESS: === Optimization of rt_error has been skipped 3 time(s); maximum number is 1 ===
+5:11:46.780814 INFO: Starting optimization step 3.
+5:11:46.780814 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+5:11:46.780814 PROGRESS: Extracting batch of 252949 precursors
+5:11:46.863863 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:11:46.863863 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:11:46.863863 INFO: FWHM in RT is 18.60 seconds, sigma is 0.68
+5:11:46.863863 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:11:46.863863 INFO: Starting candidate selection
+5:13:34.600728 INFO: Starting candidate scoring
+5:13:44.145182 INFO: Finished candidate processing
+5:13:44.145182 INFO: Collecting candidate features
+5:13:45.461369 WARNING: intensity_correlation has 38 NaNs ( 0.01 % out of 505314)
+5:13:45.522079 INFO: Collecting fragment features
+5:13:46.117092 INFO: Finished candidate scoring
+5:13:47.206459 PROGRESS: === Extracted 978804 precursors and 7478696 fragments ===
+5:13:47.406770 INFO: performing precursor FDR with 47 features
+5:13:47.406770 INFO: Decoy channel: -1
+5:13:47.406770 INFO: Competetive: True
+5:13:48.642700 WARNING: dropped 30 target PSMs due to missing features
+5:13:48.642700 WARNING: dropped 37 decoy PSMs due to missing features
+5:14:08.186169 INFO: Test AUC: 0.582
+5:14:08.186169 INFO: Train AUC: 0.595
+5:14:08.186169 INFO: AUC difference: 2.12%
+5:14:08.590128 INFO: === FDR correction performed with classifier version 12 ===
+5:14:08.621338 PROGRESS: ============================= Precursor FDR =============================
+5:14:08.621338 PROGRESS: Total precursors accumulated: 4,512
+5:14:08.621338 PROGRESS: Target precursors: 4,127 (91.47%)
+5:14:08.621338 PROGRESS: Decoy precursors: 385 (8.53%)
+5:14:08.621338 PROGRESS: 
+5:14:08.621338 PROGRESS: Precursor Summary:
+5:14:08.632861 PROGRESS: Channel   0:	 0.05 FDR: 3,173; 0.01 FDR:    21; 0.001 FDR:    21
+5:14:08.632861 PROGRESS: 
+5:14:08.632861 PROGRESS: Protein Summary:
+5:14:08.637372 PROGRESS: Channel   0:	 0.05 FDR: 2,485; 0.01 FDR:    21; 0.001 FDR:    21
+5:14:08.637372 PROGRESS: =========================================================================
+5:14:09.697987 INFO: calibration group: precursor, predicting mz
+5:14:09.697987 WARNING: mz prediction was skipped as it has not been fitted yet
+5:14:09.697987 INFO: calibration group: precursor, predicting rt
+5:14:10.045724 INFO: calibration group: fragment, predicting mz
+5:14:11.499672 INFO: === skipping optimization until target number of precursors are found ===
+5:14:11.499672 PROGRESS: === Optimization of rt_error has been skipped 4 time(s); maximum number is 1 ===
+5:14:11.499672 INFO: Starting optimization step 4.
+5:14:11.499672 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+5:14:11.499672 PROGRESS: Extracting batch of 505702 precursors
+5:14:11.664550 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:14:11.664550 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:14:11.664550 INFO: FWHM in RT is 18.60 seconds, sigma is 0.68
+5:14:11.664550 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:14:11.664550 INFO: Starting candidate selection
+5:17:45.628786 INFO: Starting candidate scoring
+5:18:14.832692 INFO: Finished candidate processing
+5:18:14.832692 INFO: Collecting candidate features
+5:18:17.511494 WARNING: intensity_correlation has 77 NaNs ( 0.01 % out of 1010278)
+5:18:17.637102 INFO: Collecting fragment features
+5:18:18.826221 INFO: Finished candidate scoring
+5:18:21.136510 PROGRESS: === Extracted 1989082 precursors and 15193952 fragments ===
+5:18:21.493900 INFO: performing precursor FDR with 47 features
+5:18:21.493900 INFO: Decoy channel: -1
+5:18:21.493900 INFO: Competetive: True
+5:18:23.917124 WARNING: dropped 73 target PSMs due to missing features
+5:18:23.917124 WARNING: dropped 71 decoy PSMs due to missing features
+5:19:15.454779 INFO: Test AUC: 0.584
+5:19:15.454779 INFO: Train AUC: 0.590
+5:19:15.454779 INFO: AUC difference: 0.91%
+5:19:16.122868 INFO: === FDR correction performed with classifier version 12 ===
+5:19:16.138608 PROGRESS: ============================= Precursor FDR =============================
+5:19:16.138608 PROGRESS: Total precursors accumulated: 8,488
+5:19:16.138608 PROGRESS: Target precursors: 7,799 (91.88%)
+5:19:16.138608 PROGRESS: Decoy precursors: 689 (8.12%)
+5:19:16.138608 PROGRESS: 
+5:19:16.138608 PROGRESS: Precursor Summary:
+5:19:16.154135 PROGRESS: Channel   0:	 0.05 FDR: 6,348; 0.01 FDR: 4,259; 0.001 FDR:    18
+5:19:16.154135 PROGRESS: 
+5:19:16.154135 PROGRESS: Protein Summary:
+5:19:16.169761 PROGRESS: Channel   0:	 0.05 FDR: 4,207; 0.01 FDR: 2,665; 0.001 FDR:    18
+5:19:16.169761 PROGRESS: =========================================================================
+5:19:16.467549 INFO: fragments_df_filtered: 5000
+5:19:16.924461 INFO: calibration group: precursor, fitting rt estimator 
+5:19:20.430622 INFO: calibration group: fragment, fitting mz estimator 
+5:19:25.408916 INFO: calibration group: precursor, predicting mz
+5:19:25.408916 WARNING: mz prediction was skipped as it has not been fitted yet
+5:19:25.408916 INFO: calibration group: precursor, predicting rt
+5:19:25.440573 INFO: calibration group: fragment, predicting mz
+5:19:25.566091 INFO: === checking if optimization conditions were reached ===
+5:19:25.566091 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+5:19:25.581744 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 831.3454.
+5:19:25.581744 INFO: ==============================================
+5:19:25.581744 INFO: Starting optimization step 5.
+5:19:25.581744 PROGRESS: === Extracting elution groups 0 to 24000 ===
+5:19:25.581744 PROGRESS: Extracting batch of 47395 precursors
+5:19:25.597336 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:19:25.597336 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:19:25.597336 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:19:25.597336 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:19:25.597336 INFO: Starting candidate selection
+5:19:30.425687 INFO: Starting candidate scoring
+5:19:32.151570 INFO: Finished candidate processing
+5:19:32.151570 INFO: Collecting candidate features
+5:19:32.447825 WARNING: intensity_correlation has 113 NaNs ( 0.12 % out of 92640)
+5:19:32.465179 INFO: Collecting fragment features
+5:19:32.590410 INFO: Finished candidate scoring
+5:19:32.653309 PROGRESS: === Extracted 92640 precursors and 612976 fragments ===
+5:19:32.653309 INFO: performing precursor FDR with 47 features
+5:19:32.653309 INFO: Decoy channel: -1
+5:19:32.653309 INFO: Competetive: True
+5:19:32.779607 WARNING: dropped 58 target PSMs due to missing features
+5:19:32.779607 WARNING: dropped 55 decoy PSMs due to missing features
+5:19:34.574569 INFO: Test AUC: 0.567
+5:19:34.574569 INFO: Train AUC: 0.599
+5:19:34.574569 INFO: AUC difference: 5.29%
+5:19:34.574569 WARNING: AUC difference > 5%. This may indicate overfitting.
+5:19:35.729481 INFO: === FDR correction performed with classifier version 12 ===
+5:19:35.729481 PROGRESS: ============================= Precursor FDR =============================
+5:19:35.729481 PROGRESS: Total precursors accumulated: 471
+5:19:35.729481 PROGRESS: Target precursors: 428 (90.87%)
+5:19:35.729481 PROGRESS: Decoy precursors: 43 (9.13%)
+5:19:35.729481 PROGRESS: 
+5:19:35.729481 PROGRESS: Precursor Summary:
+5:19:35.729481 PROGRESS: Channel   0:	 0.05 FDR:   281; 0.01 FDR:    36; 0.001 FDR:    36
+5:19:35.729481 PROGRESS: 
+5:19:35.729481 PROGRESS: Protein Summary:
+5:19:35.729481 PROGRESS: Channel   0:	 0.05 FDR:   273; 0.01 FDR:    36; 0.001 FDR:    36
+5:19:35.729481 PROGRESS: =========================================================================
+5:19:36.135617 INFO: calibration group: precursor, predicting mz
+5:19:36.135617 WARNING: mz prediction was skipped as it has not been fitted yet
+5:19:36.135617 INFO: calibration group: precursor, predicting rt
+5:19:36.183235 INFO: calibration group: fragment, predicting mz
+5:19:36.377051 INFO: === skipping optimization until target number of precursors are found ===
+5:19:36.378115 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+5:19:36.378115 INFO: Starting optimization step 6.
+5:19:36.378115 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+5:19:36.378115 PROGRESS: Extracting batch of 63206 precursors
+5:19:36.408505 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:19:36.408505 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:19:36.409539 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:19:36.409539 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:19:36.409539 INFO: Starting candidate selection
+5:19:42.926619 INFO: Starting candidate scoring
+5:19:45.289793 INFO: Finished candidate processing
+5:19:45.289793 INFO: Collecting candidate features
+5:19:45.674495 WARNING: intensity_correlation has 161 NaNs ( 0.13 % out of 123677)
+5:19:45.690229 INFO: Collecting fragment features
+5:19:45.862260 INFO: Finished candidate scoring
+5:19:46.046995 PROGRESS: === Extracted 216317 precursors and 1431982 fragments ===
+5:19:46.109727 INFO: performing precursor FDR with 47 features
+5:19:46.109727 INFO: Decoy channel: -1
+5:19:46.109727 INFO: Competetive: True
+5:19:46.451180 WARNING: dropped 147 target PSMs due to missing features
+5:19:46.451180 WARNING: dropped 127 decoy PSMs due to missing features
+5:19:50.902386 INFO: Test AUC: 0.563
+5:19:50.902386 INFO: Train AUC: 0.594
+5:19:50.902386 INFO: AUC difference: 5.15%
+5:19:50.902386 WARNING: AUC difference > 5%. This may indicate overfitting.
+5:19:51.121989 INFO: === FDR correction performed with classifier version 12 ===
+5:19:51.121989 PROGRESS: ============================= Precursor FDR =============================
+5:19:51.121989 PROGRESS: Total precursors accumulated: 1,037
+5:19:51.121989 PROGRESS: Target precursors: 945 (91.13%)
+5:19:51.121989 PROGRESS: Decoy precursors: 92 (8.87%)
+5:19:51.121989 PROGRESS: 
+5:19:51.121989 PROGRESS: Precursor Summary:
+5:19:51.137582 PROGRESS: Channel   0:	 0.05 FDR:   724; 0.01 FDR:     8; 0.001 FDR:     8
+5:19:51.137582 PROGRESS: 
+5:19:51.137582 PROGRESS: Protein Summary:
+5:19:51.137582 PROGRESS: Channel   0:	 0.05 FDR:   683; 0.01 FDR:     8; 0.001 FDR:     8
+5:19:51.137582 PROGRESS: =========================================================================
+5:19:51.545013 INFO: calibration group: precursor, predicting mz
+5:19:51.545013 WARNING: mz prediction was skipped as it has not been fitted yet
+5:19:51.545013 INFO: calibration group: precursor, predicting rt
+5:19:51.644359 INFO: calibration group: fragment, predicting mz
+5:19:52.027981 INFO: === skipping optimization until target number of precursors are found ===
+5:19:52.027981 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+5:19:52.027981 INFO: Starting optimization step 7.
+5:19:52.027981 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+5:19:52.027981 PROGRESS: Extracting batch of 126403 precursors
+5:19:52.087394 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:19:52.087394 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:19:52.087394 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:19:52.087394 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:19:52.087394 INFO: Starting candidate selection
+5:20:04.703814 INFO: Starting candidate scoring
+5:20:09.382912 INFO: Finished candidate processing
+5:20:09.382912 INFO: Collecting candidate features
+5:20:10.049763 WARNING: intensity_correlation has 355 NaNs ( 0.14 % out of 247210)
+5:20:10.112943 INFO: Collecting fragment features
+5:20:10.376406 INFO: Finished candidate scoring
+5:20:10.841048 PROGRESS: === Extracted 463527 precursors and 3069697 fragments ===
+5:20:10.924043 INFO: performing precursor FDR with 47 features
+5:20:10.939676 INFO: Decoy channel: -1
+5:20:10.939676 INFO: Competetive: True
+5:20:11.581455 WARNING: dropped 335 target PSMs due to missing features
+5:20:11.581455 WARNING: dropped 294 decoy PSMs due to missing features
+5:20:21.274991 INFO: Test AUC: 0.569
+5:20:21.274991 INFO: Train AUC: 0.588
+5:20:21.274991 INFO: AUC difference: 3.26%
+5:20:21.554349 INFO: === FDR correction performed with classifier version 12 ===
+5:20:21.554349 PROGRESS: ============================= Precursor FDR =============================
+5:20:21.554349 PROGRESS: Total precursors accumulated: 2,181
+5:20:21.554349 PROGRESS: Target precursors: 1,991 (91.29%)
+5:20:21.554349 PROGRESS: Decoy precursors: 190 (8.71%)
+5:20:21.554349 PROGRESS: 
+5:20:21.554349 PROGRESS: Precursor Summary:
+5:20:21.569870 PROGRESS: Channel   0:	 0.05 FDR: 1,463; 0.01 FDR:     8; 0.001 FDR:     8
+5:20:21.569870 PROGRESS: 
+5:20:21.569870 PROGRESS: Protein Summary:
+5:20:21.569870 PROGRESS: Channel   0:	 0.05 FDR: 1,279; 0.01 FDR:     8; 0.001 FDR:     8
+5:20:21.569870 PROGRESS: =========================================================================
+5:20:22.202354 INFO: calibration group: precursor, predicting mz
+5:20:22.202354 WARNING: mz prediction was skipped as it has not been fitted yet
+5:20:22.202354 INFO: calibration group: precursor, predicting rt
+5:20:22.380136 INFO: calibration group: fragment, predicting mz
+5:20:23.103086 INFO: === skipping optimization until target number of precursors are found ===
+5:20:23.103086 PROGRESS: === Optimization of rt_error has been skipped 3 time(s); maximum number is 1 ===
+5:20:23.103086 INFO: Starting optimization step 8.
+5:20:23.103086 PROGRESS: === Extracting elution groups 120000 to 248000 ===
+5:20:23.103086 PROGRESS: Extracting batch of 252949 precursors
+5:20:23.183908 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:20:23.183908 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:20:23.183908 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:20:23.183908 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:20:23.183908 INFO: Starting candidate selection
+5:20:48.170852 INFO: Starting candidate scoring
+5:20:57.323518 INFO: Finished candidate processing
+5:20:57.323518 INFO: Collecting candidate features
+5:20:58.618878 WARNING: intensity_correlation has 676 NaNs ( 0.14 % out of 494029)
+5:20:58.665817 INFO: Collecting fragment features
+5:20:59.201575 INFO: Finished candidate scoring
+5:21:00.220333 PROGRESS: === Extracted 957556 precursors and 6336023 fragments ===
+5:21:00.413431 INFO: performing precursor FDR with 47 features
+5:21:00.413431 INFO: Decoy channel: -1
+5:21:00.413431 INFO: Competetive: True
+5:21:01.640274 WARNING: dropped 690 target PSMs due to missing features
+5:21:01.640274 WARNING: dropped 615 decoy PSMs due to missing features
+5:21:21.595179 INFO: Test AUC: 0.572
+5:21:21.595179 INFO: Train AUC: 0.584
+5:21:21.595179 INFO: AUC difference: 1.96%
+5:21:21.993497 INFO: === FDR correction performed with classifier version 12 ===
+5:21:22.009189 PROGRESS: ============================= Precursor FDR =============================
+5:21:22.009189 PROGRESS: Total precursors accumulated: 4,368
+5:21:22.009189 PROGRESS: Target precursors: 3,985 (91.23%)
+5:21:22.009189 PROGRESS: Decoy precursors: 383 (8.77%)
+5:21:22.009189 PROGRESS: 
+5:21:22.009189 PROGRESS: Precursor Summary:
+5:21:22.009189 PROGRESS: Channel   0:	 0.05 FDR: 3,003; 0.01 FDR:    47; 0.001 FDR:    47
+5:21:22.009189 PROGRESS: 
+5:21:22.009189 PROGRESS: Protein Summary:
+5:21:22.009189 PROGRESS: Channel   0:	 0.05 FDR: 2,304; 0.01 FDR:    47; 0.001 FDR:    47
+5:21:22.024757 PROGRESS: =========================================================================
+5:21:23.087492 INFO: calibration group: precursor, predicting mz
+5:21:23.087492 WARNING: mz prediction was skipped as it has not been fitted yet
+5:21:23.087492 INFO: calibration group: precursor, predicting rt
+5:21:23.411292 INFO: calibration group: fragment, predicting mz
+5:21:24.908687 INFO: === skipping optimization until target number of precursors are found ===
+5:21:24.908687 PROGRESS: === Optimization of rt_error has been skipped 4 time(s); maximum number is 1 ===
+5:21:24.908687 INFO: Starting optimization step 9.
+5:21:24.908687 PROGRESS: === Extracting elution groups 248000 to 504000 ===
+5:21:24.908687 PROGRESS: Extracting batch of 505702 precursors
+5:21:25.068476 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:21:25.068476 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:21:25.068476 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:21:25.068476 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:21:25.068476 INFO: Starting candidate selection
+5:22:14.638672 INFO: Starting candidate scoring
+5:22:37.840919 INFO: Finished candidate processing
+5:22:37.840919 INFO: Collecting candidate features
+5:22:40.504138 WARNING: intensity_correlation has 1383 NaNs ( 0.14 % out of 988438)
+5:22:40.661772 INFO: Collecting fragment features
+5:22:41.757830 INFO: Finished candidate scoring
+5:22:43.999486 PROGRESS: === Extracted 1945994 precursors and 12874758 fragments ===
+5:22:44.351935 INFO: performing precursor FDR with 47 features
+5:22:44.351935 INFO: Decoy channel: -1
+5:22:44.351935 INFO: Competetive: True
+5:22:46.754414 WARNING: dropped 1404 target PSMs due to missing features
+5:22:46.754414 WARNING: dropped 1284 decoy PSMs due to missing features
+5:23:28.569701 INFO: Test AUC: 0.572
+5:23:28.569701 INFO: Train AUC: 0.580
+5:23:28.569701 INFO: AUC difference: 1.30%
+5:23:29.209420 INFO: === FDR correction performed with classifier version 12 ===
+5:23:29.225330 PROGRESS: ============================= Precursor FDR =============================
+5:23:29.225330 PROGRESS: Total precursors accumulated: 8,594
+5:23:29.225330 PROGRESS: Target precursors: 7,858 (91.44%)
+5:23:29.225330 PROGRESS: Decoy precursors: 736 (8.56%)
+5:23:29.225330 PROGRESS: 
+5:23:29.225330 PROGRESS: Precursor Summary:
+5:23:29.225330 PROGRESS: Channel   0:	 0.05 FDR: 6,261; 0.01 FDR:    74; 0.001 FDR:    74
+5:23:29.225330 PROGRESS: 
+5:23:29.225330 PROGRESS: Protein Summary:
+5:23:29.241070 PROGRESS: Channel   0:	 0.05 FDR: 3,953; 0.01 FDR:    73; 0.001 FDR:    73
+5:23:29.241070 PROGRESS: =========================================================================
+5:23:31.097596 INFO: calibration group: precursor, predicting mz
+5:23:31.097596 WARNING: mz prediction was skipped as it has not been fitted yet
+5:23:31.097596 INFO: calibration group: precursor, predicting rt
+5:23:31.758279 INFO: calibration group: fragment, predicting mz
+5:23:34.762956 INFO: === skipping optimization until target number of precursors are found ===
+5:23:34.762956 PROGRESS: === Optimization of rt_error has been skipped 5 time(s); maximum number is 1 ===
+5:23:34.762956 INFO: Starting optimization step 10.
+5:23:34.762956 PROGRESS: === Extracting elution groups 504000 to 1016000 ===
+5:23:34.762956 PROGRESS: Extracting batch of 1011429 precursors
+5:23:35.063907 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:23:35.063907 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:23:35.063907 INFO: FWHM in RT is 18.35 seconds, sigma is 0.67
+5:23:35.063907 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:23:35.063907 INFO: Starting candidate selection
+5:25:14.010413 INFO: Starting candidate scoring
+5:25:52.145417 INFO: Finished candidate processing
+5:25:52.145417 INFO: Collecting candidate features
+5:25:57.319131 WARNING: intensity_correlation has 2803 NaNs ( 0.14 % out of 1976826)
+5:25:57.334790 WARNING: height_correlation has 2 NaNs ( 0.00 % out of 1976826)
+5:25:57.562784 INFO: Collecting fragment features
+5:25:59.666829 INFO: Finished candidate scoring
+5:26:05.265240 PROGRESS: === Extracted 3922820 precursors and 25954738 fragments ===
+5:26:05.897929 INFO: performing precursor FDR with 47 features
+5:26:05.897929 INFO: Decoy channel: -1
+5:26:05.897929 INFO: Competetive: True
+5:26:10.409690 WARNING: dropped 2910 target PSMs due to missing features
+5:26:10.409690 WARNING: dropped 2581 decoy PSMs due to missing features
+5:28:34.579372 INFO: Test AUC: 0.572
+5:28:34.579372 INFO: Train AUC: 0.578
+5:28:34.579372 INFO: AUC difference: 1.13%
+5:28:35.646037 INFO: === FDR correction performed with classifier version 12 ===
+5:28:35.661555 PROGRESS: ============================= Precursor FDR =============================
+5:28:35.661555 PROGRESS: Total precursors accumulated: 16,624
+5:28:35.661555 PROGRESS: Target precursors: 15,236 (91.65%)
+5:28:35.661555 PROGRESS: Decoy precursors: 1,388 (8.35%)
+5:28:35.661555 PROGRESS: 
+5:28:35.661555 PROGRESS: Precursor Summary:
+5:28:35.682299 PROGRESS: Channel   0:	 0.05 FDR: 12,281; 0.01 FDR: 8,714; 0.001 FDR:    83
+5:28:35.682299 PROGRESS: 
+5:28:35.682299 PROGRESS: Protein Summary:
+5:28:35.693421 PROGRESS: Channel   0:	 0.05 FDR: 6,182; 0.01 FDR: 4,129; 0.001 FDR:    83
+5:28:35.693421 PROGRESS: =========================================================================
+5:28:36.197160 INFO: fragments_df_filtered: 5000
+5:28:36.716710 INFO: calibration group: precursor, fitting rt estimator 
+5:28:51.961371 INFO: calibration group: fragment, fitting mz estimator 
+5:28:57.146557 INFO: calibration group: precursor, predicting mz
+5:28:57.146557 WARNING: mz prediction was skipped as it has not been fitted yet
+5:28:57.146557 INFO: calibration group: precursor, predicting rt
+5:28:57.177913 INFO: calibration group: fragment, predicting mz
+5:28:57.325545 INFO: === checking if optimization conditions were reached ===
+5:28:57.325545 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+5:28:57.325545 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 592.8922.
+5:28:57.325545 INFO: ==============================================
+5:28:57.325545 INFO: Starting optimization step 11.
+5:28:57.325545 PROGRESS: === Extracting elution groups 0 to 24000 ===
+5:28:57.325545 PROGRESS: Extracting batch of 47395 precursors
+5:28:57.359003 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:28:57.359003 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:28:57.359003 INFO: FWHM in RT is 18.30 seconds, sigma is 0.67
+5:28:57.359003 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:28:57.359003 INFO: Starting candidate selection
+5:29:01.462968 INFO: Starting candidate scoring
+5:29:03.197100 INFO: Finished candidate processing
+5:29:03.197100 INFO: Collecting candidate features
+5:29:03.465390 WARNING: intensity_correlation has 117 NaNs ( 0.13 % out of 89997)
+5:29:03.481018 INFO: Collecting fragment features
+5:29:03.591472 INFO: Finished candidate scoring
+5:29:03.657641 PROGRESS: === Extracted 89997 precursors and 572714 fragments ===
+5:29:03.657641 INFO: performing precursor FDR with 47 features
+5:29:03.657641 INFO: Decoy channel: -1
+5:29:03.657641 INFO: Competetive: True
+5:29:03.734920 WARNING: dropped 57 target PSMs due to missing features
+5:29:03.734920 WARNING: dropped 60 decoy PSMs due to missing features
+5:29:05.397852 INFO: Test AUC: 0.558
+5:29:05.397852 INFO: Train AUC: 0.597
+5:29:05.397852 INFO: AUC difference: 6.40%
+5:29:05.397852 WARNING: AUC difference > 5%. This may indicate overfitting.
+5:29:05.574132 INFO: === FDR correction performed with classifier version 12 ===
+5:29:05.574132 PROGRESS: ============================= Precursor FDR =============================
+5:29:05.574132 PROGRESS: Total precursors accumulated: 419
+5:29:05.574132 PROGRESS: Target precursors: 380 (90.69%)
+5:29:05.574132 PROGRESS: Decoy precursors: 39 (9.31%)
+5:29:05.574132 PROGRESS: 
+5:29:05.574132 PROGRESS: Precursor Summary:
+5:29:05.574132 PROGRESS: Channel   0:	 0.05 FDR:   280; 0.01 FDR:   136; 0.001 FDR:    39
+5:29:05.574132 PROGRESS: 
+5:29:05.574132 PROGRESS: Protein Summary:
+5:29:05.574132 PROGRESS: Channel   0:	 0.05 FDR:   273; 0.01 FDR:   133; 0.001 FDR:    39
+5:29:05.574132 PROGRESS: =========================================================================
+5:29:05.845502 INFO: calibration group: precursor, predicting mz
+5:29:05.845502 WARNING: mz prediction was skipped as it has not been fitted yet
+5:29:05.845502 INFO: calibration group: precursor, predicting rt
+5:29:05.901623 INFO: calibration group: fragment, predicting mz
+5:29:06.070262 INFO: === skipping optimization until target number of precursors are found ===
+5:29:06.070262 PROGRESS: === Optimization of rt_error has been skipped 1 time(s); maximum number is 1 ===
+5:29:06.070262 INFO: Starting optimization step 12.
+5:29:06.070262 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+5:29:06.070262 PROGRESS: Extracting batch of 63206 precursors
+5:29:06.101928 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:29:06.101928 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:29:06.101928 INFO: FWHM in RT is 18.30 seconds, sigma is 0.67
+5:29:06.101928 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:29:06.101928 INFO: Starting candidate selection
+5:29:11.250499 INFO: Starting candidate scoring
+5:29:13.357798 INFO: Finished candidate processing
+5:29:13.357798 INFO: Collecting candidate features
+5:29:13.754296 WARNING: intensity_correlation has 171 NaNs ( 0.14 % out of 120099)
+5:29:13.768377 INFO: Collecting fragment features
+5:29:13.934302 INFO: Finished candidate scoring
+5:29:14.172390 PROGRESS: === Extracted 210096 precursors and 1336764 fragments ===
+5:29:14.219190 INFO: performing precursor FDR with 47 features
+5:29:14.219190 INFO: Decoy channel: -1
+5:29:14.219190 INFO: Competetive: True
+5:29:14.532556 WARNING: dropped 152 target PSMs due to missing features
+5:29:14.532556 WARNING: dropped 136 decoy PSMs due to missing features
+5:29:18.767510 INFO: Test AUC: 0.564
+5:29:18.767510 INFO: Train AUC: 0.589
+5:29:18.767510 INFO: AUC difference: 4.26%
+5:29:18.985175 INFO: === FDR correction performed with classifier version 12 ===
+5:29:18.985175 PROGRESS: ============================= Precursor FDR =============================
+5:29:18.985175 PROGRESS: Total precursors accumulated: 971
+5:29:18.985175 PROGRESS: Target precursors: 885 (91.14%)
+5:29:18.985175 PROGRESS: Decoy precursors: 86 (8.86%)
+5:29:18.985175 PROGRESS: 
+5:29:18.985175 PROGRESS: Precursor Summary:
+5:29:18.985175 PROGRESS: Channel   0:	 0.05 FDR:   674; 0.01 FDR:     8; 0.001 FDR:     8
+5:29:18.985175 PROGRESS: 
+5:29:18.985175 PROGRESS: Protein Summary:
+5:29:19.000822 PROGRESS: Channel   0:	 0.05 FDR:   636; 0.01 FDR:     8; 0.001 FDR:     8
+5:29:19.000822 PROGRESS: =========================================================================
+5:29:19.418353 INFO: calibration group: precursor, predicting mz
+5:29:19.418353 WARNING: mz prediction was skipped as it has not been fitted yet
+5:29:19.433981 INFO: calibration group: precursor, predicting rt
+5:29:19.515049 INFO: calibration group: fragment, predicting mz
+5:29:19.904531 INFO: === skipping optimization until target number of precursors are found ===
+5:29:19.904531 PROGRESS: === Optimization of rt_error has been skipped 2 time(s); maximum number is 1 ===
+5:29:19.904531 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 831.3454 found after 2 searches.
+5:29:19.904531 PROGRESS: Optimization finished for rt_error.
+5:29:20.192720 INFO: calibration group: precursor, predicting mz
+5:29:20.192720 WARNING: mz prediction was skipped as it has not been fitted yet
+5:29:20.192720 INFO: calibration group: precursor, predicting rt
+5:29:20.223963 INFO: calibration group: fragment, predicting mz
+5:29:20.441742 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+5:29:20.441742 PROGRESS: ==============================================
+5:29:20.442719 PROGRESS: ms2_error      : 10.0000
+5:29:20.442719 PROGRESS: rt_error       : 831.3454
+5:29:20.442719 PROGRESS: ==============================================
+5:29:20.450968 INFO: calibration group: precursor, predicting mz
+5:29:20.450968 WARNING: mz prediction was skipped as it has not been fitted yet
+5:29:20.450968 INFO: calibration group: precursor, predicting rt
+5:29:27.293777 INFO: calibration group: fragment, predicting mz
+5:29:58.665564 PROGRESS: Extracting batch of 10640830 precursors
+5:30:00.945185 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+5:30:00.945185 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+5:30:00.945185 INFO: FWHM in RT is 18.30 seconds, sigma is 0.67
+5:30:00.945185 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+5:30:00.945185 INFO: Starting candidate selection
+5:47:09.658822 INFO: Applying score cutoff of 62.71603814315796
+5:47:10.600936 INFO: Removed 9540715 precursors with score below cutoff
+5:47:13.699888 INFO: Starting candidate scoring
+5:52:24.600448 INFO: Finished candidate processing
+5:52:24.600448 INFO: Collecting candidate features
+5:53:04.877188 WARNING: intensity_correlation has 4 NaNs ( 0.00 % out of 11644905)
+5:53:06.349205 INFO: Collecting fragment features
+5:53:21.759337 INFO: Finished candidate scoring
+5:53:58.026231 INFO: === FDR correction performed with classifier version 23 ===
+5:53:58.041926 INFO: performing precursor FDR with 47 features
+5:53:58.041926 INFO: Decoy channel: -1
+5:53:58.041926 INFO: Competetive: True
+5:54:08.969269 WARNING: dropped 3 target PSMs due to missing features
+5:54:08.969269 WARNING: dropped 1 decoy PSMs due to missing features
+6:02:55.971916 INFO: Test AUC: 0.578
+6:02:55.971916 INFO: Train AUC: 0.580
+6:02:55.971916 INFO: AUC difference: 0.29%
+6:02:58.082472 INFO: Removing fragments below FDR threshold
+6:02:59.698232 PROGRESS: ============================= Precursor FDR =============================
+6:03:02.269522 PROGRESS: Total precursors accumulated: 49,191
+6:03:02.269522 PROGRESS: Target precursors: 48,704 (99.01%)
+6:03:02.281543 PROGRESS: Decoy precursors: 487 (0.99%)
+6:03:02.281543 PROGRESS: 
+6:03:02.281543 PROGRESS: Precursor Summary:
+6:03:02.335317 PROGRESS: Channel   0:	 0.05 FDR: 48,704; 0.01 FDR: 48,704; 0.001 FDR:    55
+6:03:02.335317 PROGRESS: 
+6:03:02.335317 PROGRESS: Protein Summary:
+6:03:02.413697 PROGRESS: Channel   0:	 0.05 FDR: 8,784; 0.01 FDR: 8,784; 0.001 FDR:    53
+6:03:02.413697 PROGRESS: =========================================================================
+6:03:03.760282 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+6:03:05.553443 PROGRESS: Loading raw file 6/6: LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:03:05.553443 INFO: Creating workflow folder for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03 at D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:03:40.440660 INFO: Determining DIA cycle
+6:03:40.457792 WARNING: Failed to determine DIA cycle, will retry without MS1 spectra.
+6:03:40.474316 INFO: Determining DIA cycle
+6:03:40.489357 INFO: Found cycle with start 0.00 min and length 151.
+6:03:40.615749 INFO: ============ Raw file stats ============
+6:03:40.615749 INFO: RT (min)            : 0.0 - 150.0
+6:03:40.615749 INFO: RT duration (sec)   : 8999.7
+6:03:40.615749 INFO: RT duration (min)   : 150.0
+6:03:40.615749 INFO: Cycle len (scans)   : 151
+6:03:40.615749 INFO: Cycle len (sec)     : 5.84
+6:03:40.615749 INFO: Number of cycles    : 1542
+6:03:40.615749 INFO: MS2 range (m/z)     : 396.4 - 1004.7
+6:03:40.615749 INFO: ========================================
+6:03:46.168961 INFO: Initializing CalibrationManager
+6:03:46.168961 INFO: Loading calibration config
+6:03:46.184594 INFO: Calibration config: [{'name': 'fragment', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}]}, {'name': 'precursor', 'estimators': [{'name': 'mz', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mz_library'], 'target_columns': ['mz_observed'], 'output_columns': ['mz_calibrated'], 'transform_deviation': '1e6', 'function': LOESSRegression(n_kernels=2)}, {'name': 'rt', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 6}, 'input_columns': ['rt_library'], 'target_columns': ['rt_observed'], 'output_columns': ['rt_calibrated'], 'function': LOESSRegression()}, {'name': 'mobility', 'model': 'LOESSRegression', 'model_args': {'n_kernels': 2}, 'input_columns': ['mobility_library'], 'target_columns': ['mobility_observed'], 'output_columns': ['mobility_calibrated'], 'function': LOESSRegression(n_kernels=2)}]}]
+6:03:46.184594 INFO: Calibration group :fragment, found 1 estimator(s)
+6:03:46.184594 INFO: Calibration group :precursor, found 3 estimator(s)
+6:03:46.184594 INFO: Disabling ion mobility calibration
+6:03:46.184594 INFO: removed mobility estimator from group precursor
+6:03:46.184594 INFO: Initializing OptimizationManager
+6:03:46.184594 INFO: initial parameter: ms1_error = 30
+6:03:46.184594 INFO: initial parameter: ms2_error = 30
+6:03:46.184594 INFO: initial parameter: rt_error = 4499.99853515625
+6:03:46.184594 INFO: initial parameter: mobility_error = 0.1
+6:03:46.184594 INFO: initial parameter: column_type = library
+6:03:46.184594 INFO: initial parameter: num_candidates = 1
+6:03:46.184594 INFO: initial parameter: classifier_version = -1
+6:03:46.184594 INFO: initial parameter: fwhm_rt = 5
+6:03:46.184594 INFO: initial parameter: fwhm_mobility = 0.01
+6:03:46.184594 INFO: initial parameter: score_cutoff = 0
+6:03:46.184594 INFO: Initializing TimingManager
+6:03:46.184594 PROGRESS: Initializing workflow LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:03:46.184594 INFO: Initializing FDRManager
+6:03:46.184594 INFO: Loading classifier store from C:\Users\robbe\AppData\Local\Programs\AlphaDIA\_internal\alphadia\constants\classifier
+6:03:48.802171 PROGRESS: 5,385,906 target precursors potentially observable (0 removed)
+6:03:51.953950 PROGRESS: Starting initial search for precursors.
+6:03:52.339316 INFO: Starting optimization step 0.
+6:03:52.355276 PROGRESS: === Extracting elution groups 0 to 8000 ===
+6:03:52.355276 PROGRESS: Extracting batch of 15803 precursors
+6:03:52.372485 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:03:52.372485 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:03:52.372485 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+6:03:52.372485 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+6:03:52.372485 INFO: Starting candidate selection
+6:03:58.893583 INFO: Starting candidate scoring
+6:03:59.245354 INFO: Finished candidate processing
+6:03:59.245354 INFO: Collecting candidate features
+6:03:59.303846 INFO: Collecting fragment features
+6:03:59.364356 INFO: Finished candidate scoring
+6:03:59.375617 PROGRESS: === Extracted 15797 precursors and 131762 fragments ===
+6:03:59.375617 INFO: performing precursor FDR with 47 features
+6:03:59.375617 INFO: Decoy channel: -1
+6:03:59.375617 INFO: Competetive: True
+6:03:59.637691 INFO: Test AUC: 0.517
+6:03:59.637691 INFO: Train AUC: 0.548
+6:03:59.637691 INFO: AUC difference: 5.53%
+6:03:59.637691 WARNING: AUC difference > 5%. This may indicate overfitting.
+6:03:59.803971 INFO: === FDR correction performed with classifier version -1 ===
+6:03:59.803971 PROGRESS: ============================= Precursor FDR =============================
+6:03:59.803971 PROGRESS: Total precursors accumulated: 1
+6:03:59.803971 PROGRESS: Target precursors: 1 (100.00%)
+6:03:59.803971 PROGRESS: Decoy precursors: 0 (0.00%)
+6:03:59.803971 PROGRESS: 
+6:03:59.803971 PROGRESS: Precursor Summary:
+6:03:59.803971 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+6:03:59.803971 PROGRESS: 
+6:03:59.803971 PROGRESS: Protein Summary:
+6:03:59.803971 PROGRESS: Channel   0:	 0.05 FDR:     1; 0.01 FDR:     1; 0.001 FDR:     1
+6:03:59.803971 PROGRESS: =========================================================================
+6:04:00.022362 INFO: Starting optimization step 1.
+6:04:00.022362 PROGRESS: === Extracting elution groups 8000 to 24000 ===
+6:04:00.022362 PROGRESS: Extracting batch of 31592 precursors
+6:04:00.035567 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:04:00.035567 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:04:00.035567 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+6:04:00.035567 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+6:04:00.035567 INFO: Starting candidate selection
+6:04:13.105521 INFO: Starting candidate scoring
+6:04:13.775301 INFO: Finished candidate processing
+6:04:13.775301 INFO: Collecting candidate features
+6:04:13.914030 INFO: Collecting fragment features
+6:04:13.962944 INFO: Finished candidate scoring
+6:04:14.057296 PROGRESS: === Extracted 47348 precursors and 395362 fragments ===
+6:04:14.088593 INFO: performing precursor FDR with 47 features
+6:04:14.088593 INFO: Decoy channel: -1
+6:04:14.088593 INFO: Competetive: True
+6:04:15.410699 INFO: Test AUC: 0.549
+6:04:15.410699 INFO: Train AUC: 0.569
+6:04:15.410699 INFO: AUC difference: 3.59%
+6:04:15.586068 INFO: === FDR correction performed with classifier version -1 ===
+6:04:15.617460 PROGRESS: ============================= Precursor FDR =============================
+6:04:15.617460 PROGRESS: Total precursors accumulated: 23,968
+6:04:15.617460 PROGRESS: Target precursors: 14,177 (59.15%)
+6:04:15.617460 PROGRESS: Decoy precursors: 9,791 (40.85%)
+6:04:15.617460 PROGRESS: 
+6:04:15.617460 PROGRESS: Precursor Summary:
+6:04:15.617460 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+6:04:15.617460 PROGRESS: 
+6:04:15.617460 PROGRESS: Protein Summary:
+6:04:15.617460 PROGRESS: Channel   0:	 0.05 FDR:     0; 0.01 FDR:     0; 0.001 FDR:     0
+6:04:15.617460 PROGRESS: =========================================================================
+6:04:15.925059 INFO: Starting optimization step 2.
+6:04:15.925059 PROGRESS: === Extracting elution groups 24000 to 56000 ===
+6:04:15.926060 PROGRESS: Extracting batch of 63206 precursors
+6:04:15.949449 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:04:15.949449 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:04:15.960002 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+6:04:15.960002 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+6:04:15.960002 INFO: Starting candidate selection
+6:04:42.122726 INFO: Starting candidate scoring
+6:04:43.839917 INFO: Finished candidate processing
+6:04:43.839917 INFO: Collecting candidate features
+6:04:44.140521 INFO: Collecting fragment features
+6:04:44.280912 INFO: Finished candidate scoring
+6:04:44.447150 PROGRESS: === Extracted 110506 precursors and 923664 fragments ===
+6:04:44.494759 INFO: performing precursor FDR with 47 features
+6:04:44.494759 INFO: Decoy channel: -1
+6:04:44.494759 INFO: Competetive: True
+6:04:46.910146 INFO: Test AUC: 0.568
+6:04:46.910146 INFO: Train AUC: 0.577
+6:04:46.911168 INFO: AUC difference: 1.50%
+6:04:47.091885 INFO: === FDR correction performed with classifier version -1 ===
+6:04:47.091885 PROGRESS: ============================= Precursor FDR =============================
+6:04:47.091885 PROGRESS: Total precursors accumulated: 338
+6:04:47.091885 PROGRESS: Target precursors: 308 (91.12%)
+6:04:47.091885 PROGRESS: Decoy precursors: 30 (8.88%)
+6:04:47.091885 PROGRESS: 
+6:04:47.091885 PROGRESS: Precursor Summary:
+6:04:47.091885 PROGRESS: Channel   0:	 0.05 FDR:   205; 0.01 FDR:    12; 0.001 FDR:    12
+6:04:47.091885 PROGRESS: 
+6:04:47.091885 PROGRESS: Protein Summary:
+6:04:47.107499 PROGRESS: Channel   0:	 0.05 FDR:   199; 0.01 FDR:    12; 0.001 FDR:    12
+6:04:47.107499 PROGRESS: =========================================================================
+6:04:47.526386 INFO: Starting optimization step 3.
+6:04:47.526386 PROGRESS: === Extracting elution groups 56000 to 120000 ===
+6:04:47.526386 PROGRESS: Extracting batch of 126403 precursors
+6:04:47.604860 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:04:47.604860 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:04:47.604860 INFO: FWHM in RT is 5.00 seconds, sigma is 0.18
+6:04:47.604860 INFO: FWHM in mobility is 0.010 1/K_0, sigma is 1.00
+6:04:47.604860 INFO: Starting candidate selection
+6:05:40.147319 INFO: Starting candidate scoring
+6:05:42.477194 INFO: Finished candidate processing
+6:05:42.477194 INFO: Collecting candidate features
+6:05:43.059862 INFO: Collecting fragment features
+6:05:43.264160 INFO: Finished candidate scoring
+6:05:43.575288 PROGRESS: === Extracted 236806 precursors and 1979263 fragments ===
+6:05:43.637854 INFO: performing precursor FDR with 47 features
+6:05:43.637854 INFO: Decoy channel: -1
+6:05:43.637854 INFO: Competetive: True
+6:05:48.661651 INFO: Test AUC: 0.569
+6:05:48.661651 INFO: Train AUC: 0.586
+6:05:48.661651 INFO: AUC difference: 2.91%
+6:05:48.934031 INFO: === FDR correction performed with classifier version -1 ===
+6:05:48.935968 PROGRESS: ============================= Precursor FDR =============================
+6:05:48.936969 PROGRESS: Total precursors accumulated: 1,021
+6:05:48.936969 PROGRESS: Target precursors: 929 (90.99%)
+6:05:48.936969 PROGRESS: Decoy precursors: 92 (9.01%)
+6:05:48.936969 PROGRESS: 
+6:05:48.937973 PROGRESS: Precursor Summary:
+6:05:48.941120 PROGRESS: Channel   0:	 0.05 FDR:   796; 0.01 FDR:   518; 0.001 FDR:   337
+6:05:48.941120 PROGRESS: 
+6:05:48.941120 PROGRESS: Protein Summary:
+6:05:48.941120 PROGRESS: Channel   0:	 0.05 FDR:   707; 0.01 FDR:   471; 0.001 FDR:   315
+6:05:48.941120 PROGRESS: =========================================================================
+6:05:48.979928 INFO: fragments_df_filtered: 3314
+6:05:49.414136 INFO: calibration group: precursor, fitting rt estimator 
+6:05:49.554625 INFO: calibration group: fragment, fitting mz estimator 
+6:05:51.724300 INFO: calibration group: precursor, predicting mz
+6:05:51.724300 WARNING: mz prediction was skipped as it has not been fitted yet
+6:05:51.724300 INFO: calibration group: precursor, predicting rt
+6:05:51.837432 INFO: calibration group: fragment, predicting mz
+6:05:52.157013 PROGRESS: Required number of precursors found. Starting search parameter optimization.
+6:05:52.157013 INFO: Starting optimization step 4.
+6:05:52.157013 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:05:52.157013 PROGRESS: Extracting batch of 110601 precursors
+6:05:52.219926 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:05:52.219926 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:05:52.219926 INFO: FWHM in RT is 18.53 seconds, sigma is 0.67
+6:05:52.219926 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:05:52.219926 INFO: Starting candidate selection
+6:06:39.626678 INFO: Starting candidate scoring
+6:06:44.590856 INFO: Finished candidate processing
+6:06:44.590856 INFO: Collecting candidate features
+6:06:45.253582 WARNING: intensity_correlation has 4 NaNs ( 0.00 % out of 221023)
+6:06:45.285192 INFO: Collecting fragment features
+6:06:45.590472 INFO: Finished candidate scoring
+6:06:45.833505 PROGRESS: === Extracted 221023 precursors and 1905918 fragments ===
+6:06:45.833505 INFO: performing precursor FDR with 47 features
+6:06:45.833505 INFO: Decoy channel: -1
+6:06:45.833505 INFO: Competetive: True
+6:06:46.124074 WARNING: dropped 2 target PSMs due to missing features
+6:06:46.124074 WARNING: dropped 2 decoy PSMs due to missing features
+6:06:50.539864 INFO: Test AUC: 0.572
+6:06:50.539864 INFO: Train AUC: 0.587
+6:06:50.539864 INFO: AUC difference: 2.51%
+6:06:50.759634 INFO: === FDR correction performed with classifier version 3 ===
+6:06:50.759634 PROGRESS: ============================= Precursor FDR =============================
+6:06:50.759634 PROGRESS: Total precursors accumulated: 479
+6:06:50.759634 PROGRESS: Target precursors: 438 (91.44%)
+6:06:50.759634 PROGRESS: Decoy precursors: 41 (8.56%)
+6:06:50.759634 PROGRESS: 
+6:06:50.759634 PROGRESS: Precursor Summary:
+6:06:50.759634 PROGRESS: Channel   0:	 0.05 FDR:   395; 0.01 FDR:   302; 0.001 FDR:   200
+6:06:50.759634 PROGRESS: 
+6:06:50.775255 PROGRESS: Protein Summary:
+6:06:50.775255 PROGRESS: Channel   0:	 0.05 FDR:   378; 0.01 FDR:   289; 0.001 FDR:   198
+6:06:50.775255 PROGRESS: =========================================================================
+6:06:50.795744 INFO: fragments_df_filtered: 1825
+6:06:51.190380 INFO: calibration group: precursor, fitting rt estimator 
+6:06:53.136372 INFO: calibration group: fragment, fitting mz estimator 
+6:06:53.912438 INFO: calibration group: precursor, predicting mz
+6:06:53.912438 WARNING: mz prediction was skipped as it has not been fitted yet
+6:06:53.912438 INFO: calibration group: precursor, predicting rt
+6:06:54.006837 INFO: calibration group: fragment, predicting mz
+6:06:54.328450 INFO: === checking if optimization conditions were reached ===
+6:06:54.328450 PROGRESS: ❌ ms2_error      : 10.0000 > 10.0000 or insufficient steps taken.
+6:06:54.328450 INFO: ==============================================
+6:06:54.344595 INFO: Starting optimization step 5.
+6:06:54.344934 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:06:54.344934 PROGRESS: Extracting batch of 110601 precursors
+6:06:54.398365 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:06:54.398365 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:06:54.398365 INFO: FWHM in RT is 18.69 seconds, sigma is 0.68
+6:06:54.398365 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:06:54.398365 INFO: Starting candidate selection
+6:07:42.479287 INFO: Starting candidate scoring
+6:07:46.946560 INFO: Finished candidate processing
+6:07:46.946560 INFO: Collecting candidate features
+6:07:47.555733 WARNING: intensity_correlation has 17 NaNs ( 0.01 % out of 220908)
+6:07:47.620382 INFO: Collecting fragment features
+6:07:47.877331 INFO: Finished candidate scoring
+6:07:48.098821 PROGRESS: === Extracted 220908 precursors and 1561544 fragments ===
+6:07:48.098821 INFO: performing precursor FDR with 47 features
+6:07:48.098821 INFO: Decoy channel: -1
+6:07:48.098821 INFO: Competetive: True
+6:07:48.424935 WARNING: dropped 7 target PSMs due to missing features
+6:07:48.424935 WARNING: dropped 10 decoy PSMs due to missing features
+6:07:52.986879 INFO: Test AUC: 0.567
+6:07:52.986879 INFO: Train AUC: 0.589
+6:07:52.986879 INFO: AUC difference: 3.88%
+6:07:53.160366 INFO: === FDR correction performed with classifier version 4 ===
+6:07:53.175984 PROGRESS: ============================= Precursor FDR =============================
+6:07:53.175984 PROGRESS: Total precursors accumulated: 590
+6:07:53.175984 PROGRESS: Target precursors: 537 (91.02%)
+6:07:53.175984 PROGRESS: Decoy precursors: 53 (8.98%)
+6:07:53.175984 PROGRESS: 
+6:07:53.175984 PROGRESS: Precursor Summary:
+6:07:53.175984 PROGRESS: Channel   0:	 0.05 FDR:   404; 0.01 FDR:   206; 0.001 FDR:   184
+6:07:53.175984 PROGRESS: 
+6:07:53.175984 PROGRESS: Protein Summary:
+6:07:53.175984 PROGRESS: Channel   0:	 0.05 FDR:   379; 0.01 FDR:   199; 0.001 FDR:   179
+6:07:53.175984 PROGRESS: =========================================================================
+6:07:53.191615 INFO: fragments_df_filtered: 1249
+6:07:53.593959 INFO: calibration group: precursor, fitting rt estimator 
+6:07:53.688275 INFO: calibration group: fragment, fitting mz estimator 
+6:07:54.077376 INFO: calibration group: precursor, predicting mz
+6:07:54.077376 WARNING: mz prediction was skipped as it has not been fitted yet
+6:07:54.077376 INFO: calibration group: precursor, predicting rt
+6:07:54.171788 INFO: calibration group: fragment, predicting mz
+6:07:54.495727 INFO: === checking if optimization conditions were reached ===
+6:07:54.495727 PROGRESS: ✅ ms2_error      : 10.0000 <= 10.0000
+6:07:54.495727 INFO: ==============================================
+6:07:54.495727 PROGRESS: Optimization finished for ms2_error.
+6:07:54.893153 INFO: calibration group: precursor, predicting mz
+6:07:54.894158 WARNING: mz prediction was skipped as it has not been fitted yet
+6:07:54.894158 INFO: calibration group: precursor, predicting rt
+6:07:54.996093 INFO: calibration group: fragment, predicting mz
+6:07:55.299105 INFO: Starting optimization step 0.
+6:07:55.299105 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:07:55.299105 PROGRESS: Extracting batch of 110601 precursors
+6:07:55.350828 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:07:55.350828 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:07:55.350828 INFO: FWHM in RT is 17.57 seconds, sigma is 0.64
+6:07:55.350828 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:07:55.350828 INFO: Starting candidate selection
+6:08:43.447427 INFO: Starting candidate scoring
+6:08:47.604084 INFO: Finished candidate processing
+6:08:47.604084 INFO: Collecting candidate features
+6:08:48.232014 WARNING: intensity_correlation has 17 NaNs ( 0.01 % out of 220914)
+6:08:48.294632 INFO: Collecting fragment features
+6:08:48.575806 INFO: Finished candidate scoring
+6:08:48.797277 PROGRESS: === Extracted 220914 precursors and 1556449 fragments ===
+6:08:48.797277 INFO: performing precursor FDR with 47 features
+6:08:48.797277 INFO: Decoy channel: -1
+6:08:48.797277 INFO: Competetive: True
+6:08:49.107722 WARNING: dropped 7 target PSMs due to missing features
+6:08:49.107722 WARNING: dropped 10 decoy PSMs due to missing features
+6:08:53.543315 INFO: Test AUC: 0.576
+6:08:53.543315 INFO: Train AUC: 0.597
+6:08:53.543315 INFO: AUC difference: 3.50%
+6:08:53.748325 INFO: === FDR correction performed with classifier version 5 ===
+6:08:53.763945 PROGRESS: ============================= Precursor FDR =============================
+6:08:53.763945 PROGRESS: Total precursors accumulated: 605
+6:08:53.763945 PROGRESS: Target precursors: 551 (91.07%)
+6:08:53.763945 PROGRESS: Decoy precursors: 54 (8.93%)
+6:08:53.763945 PROGRESS: 
+6:08:53.763945 PROGRESS: Precursor Summary:
+6:08:53.763945 PROGRESS: Channel   0:	 0.05 FDR:   423; 0.01 FDR:   251; 0.001 FDR:   169
+6:08:53.763945 PROGRESS: 
+6:08:53.763945 PROGRESS: Protein Summary:
+6:08:53.763945 PROGRESS: Channel   0:	 0.05 FDR:   397; 0.01 FDR:   243; 0.001 FDR:   164
+6:08:53.763945 PROGRESS: =========================================================================
+6:08:53.779574 INFO: fragments_df_filtered: 1330
+6:08:54.196469 INFO: calibration group: precursor, fitting rt estimator 
+6:08:54.306338 INFO: calibration group: fragment, fitting mz estimator 
+6:08:54.742112 INFO: calibration group: precursor, predicting mz
+6:08:54.757827 WARNING: mz prediction was skipped as it has not been fitted yet
+6:08:54.757827 INFO: calibration group: precursor, predicting rt
+6:08:54.844088 INFO: calibration group: fragment, predicting mz
+6:08:55.148118 INFO: === checking if optimization conditions were reached ===
+6:08:55.148118 PROGRESS: === Optimization of rt_error has been performed 1 time(s); minimum number is 2 ===
+6:08:55.163749 PROGRESS: ❌ rt_error       : optimization incomplete after 1 search(es). Will search with parameter 681.7986.
+6:08:55.163749 INFO: ==============================================
+6:08:55.163749 INFO: Starting optimization step 1.
+6:08:55.163749 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:08:55.163749 PROGRESS: Extracting batch of 110601 precursors
+6:08:55.215188 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:08:55.215188 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:08:55.215188 INFO: FWHM in RT is 17.13 seconds, sigma is 0.62
+6:08:55.215188 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:08:55.215188 INFO: Starting candidate selection
+6:09:05.097035 INFO: Starting candidate scoring
+6:09:08.836720 INFO: Finished candidate processing
+6:09:08.836720 INFO: Collecting candidate features
+6:09:09.479712 WARNING: intensity_correlation has 362 NaNs ( 0.17 % out of 210454)
+6:09:09.526664 INFO: Collecting fragment features
+6:09:09.760682 INFO: Finished candidate scoring
+6:09:09.976820 PROGRESS: === Extracted 210454 precursors and 1215463 fragments ===
+6:09:09.992445 INFO: performing precursor FDR with 47 features
+6:09:09.992445 INFO: Decoy channel: -1
+6:09:09.992445 INFO: Competetive: True
+6:09:10.296402 WARNING: dropped 197 target PSMs due to missing features
+6:09:10.296402 WARNING: dropped 165 decoy PSMs due to missing features
+6:09:14.629209 INFO: Test AUC: 0.558
+6:09:14.629209 INFO: Train AUC: 0.580
+6:09:14.629209 INFO: AUC difference: 3.90%
+6:09:14.796441 INFO: === FDR correction performed with classifier version 5 ===
+6:09:14.796441 PROGRESS: ============================= Precursor FDR =============================
+6:09:14.796441 PROGRESS: Total precursors accumulated: 707
+6:09:14.796441 PROGRESS: Target precursors: 644 (91.09%)
+6:09:14.796441 PROGRESS: Decoy precursors: 63 (8.91%)
+6:09:14.796441 PROGRESS: 
+6:09:14.796441 PROGRESS: Precursor Summary:
+6:09:14.796441 PROGRESS: Channel   0:	 0.05 FDR:   531; 0.01 FDR:   357; 0.001 FDR:   334
+6:09:14.796441 PROGRESS: 
+6:09:14.796441 PROGRESS: Protein Summary:
+6:09:14.812916 PROGRESS: Channel   0:	 0.05 FDR:   501; 0.01 FDR:   335; 0.001 FDR:   315
+6:09:14.815082 PROGRESS: =========================================================================
+6:09:14.827163 INFO: fragments_df_filtered: 1396
+6:09:15.217166 INFO: calibration group: precursor, fitting rt estimator 
+6:09:15.327648 INFO: calibration group: fragment, fitting mz estimator 
+6:09:15.824043 INFO: calibration group: precursor, predicting mz
+6:09:15.824043 WARNING: mz prediction was skipped as it has not been fitted yet
+6:09:15.824043 INFO: calibration group: precursor, predicting rt
+6:09:15.939422 INFO: calibration group: fragment, predicting mz
+6:09:16.259086 INFO: === checking if optimization conditions were reached ===
+6:09:16.259086 PROGRESS: === Optimization of rt_error has been performed 2 time(s); minimum number is 2 ===
+6:09:16.259086 PROGRESS: ❌ rt_error       : optimization incomplete after 2 search(es). Will search with parameter 551.5347.
+6:09:16.273685 INFO: ==============================================
+6:09:16.273685 INFO: Starting optimization step 2.
+6:09:16.275197 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:09:16.275197 PROGRESS: Extracting batch of 110601 precursors
+6:09:16.327278 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:09:16.327278 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:09:16.327278 INFO: FWHM in RT is 16.89 seconds, sigma is 0.61
+6:09:16.327278 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:09:16.327278 INFO: Starting candidate selection
+6:09:24.750372 INFO: Starting candidate scoring
+6:09:28.256261 INFO: Finished candidate processing
+6:09:28.256261 INFO: Collecting candidate features
+6:09:28.866284 WARNING: intensity_correlation has 367 NaNs ( 0.18 % out of 208077)
+6:09:28.908178 INFO: Collecting fragment features
+6:09:29.143555 INFO: Finished candidate scoring
+6:09:29.322371 PROGRESS: === Extracted 208077 precursors and 1168017 fragments ===
+6:09:29.322371 INFO: performing precursor FDR with 47 features
+6:09:29.322371 INFO: Decoy channel: -1
+6:09:29.322371 INFO: Competetive: True
+6:09:29.605422 WARNING: dropped 199 target PSMs due to missing features
+6:09:29.605422 WARNING: dropped 168 decoy PSMs due to missing features
+6:09:33.651655 INFO: Test AUC: 0.557
+6:09:33.651655 INFO: Train AUC: 0.578
+6:09:33.651655 INFO: AUC difference: 3.66%
+6:09:33.866217 INFO: === FDR correction performed with classifier version 5 ===
+6:09:33.884350 PROGRESS: ============================= Precursor FDR =============================
+6:09:33.884350 PROGRESS: Total precursors accumulated: 722
+6:09:33.884350 PROGRESS: Target precursors: 656 (90.86%)
+6:09:33.884350 PROGRESS: Decoy precursors: 66 (9.14%)
+6:09:33.884350 PROGRESS: 
+6:09:33.884350 PROGRESS: Precursor Summary:
+6:09:33.884350 PROGRESS: Channel   0:	 0.05 FDR:   544; 0.01 FDR:   408; 0.001 FDR:   282
+6:09:33.884350 PROGRESS: 
+6:09:33.884350 PROGRESS: Protein Summary:
+6:09:33.884350 PROGRESS: Channel   0:	 0.05 FDR:   515; 0.01 FDR:   381; 0.001 FDR:   269
+6:09:33.884350 PROGRESS: =========================================================================
+6:09:33.903565 INFO: fragments_df_filtered: 1461
+6:09:34.304639 INFO: calibration group: precursor, fitting rt estimator 
+6:09:34.425087 INFO: calibration group: fragment, fitting mz estimator 
+6:09:34.955021 INFO: calibration group: precursor, predicting mz
+6:09:34.956023 WARNING: mz prediction was skipped as it has not been fitted yet
+6:09:34.956023 INFO: calibration group: precursor, predicting rt
+6:09:35.057515 INFO: calibration group: fragment, predicting mz
+6:09:35.381448 INFO: === checking if optimization conditions were reached ===
+6:09:35.381448 PROGRESS: === Optimization of rt_error has been performed 3 time(s); minimum number is 2 ===
+6:09:35.384923 PROGRESS: ❌ rt_error       : optimization incomplete after 3 search(es). Will search with parameter 516.2129.
+6:09:35.384923 INFO: ==============================================
+6:09:35.384923 INFO: Starting optimization step 3.
+6:09:35.384923 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:09:35.384923 PROGRESS: Extracting batch of 110601 precursors
+6:09:35.450452 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:09:35.450452 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:09:35.450452 INFO: FWHM in RT is 16.92 seconds, sigma is 0.62
+6:09:35.450452 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:09:35.450452 INFO: Starting candidate selection
+6:09:43.222904 INFO: Starting candidate scoring
+6:09:46.676458 INFO: Finished candidate processing
+6:09:46.676458 INFO: Collecting candidate features
+6:09:47.321835 WARNING: intensity_correlation has 367 NaNs ( 0.18 % out of 208915)
+6:09:47.355365 INFO: Collecting fragment features
+6:09:47.596940 INFO: Finished candidate scoring
+6:09:47.829582 PROGRESS: === Extracted 208915 precursors and 1172495 fragments ===
+6:09:47.829582 INFO: performing precursor FDR with 47 features
+6:09:47.829582 INFO: Decoy channel: -1
+6:09:47.829582 INFO: Competetive: True
+6:09:48.110505 WARNING: dropped 191 target PSMs due to missing features
+6:09:48.110505 WARNING: dropped 176 decoy PSMs due to missing features
+6:09:52.229960 INFO: Test AUC: 0.558
+6:09:52.229960 INFO: Train AUC: 0.579
+6:09:52.229960 INFO: AUC difference: 3.69%
+6:09:52.448972 INFO: === FDR correction performed with classifier version 5 ===
+6:09:52.449972 PROGRESS: ============================= Precursor FDR =============================
+6:09:52.450972 PROGRESS: Total precursors accumulated: 796
+6:09:52.452127 PROGRESS: Target precursors: 723 (90.83%)
+6:09:52.452127 PROGRESS: Decoy precursors: 73 (9.17%)
+6:09:52.452127 PROGRESS: 
+6:09:52.452127 PROGRESS: Precursor Summary:
+6:09:52.455038 PROGRESS: Channel   0:	 0.05 FDR:   537; 0.01 FDR:   418; 0.001 FDR:   327
+6:09:52.455038 PROGRESS: 
+6:09:52.455038 PROGRESS: Protein Summary:
+6:09:52.457979 PROGRESS: Channel   0:	 0.05 FDR:   506; 0.01 FDR:   394; 0.001 FDR:   309
+6:09:52.457979 PROGRESS: =========================================================================
+6:09:52.463159 INFO: fragments_df_filtered: 1494
+6:09:52.862360 INFO: calibration group: precursor, fitting rt estimator 
+6:09:52.976779 INFO: calibration group: fragment, fitting mz estimator 
+6:09:53.413876 INFO: calibration group: precursor, predicting mz
+6:09:53.413876 WARNING: mz prediction was skipped as it has not been fitted yet
+6:09:53.413876 INFO: calibration group: precursor, predicting rt
+6:09:53.509306 INFO: calibration group: fragment, predicting mz
+6:09:53.829011 INFO: === checking if optimization conditions were reached ===
+6:09:53.829011 PROGRESS: === Optimization of rt_error has been performed 4 time(s); minimum number is 2 ===
+6:09:53.843831 PROGRESS: ❌ rt_error       : optimization incomplete after 4 search(es). Will search with parameter 503.6492.
+6:09:53.843831 INFO: ==============================================
+6:09:53.844777 INFO: Starting optimization step 4.
+6:09:53.844777 PROGRESS: === Extracting elution groups 0 to 56000 ===
+6:09:53.844777 PROGRESS: Extracting batch of 110601 precursors
+6:09:53.893236 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:09:53.893236 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:09:53.893236 INFO: FWHM in RT is 16.87 seconds, sigma is 0.61
+6:09:53.893236 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:09:53.893236 INFO: Starting candidate selection
+6:10:01.526086 INFO: Starting candidate scoring
+6:10:06.401258 INFO: Finished candidate processing
+6:10:06.401258 INFO: Collecting candidate features
+6:10:07.022817 WARNING: intensity_correlation has 361 NaNs ( 0.17 % out of 208115)
+6:10:07.070214 INFO: Collecting fragment features
+6:10:07.342750 INFO: Finished candidate scoring
+6:10:07.552766 PROGRESS: === Extracted 208115 precursors and 1156755 fragments ===
+6:10:07.564355 INFO: performing precursor FDR with 47 features
+6:10:07.564355 INFO: Decoy channel: -1
+6:10:07.564355 INFO: Competetive: True
+6:10:07.826268 WARNING: dropped 190 target PSMs due to missing features
+6:10:07.826268 WARNING: dropped 171 decoy PSMs due to missing features
+6:10:11.873484 INFO: Test AUC: 0.556
+6:10:11.873484 INFO: Train AUC: 0.579
+6:10:11.873484 INFO: AUC difference: 4.00%
+6:10:12.080799 INFO: === FDR correction performed with classifier version 5 ===
+6:10:12.080799 PROGRESS: ============================= Precursor FDR =============================
+6:10:12.080799 PROGRESS: Total precursors accumulated: 764
+6:10:12.080799 PROGRESS: Target precursors: 696 (91.10%)
+6:10:12.080799 PROGRESS: Decoy precursors: 68 (8.90%)
+6:10:12.080799 PROGRESS: 
+6:10:12.080799 PROGRESS: Precursor Summary:
+6:10:12.080799 PROGRESS: Channel   0:	 0.05 FDR:   536; 0.01 FDR:   384; 0.001 FDR:   283
+6:10:12.080799 PROGRESS: 
+6:10:12.080799 PROGRESS: Protein Summary:
+6:10:12.097315 PROGRESS: Channel   0:	 0.05 FDR:   505; 0.01 FDR:   361; 0.001 FDR:   272
+6:10:12.097315 PROGRESS: =========================================================================
+6:10:12.112421 INFO: fragments_df_filtered: 1453
+6:10:12.499072 INFO: calibration group: precursor, fitting rt estimator 
+6:10:12.609090 INFO: calibration group: fragment, fitting mz estimator 
+6:10:13.109979 INFO: calibration group: precursor, predicting mz
+6:10:13.109979 WARNING: mz prediction was skipped as it has not been fitted yet
+6:10:13.109979 INFO: calibration group: precursor, predicting rt
+6:10:13.219839 INFO: calibration group: fragment, predicting mz
+6:10:13.562840 INFO: === checking if optimization conditions were reached ===
+6:10:13.562840 PROGRESS: === Optimization of rt_error has been performed 5 time(s); minimum number is 2 ===
+6:10:13.562840 PROGRESS: ✅ rt_error       : optimization complete. Optimal parameter 503.6492 found after 5 searches.
+6:10:13.562840 INFO: ==============================================
+6:10:13.562840 PROGRESS: Optimization finished for rt_error.
+6:10:13.950093 INFO: calibration group: precursor, predicting mz
+6:10:13.965715 WARNING: mz prediction was skipped as it has not been fitted yet
+6:10:13.965715 INFO: calibration group: precursor, predicting rt
+6:10:14.060189 INFO: calibration group: fragment, predicting mz
+6:10:14.421587 PROGRESS: Search parameter optimization finished. Values taken forward for search are:
+6:10:14.421587 PROGRESS: ==============================================
+6:10:14.421587 PROGRESS: ms2_error      : 10.0000
+6:10:14.437320 PROGRESS: rt_error       : 503.6492
+6:10:14.437320 PROGRESS: ==============================================
+6:10:14.452956 INFO: calibration group: precursor, predicting mz
+6:10:14.452956 WARNING: mz prediction was skipped as it has not been fitted yet
+6:10:14.452956 INFO: calibration group: precursor, predicting rt
+6:10:21.508094 INFO: calibration group: fragment, predicting mz
+6:10:53.071732 PROGRESS: Extracting batch of 10640830 precursors
+6:10:55.338878 INFO: Duty cycle consists of 151 frames, 5.84 seconds cycle time
+6:10:55.339877 INFO: Duty cycle consists of 1 scans, 0.00000 1/K_0 resolution
+6:10:55.339877 INFO: FWHM in RT is 17.08 seconds, sigma is 0.62
+6:10:55.339877 INFO: FWHM in mobility is 0.000 1/K_0, sigma is 1.00
+6:10:55.340779 INFO: Starting candidate selection
+6:23:15.570025 INFO: Applying score cutoff of 73.89944689941406
+6:23:15.910513 INFO: Removed 17622736 precursors with score below cutoff
+6:23:19.074142 INFO: Starting candidate scoring
+6:24:53.058325 INFO: Finished candidate processing
+6:24:53.058325 INFO: Collecting candidate features
+6:25:04.297717 INFO: Collecting fragment features
+6:25:09.200423 INFO: Finished candidate scoring
+6:25:18.646334 INFO: === FDR correction performed with classifier version 10 ===
+6:25:18.646334 INFO: performing precursor FDR with 47 features
+6:25:18.646334 INFO: Decoy channel: -1
+6:25:18.646334 INFO: Competetive: True
+6:26:30.320276 INFO: Test AUC: 0.581
+6:26:30.320276 INFO: Train AUC: 0.586
+6:26:30.320276 INFO: AUC difference: 0.76%
+6:26:31.187881 INFO: Removing fragments below FDR threshold
+6:26:31.709750 PROGRESS: ============================= Precursor FDR =============================
+6:26:31.709750 PROGRESS: Total precursors accumulated: 45,856
+6:26:31.709750 PROGRESS: Target precursors: 45,402 (99.01%)
+6:26:31.709750 PROGRESS: Decoy precursors: 454 (0.99%)
+6:26:31.713878 PROGRESS: 
+6:26:31.713878 PROGRESS: Precursor Summary:
+6:26:31.757930 PROGRESS: Channel   0:	 0.05 FDR: 45,402; 0.01 FDR: 45,402; 0.001 FDR: 30,770
+6:26:31.757930 PROGRESS: 
+6:26:31.757930 PROGRESS: Protein Summary:
+6:26:31.854405 PROGRESS: Channel   0:	 0.05 FDR: 8,388; 0.01 FDR: 8,388; 0.001 FDR: 6,287
+6:26:31.854405 PROGRESS: =========================================================================
+6:26:32.948514 INFO: Finished workflow for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:27:32.822479 PROGRESS: Processing search outputs
+6:27:32.823387 PROGRESS: Performing protein grouping and FDR
+6:27:32.825544 INFO: Building output for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+6:27:33.036536 INFO: Building output for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+6:27:33.241478 INFO: Building output for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+6:27:33.430547 INFO: Building output for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+6:27:33.567894 INFO: Building output for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+6:27:33.646609 INFO: Building output for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:27:33.724824 INFO: Building combined output
+6:27:34.403400 INFO: Performing protein inference
+6:27:34.954644 INFO: Inference strategy: heuristic. Using maximum parsimony with grouping for protein inference
+6:27:59.217823 INFO: Performing protein FDR
+6:28:08.899220 INFO: Normalizing q-values using 11,510 targets and 2,069 decoys
+6:28:08.907227 INFO: Test AUC: 0.880
+6:28:08.907227 INFO: Train AUC: 0.878
+6:28:08.907227 INFO: AUC difference: 0.20%
+6:28:09.770810 PROGRESS: ================ Protein FDR =================
+6:28:09.770810 PROGRESS: Unique protein groups in output
+6:28:09.770810 PROGRESS:   1% protein FDR: 6,889
+6:28:09.770810 PROGRESS: 
+6:28:09.770810 PROGRESS: Unique precursor in output
+6:28:09.770810 PROGRESS:   1% protein FDR: 72,235
+6:28:09.770810 PROGRESS: ================================================
+6:28:09.770810 PROGRESS: Building search statistics
+6:28:10.051996 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01\optimization_manager.pkl
+6:28:10.067511 INFO: Initializing OptimizationManager
+6:28:10.184156 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02\optimization_manager.pkl
+6:28:10.200778 INFO: Initializing OptimizationManager
+6:28:10.309502 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03\optimization_manager.pkl
+6:28:10.333662 INFO: Initializing OptimizationManager
+6:28:10.439774 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01\optimization_manager.pkl
+6:28:10.439774 INFO: Initializing OptimizationManager
+6:28:10.549386 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02\optimization_manager.pkl
+6:28:10.549386 INFO: Initializing OptimizationManager
+6:28:10.643693 INFO: Loaded OptimizationManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03\optimization_manager.pkl
+6:28:10.659265 INFO: Initializing OptimizationManager
+6:28:10.659265 INFO: Writing stat output to disk
+6:28:10.659265 INFO: Saving D:\Proteobench_manuscript_data\run_output\alphadia_default\stat.tsv to disk
+6:28:10.701496 PROGRESS: Building internal statistics
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Loaded TimingManager from D:\Proteobench_manuscript_data\run_output\alphadia_default\.progress\LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03\timing_manager.pkl
+6:28:10.706506 INFO: Initializing TimingManager
+6:28:10.706506 INFO: Writing internal output to disk
+6:28:10.706506 INFO: Saving D:\Proteobench_manuscript_data\run_output\alphadia_default\internal.tsv to disk
+6:28:10.722258 PROGRESS: Performing label free quantification
+6:28:10.823793 INFO: Accumulating fragment data
+6:28:10.839535 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_01
+6:28:11.579931 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_02
+6:28:12.854958 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_A_Sample_Alpha_03
+6:28:14.007851 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_01
+6:28:15.269397 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02
+6:28:16.450445 INFO: reading frag file for LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03
+6:28:17.942302 PROGRESS: Performing label free quantification on the pg level
+6:28:17.942302 INFO: Filtering fragments by quality
+6:28:18.368423 INFO: Performing label-free quantification using directLFQ
+6:28:20.603886 INFO: 6889 lfq-groups total
+6:28:22.698249 INFO: using 10 processes
+6:28:32.412211 INFO: Writing pg output to disk
+6:28:32.412211 INFO: Saving D:\Proteobench_manuscript_data\run_output\alphadia_default\pg.matrix.tsv to disk
+6:28:32.714729 INFO: Writing psm output to disk
+6:28:32.714729 INFO: Saving D:\Proteobench_manuscript_data\run_output\alphadia_default\precursors.tsv to disk
+6:29:02.175754 PROGRESS: Building spectral library
+6:29:02.270160 INFO: Building MBR spectral library
+6:29:02.270160 INFO: Running MbrLibraryBuilder
+6:29:04.623568 INFO: MBR spectral library contains 72,235 precursors, 6,889 proteins
+6:29:04.623568 INFO: Writing MBR spectral library to disk
+6:29:05.908718 PROGRESS: =================== Search Finished ===================
+6:29:44.511014 WARNING: WARNING: Temp mmap arrays were written to C:\Users\robbe\AppData\Local\Temp\temp_mmap_8v_pxnr2. Cleanup of this folder is OS dependant, and might need to be triggered manually! Current space: 53,300,146,176

--- a/test/params/log_alphadia_1.csv
+++ b/test/params/log_alphadia_1.csv
@@ -1,6 +1,6 @@
 ,0
 software_name,AlphaDIA
-software_version,1.0
+software_version,1.7.0
 search_engine,AlphaDIA
 search_engine_version,None
 ident_fdr_psm,None

--- a/test/params/log_alphadia_2.csv
+++ b/test/params/log_alphadia_2.csv
@@ -1,6 +1,6 @@
 ,0
 software_name,AlphaDIA
-software_version,1.0
+software_version,1.7.2
 search_engine,AlphaDIA
 search_engine_version,None
 ident_fdr_psm,None

--- a/test/params/log_alphadia_2.csv
+++ b/test/params/log_alphadia_2.csv
@@ -1,15 +1,15 @@
 ,0
 software_name,AlphaDIA
-software_version,1.7.2
+software_version,1.0
 search_engine,AlphaDIA
-search_engine_version,1.7.2
-ident_fdr_psm,0.01
-ident_fdr_peptide,
-ident_fdr_protein,0.01
+search_engine_version,None
+ident_fdr_psm,None
+ident_fdr_peptide,None
+ident_fdr_protein,None
 enable_match_between_runs,False
-precursor_mass_tolerance,"[-4.0 ppm, 4.0 ppm]"
-fragment_mass_tolerance,"[-7.0 ppm, 7.0 ppm]"
-enzyme,Trypsin
+precursor_mass_tolerance,4 
+fragment_mass_tolerance,7 
+enzyme,trypsin
 allowed_miscleavages,1
 min_peptide_length,7
 max_peptide_length,35
@@ -18,6 +18,6 @@ variable_mods,Oxidation@M;Acetyl@Protein N-term
 max_mods,2
 min_precursor_charge,2
 max_precursor_charge,4
-quantification_method,None
+quantification_method,DirectLFQ
 protein_inference,heuristic
 abundance_normalization_ions,None

--- a/test/test_parse_params_alphadia.py
+++ b/test/test_parse_params_alphadia.py
@@ -1,0 +1,29 @@
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import proteobench.io.params.alphadia as alphadia_params
+
+TESTDATA_DIR = Path(__file__).parent / "params"
+
+fnames = [
+    "log_alphadia_1.txt",
+    "log_alphadia_2.txt",
+    "log_alphadia_1.8.txt",
+    "log_alphadia_1.10.txt",
+]
+fnames = [TESTDATA_DIR / f for f in fnames]
+
+
+@pytest.mark.parametrize("file", fnames)
+def test_extract_params(file):
+    expected = pd.read_csv(file.with_suffix(".csv"), index_col=0).squeeze("columns")
+    actual = alphadia_params.extract_params(file)
+    actual = pd.Series(actual.__dict__)
+    actual = pd.read_csv(io.StringIO(actual.to_csv()), index_col=0).squeeze("columns")
+    expected = expected.loc[actual.index]
+    print(f"Expected: {expected}")
+    print(f"Actual: {actual}")
+    assert expected.equals(actual)


### PR DESCRIPTION
I think we should really still consider using the .yaml (currently not done because it doesnt contain the AlphaDIA version) to parse the params, because this is only infinitesimally better than the previous rendition, but at least it works across all versions now 