### PR TITLE
move hardcoded labels to quant variables

### DIFF
--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -244,7 +244,9 @@ class QuantUIObjects:
             description_slider_md=self.variables_quant.description_slider_md,
             default_val_slider=self.variables_quant.default_val_slider,
         )
-        tab1_results.generate_main_selectbox(selectbox_id_uuid=self.variables_quant.selectbox_id_uuid)
+        tab1_results.generate_main_selectbox(
+            self.variables_quant, selectbox_id_uuid=self.variables_quant.selectbox_id_uuid
+        )
         tab1_results.display_existing_results(variables_quant=self.variables_quant, ionmodule=self.ionmodule)
 
     def display_all_data_results_submitted(self) -> None:

--- a/webinterface/pages/base_pages/tab1_results.py
+++ b/webinterface/pages/base_pages/tab1_results.py
@@ -46,7 +46,7 @@ def generate_main_slider(slider_id_uuid: str, description_slider_md: str, defaul
     )
 
 
-def generate_main_selectbox(selectbox_id_uuid) -> None:
+def generate_main_selectbox(variables_quant, selectbox_id_uuid) -> None:
     """
     Create the selectbox for the Streamlit UI.
     """
@@ -57,7 +57,7 @@ def generate_main_selectbox(selectbox_id_uuid) -> None:
         # TODO: Other labels based on different modules, e.g. mass tolerances are less relevant for DIA
         st.selectbox(
             "Select label to plot",
-            ["None", "precursor_mass_tolerance", "fragment_mass_tolerance", "enable_match_between_runs"],
+            variables_quant.metric_plot_labels,
             key=st.session_state[selectbox_id_uuid],
         )
     except Exception as e:

--- a/webinterface/pages/pages_variables/Quant/lfq_DDA_ion_Astral_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DDA_ion_Astral_variables.py
@@ -46,6 +46,20 @@ class VariablesDDAQuantAstral:
     download_selector_id_uuid: str = "download_selector_id_dda_quant_Astral"
     table_id_uuid: str = "table_id_dda_quant_Astral"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "precursor_mass_tolerance",
+            "fragment_mass_tolerance",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+        ]
+    )
+
     placeholder_table: str = "placeholder_table_dda_quant_Astral"
     placeholder_slider: str = "placeholder_slider_dda_quant_Astral"
 

--- a/webinterface/pages/pages_variables/Quant/lfq_DDA_ion_QExactive_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DDA_ion_QExactive_variables.py
@@ -46,6 +46,20 @@ class VariablesDDAQuant:
     download_selector_id_uuid: str = "download_selector_id"
     table_id_uuid: str = "table_id"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "precursor_mass_tolerance",
+            "fragment_mass_tolerance",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+        ]
+    )
+
     placeholder_table: str = "placeholder_table"
     placeholder_slider: str = "placeholder_slider"
 

--- a/webinterface/pages/pages_variables/Quant/lfq_DDA_peptidoform_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DDA_peptidoform_variables.py
@@ -46,6 +46,20 @@ class VariablesDDAQuant:
     download_selector_id_uuid: str = "download_selector_id_dda_quant_peptidoform"
     table_id_uuid: str = "table_id_dda_quant_peptidoform"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "precursor_mass_tolerance",
+            "fragment_mass_tolerance",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+        ]
+    )
+
     placeholder_table: str = "placeholder_table_dda_quant_peptidoform"
     placeholder_slider: str = "placeholder_slider_dda_quant_peptidoform"
 
@@ -73,7 +87,9 @@ class VariablesDDAQuant:
 
     texts: Type[WebpageTexts] = WebpageTexts
 
-    doc_url: str = "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/3-quant-lfq-peptidoform-dda/"
+    doc_url: str = (
+        "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/3-quant-lfq-peptidoform-dda/"
+    )
     title: str = "DDA peptidoform quantification"
 
     additional_params_json: str = "../proteobench/io/params/json/Quant/quant_lfq_DDA_peptidoform.json"

