### PR TITLE
Change unused server settings

### DIFF
--- a/webinterface/.streamlit/config.toml
+++ b/webinterface/.streamlit/config.toml
@@ -7,3 +7,6 @@ disableWidgetStateDuplicationWarning = true
 
 [server]
 maxUploadSize = 1000
+
+[browser]
+gatherUsageStats = false

--- a/webinterface/.streamlit/config.toml
+++ b/webinterface/.streamlit/config.toml
@@ -6,5 +6,4 @@ base="light"
 disableWidgetStateDuplicationWarning = true
 
 [server]
-enableStaticServing = true
 maxUploadSize = 1000


### PR DESCRIPTION
- remove static serving (was used for the FASTA once)
- remove telemetry (to be more GDPR conform)