### PR TITLE
Move location of raw files and FASTA on the server

### DIFF
--- a/docs/available-modules/active-modules/2-quant-lfq-ion-dda.md
+++ b/docs/available-modules/active-modules/2-quant-lfq-ion-dda.md
@@ -27,11 +27,11 @@ The files can be downloaded from the proteomeXchange repository [PXD028735](http
 - [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_02.raw)
 - [LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_DDA_Condition_B_Sample_Alpha_03.raw)
 
-Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/datasets/raw_files/DDA/](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA/)
+Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/raws/DDA/](https://proteobench.cubimed.rub.de/raws/DDA/)
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/datasets/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
 present in the samples **and contaminant proteins**
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/docs/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef.md
+++ b/docs/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef.md
@@ -30,20 +30,20 @@ These files are available alongside all the associated metadata27 on the Proteom
 
 The files are currently not yet uploaded to the ProteomeXchange repository, but we are working on this to make them accessible in the near future.
 
-For now, you can download the raw files via:
+For now, you can download the raw files from the ProteoBench server here:
 
-- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d.zip)
-- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d.zip)
-- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d.zip)
-- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d.zip)
-- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d.zip)
-- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d.zip)
+- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_01_11494.d.zip)
+- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_02_11500.d.zip)
+- [ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_A_Sample_Alpha_03_11506.d.zip)
+- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_01_11496.d.zip)
+- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_02_11502.d.zip)
+- [ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d](https://proteobench.cubimed.rub.de/raws/diaPASEF/ttSCP_diaPASEF_Condition_B_Sample_Alpha_03_11508.d.zip)
 
-Alternatively, you can download them from a private server here: [https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/](https://proteobench.cubimed.rub.de/datasets/raw_files/diaPASEF/))
+All files can be found here [proteobench.cubimed.rub.de/raws/diaPASEF/](https://proteobench.cubimed.rub.de/raws/diaPASEF/)
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="https://proteobench.cubimed.rub.de/datasets/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip" download>ProteoBenchFASTA_MixedSpecies_HYE.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
 present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/docs/available-modules/active-modules/7-quant-lfq-precursor-dia-Astral_2Th.md
+++ b/docs/available-modules/active-modules/7-quant-lfq-precursor-dia-Astral_2Th.md
@@ -25,18 +25,20 @@ The mass spectrometer was operated in positive ionization mode with data-indepen
 
 The files are currently not yet uploaded to the ProteomeXchange repository, but we are working on this to make them accessible in the near future.
 
-For now, you can download the raw files via a private server:
+For now, you can download the raw files from the ProteoBench server here:
 
-- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP1.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP1.raw)
-- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP2.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP2.raw)
-- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP3.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP3.raw)
-- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP1.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP1.raw)
-- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP2.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP2.raw)
-- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP3.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP3.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP1.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP1.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP2.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP2.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_A_REP3.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_A_REP3.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP1.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP1.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP2.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP2.raw)
+- [LFQ_Astral_DIA_15min_50ng_Condition_B_REP3.raw](https://proteobench.cubimed.rub.de/raws/DIA-astral/LFQ_Astral_DIA_15min_50ng_Condition_B_REP3.raw)
+
+All files can be found here [proteobench.cubimed.rub.de/raws/DIA-astral/](https://proteobench.cubimed.rub.de/raws/DIA-astral/)
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="https://proteobench.cubimed.rub.de/datasets/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip" download>ProteoBenchFASTA_MixedSpecies_HYE.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
 present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/docs/available-modules/active-modules/8-quant-lfq-precursor-dda-Astral.md
+++ b/docs/available-modules/active-modules/8-quant-lfq-precursor-dda-Astral.md
@@ -20,23 +20,25 @@ Please refer to the original publication for the full description of sample prep
 
 Data acquisition parameters were as following:
 Peptides were loaded directly onto the analytical column and were separated by reversed-phase chromatography using a 50 cm μPAC™ column (Thermo Scientific, cat # COL-NANO050NEOB), featuring a structured pillar array bed with a 180 µm bed width. The chromatographic gradient was initiated with 96% buffer A and 4% buffer B at a flow rate of 750 nL/min durig 1 minute. The flow rate was then reduced to 250 nL/min, and the percentage of buffer B was further increased to 40% over 15 minutes. Buffer A: 0.1% formic acid in water. Buffer B: 0.1% formic acid in 80% acetonitrile.
+
 The mass spectrometer was operated in positive ionization mode with data-dependent acquisition, with a full MS scans over a mass range of m/z 380-980 with detection in the Orbitrap at a resolution of 180,000 and a fixed cycle time of 0.5 s. Precursor ion selection width was kept at 2-Th and a normalized collision energy of 30% was used for higher-energy collisional dissociation (HCD) fragmentation. MS2 scan range was set from 145 to 1450 m/z with detection in the Astral and maximum fill time of 2.5 ms. Dynamic exclusion was enabled and set to 10 s.
 
 The files are currently not yet uploaded to the ProteomeXchange repository, but we are working on this to make them accessible in the near future.
-For now, you can download the raw files via a private server:
 
-- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP1.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP1.raw)
-- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP2.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP2.raw)
-- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP3.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP3.raw)
-- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP1.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP1.raw)
-- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP2.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP2.raw)
-- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP3.raw](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP3.raw)
+For now, you can download the raw files from the ProteoBench server here:
 
