### PR TITLE
Change min_precursor_charge parsing i2masschroq-xtandem

### DIFF
--- a/proteobench/io/params/i2masschroq.py
+++ b/proteobench/io/params/i2masschroq.py
@@ -75,7 +75,7 @@ def _extract_xtandem_params(params: pd.Series) -> ProteoBenchParameters:
         fixed_mods=";".join(fixed_mods_list),
         variable_mods=";".join(var_mods_list),
         max_mods=None,
-        min_precursor_charge=1,
+        min_precursor_charge=None,
         max_precursor_charge=int(params.loc["spectrum, maximum parent charge"]),
     )
     params.fill_none()

--- a/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_xtandem_sel.csv
+++ b/test/params/i2mproteobench_2pep_fdr01psm_fdr01prot_xtandem_sel.csv
@@ -16,7 +16,7 @@ max_peptide_length,
 fixed_mods,57.02146@C
 variable_mods,15.99491@M;Acetyl(N-term);Pyrolidone(N-term)
 max_mods,
-min_precursor_charge,1
+min_precursor_charge,
 max_precursor_charge,4
 quantification_method,
 protein_inference,

--- a/test/params/i2mq_result_parameters_sel.csv
+++ b/test/params/i2mq_result_parameters_sel.csv
@@ -16,7 +16,7 @@ max_peptide_length,
 fixed_mods,57.02146@C
 variable_mods,15.99491@M;Acetyl(N-term);Pyrolidone(N-term)
 max_mods,
-min_precursor_charge,1
+min_precursor_charge,
 max_precursor_charge,4
 quantification_method,
 protein_inference,


### PR DESCRIPTION
After discussing with @OlivierLangella, we decided that the minimum charge info on xtandem cannot be parsed, so should be set to None, and not 1