### PR TITLE
Add defaults to some DIA-NN params

### DIFF
--- a/docs/available-modules/12-parsed-parameters-for-public-submission.md
+++ b/docs/available-modules/12-parsed-parameters-for-public-submission.md
@@ -125,13 +125,13 @@ DIA-NN parameters are parsed either from the command line string found in the lo
 | fragment_mass_tolerance  |      Value set for **--mass-acc**. If this parameter is not set, it means tolerance optimization will<br> be performed. In that case, as well as if --cfg is set, the value will be parsed from line <br>**Optimised mass accuracy: X ppm**      |
 | enzyme                   |     No --cfg: value set for **--cut**<br>--cfg: parsed from line **In silico digest will involve cuts at X but excluding cuts at X**        |
 | allowed_miscleavages     |     No --cfg: value set for **--missed-cleavages**<br>--cfg: parsed from line **Maximum number of missed cleavages set to X**        |
-| min_peptide_length       |     No --cfg: value set for **--min-pep-len**<br>--cfg: parsed from the line **Min peptide length set to X**        |
-| max_peptide_length       |     No --cfg: value set for **--max-pep-len**<br>--cfg: parsed from the line **Max peptide length set to X**        |
+| min_peptide_length       |     No --cfg: value set for **--min-pep-len** (if not provided, default = 7)<br>--cfg: parsed from the line **Min peptide length set to X**        |
+| max_peptide_length       |     No --cfg: value set for **--max-pep-len** (if not provided, default = 30)<br>--cfg: parsed from the line **Max peptide length set to X**        |
 | fixed_mods               |     No --cfg: value set for **--mod**<br>--cfg: parsed from the lines **X enabled as a fixed modification** and **Modification X with mass<br> delta X at X will be considered as fixed        |
 | variable_mods            |     No --cfg: value set for **--var-mod**<br>--cfg: parsed form line **Modification X with mass delta X at X will be considered as variable**        |
 | max_mods                 |      No --cfg: value set for **var-mods**<br>--cfg: parsed from line **Maximum number of variable modifications set to X**       |
-| min_precursor_charge     |      No --cfg: value set for **min-pr-charge**<br>--cfg: parsed from line **Min precursor charge set to X**      |
-| max_precursor_charge     |      No --cfg: value set for **max-pr-charge**<br>--cfg: parsed from line **Max precursor charge set to X**      |
+| min_precursor_charge     |      No --cfg: value set for **min-pr-charge** (if not provided, default = 1) <br>--cfg: parsed from line **Min precursor charge set to X**      |
+| max_precursor_charge     |      No --cfg: value set for **max-pr-charge** (if not provided, default = 4) <br>--cfg: parsed from line **Max precursor charge set to X**      |
 | quantification_method    |     No --cfg: either **Legacy** (if --direct-quant set), **QuantUMS high-accuracy if --high-acc set<br>or **QuantUMS high-precision (default)<br>--cfg: parsed from line **X quantification mode**       |
 | protein_inference        |      No --cfg: value set for **--pg-level** or **no-prot-inf**, with the mapping {**0**: **Isoforms**, **1**: **Protein_names**, **2**: **Genes**}<br>--cfg: parsed from line **Implicit protein grouping: X**       |
 | predictors_library       |      No --cfg: either **DIA-NN** if **--predictor** is set, or **User defined** if **--lib** is set to a path     |

--- a/proteobench/io/params/diann.py
+++ b/proteobench/io/params/diann.py
@@ -394,6 +394,10 @@ def extract_params(fname: str) -> ProteoBenchParameters:
         "enable_match_between_runs": False,
         "quantification_method": "QuantUMS high-precision",
         "protein_inference": "Genes",  # Default value, if not specified in the command line
+        "min_precursor_charge": 1,
+        "max_precursor_charge": 4,
+        "min_peptide_length": 7,
+        "max_peptide_length": 30,
     }
 
     try:

--- a/test/params/DIANN_1.7.16.log.csv
+++ b/test/params/DIANN_1.7.16.log.csv
@@ -16,8 +16,8 @@ max_peptide_length,30
 fixed_mods,Carbamidomethyl (C)
 variable_mods,Oxidation (M)
 max_mods,1
-min_precursor_charge,None
-max_precursor_charge,None
+min_precursor_charge,1
+max_precursor_charge,4
 quantification_method,QuantUMS high-precision
 protein_inference,Genes
 abundance_normalization_ions,


### PR DESCRIPTION
If min max peptide length and min max precursor charge are left to defaults, they will not show up in cmd string and be unparsed. In this case we need to parse defaults