--- a/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_AIF_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_AIF_variables.py
@@ -56,6 +56,19 @@ class VariablesDIAQuant:
     description_results_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/AIF/result_description.md"
     description_submission_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/AIF/submit_description.md"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+            "quantification_method",
+        ]
+    )
+
     all_datapoints_submitted: str = "all_datapoints_submitted_dia_quant"
     placeholder_table_submitted: str = "placeholder_table_submitted_dia_quant"
     placeholder_slider_submitted: str = "placeholder_slider_submitted_dia_quant"
@@ -67,7 +80,9 @@ class VariablesDIAQuant:
     parse_settings_dir: str = "../proteobench/io/parsing/io_parse_settings/Quant/lfq/DIA/ion/AIF"
 
     texts: Type[WebpageTexts] = WebpageTexts
-    doc_url: str = "https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/"
+    doc_url: str = (
+        "https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/"
+    )
 
     title: str = "DIA Precursor quantification - AIF"
 

--- a/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_Astral_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_Astral_variables.py
@@ -50,6 +50,19 @@ class VariablesDIAQuantAstral:
     download_selector_id_uuid: str = "download_selector_id_dia_quant_Astral"
     table_id_uuid: str = "table_id_dia_quant_Astral"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+            "quantification_method",
+        ]
+    )
+
     description_module_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/Astral/introduction.md"
     description_files_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/Astral/file_description.md"
     description_input_file_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/Astral/input_file_description.md"

--- a/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_diaPASEF_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_diaPASEF_variables.py
@@ -50,6 +50,19 @@ class VariablesDIAQuantdiaPASEF:
     download_selector_id_uuid: str = "download_selector_id_dia_quant_diaPASEF"
     table_id_uuid: str = "table_id_dia_quant_diaPASEF"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+            "quantification_method",
+        ]
+    )
+
     description_module_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/introduction.md"
     description_files_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/file_description.md"
     description_input_file_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/input_file_description.md"
@@ -70,7 +83,9 @@ class VariablesDIAQuantdiaPASEF:
 
     texts: Type[WebpageTexts] = WebpageTexts
 
-    doc_url: str = "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef/"
+    doc_url: str = (
+        "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef/"
+    )
 
     title: str = "DIA Precursor quantification - diaPASEF"
 

--- a/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_singlecell_variables.py
+++ b/webinterface/pages/pages_variables/Quant/lfq_DIA_ion_singlecell_variables.py
@@ -49,6 +49,19 @@ class VariablesDIAQuantSC:
     download_selector_id_uuid: str = "download_selector_id_dia_quant_singlecell"
     table_id_uuid: str = "table_id_dia_quant_singlecell"
 
+    metric_plot_labels: List[str] = field(
+        default_factory=lambda: [
+            "None",
+            "enable_match_between_runs",
+            "max_mods",
+            "enzyme",
+            "ident_fdr_psm",
+            "ident_fdr_peptide",
+            "allowed_miscleavages",
+            "quantification_method",
+        ]
+    )
+
     description_module_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/singlecell/introduction.md"
     description_files_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/singlecell/file_description.md"
     description_input_file_md: str = "pages/markdown_files/Quant/lfq/DIA/ion/singlecell/input_file_description.md"
@@ -68,7 +81,9 @@ class VariablesDIAQuantSC:
     parse_settings_dir: str = "../proteobench/io/parsing/io_parse_settings/Quant/lfq/DIA/ion/singlecell"
 
     texts: Type[WebpageTexts] = WebpageTexts
-    doc_url: str = "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/6-quant-lfq-ion-dia-singlecell/"
+    doc_url: str = (
+        "https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/6-quant-lfq-ion-dia-singlecell/"
+    )
 
     title: str = "DIA Precursor quantification - singlecell"
 


### PR DESCRIPTION
Labels that can be highlighted in the plot are now defined in the QuantVariables per module, as each one might want different ones (e.g. mass tolerances)