-Alternatively, you can download them from the ProteoBench server here: [https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/](https://proteobench.cubimed.rub.de/datasets/raw_files/DDA-astral/)
+- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP1.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP1.raw)
+- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP2.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP2.raw)
+- [LFQ_Astral_DDA_15min_50ng_Condition_A_REP3.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_A_REP3.raw)
+- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP1.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP1.raw)
+- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP2.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP2.raw)
+- [LFQ_Astral_DDA_15min_50ng_Condition_B_REP3.raw](https://proteobench.cubimed.rub.de/raws/DDA-astral/LFQ_Astral_DDA_15min_50ng_Condition_B_REP3.raw)
+
+All files can be found here [proteobench.cubimed.rub.de/raws/DDA-astral/](https://proteobench.cubimed.rub.de/raws/DDA-astral/)
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/datasets/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
 present in the samples **and contaminant proteins**
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/docs/available-modules/archived-modules/4-quant-lfq-ion-dia-aif.md
+++ b/docs/available-modules/archived-modules/4-quant-lfq-ion-dia-aif.md
@@ -40,11 +40,11 @@ The files can be downloaded from the proteomeXchange repository [PXD028735](http
 - [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_02.raw)
 - [LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw](https://ftp.pride.ebi.ac.uk/pride/data/archive/2022/02/PXD028735/LFQ_Orbitrap_AIF_Condition_B_Sample_Alpha_03.raw)
 
-Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/datasets/raw_files/DIA/](https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/)
+Alternatively, you can download them from the ProteoBench server here: [proteobench.cubimed.rub.de/raws/DIA/](https://proteobench.cubimed.rub.de/raws/DIA/)
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="https://proteobench.cubimed.rub.de/datasets/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip" download>ProteoBenchFASTA_MixedSpecies_HYE.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
 present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/Astral/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/Astral/file_description.md
@@ -3,7 +3,7 @@ proteomeXchange repository (TBD) or you can download them from the ProteoBench s
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/QExactive/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/QExactive/file_description.md
@@ -1,10 +1,10 @@
 The raw files used for this module were acquired on an Orbitrap
 Q-Exactive H-FX (ThermoScientific). They can be downloaded from the
-proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DDA/
+proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/raws/DDA/
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/peptidoform/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/peptidoform/file_description.md
@@ -1,10 +1,10 @@
 The raw files used for this module were acquired on an Orbitrap
 Q-Exactive H-FX (ThermoScientific). They can be downloaded from the
-proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DDA/
+proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/raws/DDA/
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/AIF/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/AIF/file_description.md
@@ -1,10 +1,10 @@
 The raw files used for this module were acquired on an Orbitrap
 Q-Exactive H-FX (ThermoScientific). They can be downloaded from the
-proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/
+proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/raws/DIA/
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/Astral/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/Astral/file_description.md
@@ -1,9 +1,9 @@
 The raw files used for this module were acquired on a Orbitrap Astral (Thermo). They can be downloaded from the
-proteomeXchange repository TODO or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DIA-astral/
+proteomeXchange repository TODO or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/raws/DIA-astral/
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/file_description.md
@@ -1,9 +1,9 @@
 The raw files used for this module were acquired on a timsTOF SCP (Bruker). They can be downloaded from the
-proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/datasets/raw_files/DIA/
+proteomeXchange repository PXD028735 (https://www.ebi.ac.uk/pride/archive/projects/PXD028735) or you can download them from the ProteoBench server here: https://proteobench.cubimed.rub.de/raws/DIA/
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/singlecell/file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/singlecell/file_description.md
@@ -3,7 +3,7 @@ proteomeXchange repository PXD049412 (https://www.ebi.ac.uk/pride/archive/projec
 
 **It is imperative not to rename the files once downloaded!**
 
-Download the zipped FASTA file here: <a href="/datasets/fasta/ProteoBenchFASTA_DDAQuantification.zip" download>ProteoBenchFASTA_Quantification.zip</a>.
+Download the zipped FASTA file here: [ProteoBenchFASTA_MixedSpecies_HYE.zip](https://proteobench.cubimed.rub.de/fasta/ProteoBenchFASTA_MixedSpecies_HYE.zip).
 The fasta file provided for this module contains the three species
-present in the samples and contaminant proteins
+present in the samples **and contaminant proteins**.
 ([Frankenfield et al., JPR](https://pubs.acs.org/doi/10.1021/acs.jproteome.2c00145))


### PR DESCRIPTION
The RAWs and FASTA file are moved on the server. This PR reflects this in the documentation.

The FASTA is now at https://proteobench.cubimed.rub.de/fasta/
The RAWs are now at https://proteobench.cubimed.rub.de/raws/
Processed datasets are still at https://proteobench.cubimed.rub.de/datasets/
