### PR TITLE
change charge notation to adhere proforma rules

### DIFF
--- a/proteobench/io/parsing/parse_settings.py
+++ b/proteobench/io/parsing/parse_settings.py
@@ -352,7 +352,7 @@ class ParseSettingsQuant:
         """
         if self.analysis_level == "ion":
             if "proforma" in df.columns and "Charge" in df.columns:
-                df["precursor ion"] = df["proforma"] + "|Z=" + df["Charge"].astype(str)
+                df["precursor ion"] = df["proforma"] + "/" + df["Charge"].astype(str)
             return df
         elif self.analysis_level == "peptidoform":
             if "proforma" in df.columns:
@@ -453,7 +453,7 @@ class ParseModificationSettings:
 
         if analysis_level == "ion":
             try:
-                df["precursor ion"] = df["proforma"] + "|Z=" + df["Charge"].astype(str)
+                df["precursor ion"] = df["proforma"] + "/" + df["Charge"].astype(str)
             except KeyError as e:
                 raise KeyError(
                     "Not all columns required for making the precursor ion are available."

--- a/test/test_parse_settings.py
+++ b/test/test_parse_settings.py
@@ -181,7 +181,7 @@ class TestParseSettingsQuant:
         result = parse_settings_long._format_by_analysis_level(df)
         # Should add precursor ion column for ion level
         assert "precursor ion" in result.columns
-        assert all("|Z=" in ion for ion in result["precursor ion"])
+        assert all("/" in ion for ion in result["precursor ion"])
 
     def test_convert_to_standard_format_integration(self, parse_settings_long, parse_settings_short):
         # Test with long format


### PR DESCRIPTION
Fixes #861 

Go from |Z=charge to /charge to adhere to proforma 2.0 rules

Until points are resubmitted, this will lead to slightly inconsistent intermediate results, however this is pretty easily fixable locally (in excel as well)