### PR TITLE
:bug: fix links in app to documentation

### DIFF
--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/Astral/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/Astral/input_file_description.md
@@ -1,6 +1,6 @@
 
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/8-quant-lfq-ion-dda-astral/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/8-quant-lfq-ion-dda-astral/#data-set)".
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/8-quant-lfq-precursor-dda-Astral/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/8-quant-lfq-precursor-dda-Astral/#data-set)".
 
 Remember: contaminant sequences are already present in the fasta file
 associated to this module. **Do not add other contaminants** to your

--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/QExactive/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/ion/QExactive/input_file_description.md
@@ -1,6 +1,6 @@
 
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/2-quant-lfq-ion-dda/#data-set)". You can download an (*incomplete*) MaxQuant file example [here](https://raw.githubusercontent.com/Proteobench/ProteoBench/refs/heads/main/test/data/dda_quant/MaxQuant_2_5_1_evidence_sample.txt) for testing.
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/2-quant-lfq-ion-dda/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/2-quant-lfq-ion-dda/#data-set)". You can download an (*incomplete*) MaxQuant file example [here](https://raw.githubusercontent.com/Proteobench/ProteoBench/refs/heads/main/test/data/dda_quant/MaxQuant_2_5_1_evidence_sample.txt) for testing.
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/DDA/peptidoform/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DDA/peptidoform/input_file_description.md
@@ -1,5 +1,5 @@
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/3-quant-lfq-peptidoform-dda)". 
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/3-quant-lfq-peptidoform-dda)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/3-quant-lfq-peptidoform-dda)". 
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/AIF/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/AIF/input_file_description.md
@@ -1,5 +1,5 @@
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#data-set)". 
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/#data-set)".
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/Astral/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/Astral/input_file_description.md
@@ -1,5 +1,5 @@
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/7-quant-lfq-precursor-dia-Astral_2Th/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/7-quant-lfq-precursor-dia-Astral_2Th/#data-set)". 
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/7-quant-lfq-precursor-dia-Astral_2Th/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/7-quant-lfq-precursor-dia-Astral_2Th/#data-set)". 
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/diaPASEF/input_file_description.md
@@ -1,5 +1,5 @@
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/5-quant-lfq-ion-dia-diapasef/#how-to-use)" section of this module. For the raw data to run your workflow on, please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/5-quant-lfq-ion-dia-diapasef/#data-set)". 
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef/#how-to-use)" section of this module. For the raw data to run your workflow on, please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/active-modules/5-quant-lfq-ion-dia-diapasef/#data-set)". 
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/singlecell/input_file_description.md
+++ b/webinterface/pages/markdown_files/Quant/lfq/DIA/ion/singlecell/input_file_description.md
@@ -1,5 +1,5 @@
 Please upload the output of your analysis, and indicate what software
-tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/#data-set)". 
+tool it comes from (this is necessary to correctly parse your table) - find more information in the "[How to use](https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/#how-to-use)" section of this module. To the raw data to run your workflow on please see the section "[Data set](https://proteobench.readthedocs.io/en/latest/available-modules/archived-modules/4-quant-lfq-ion-dia-aif/#data-set)".
 
 Remember: contaminant sequences are already present in the fasta file 
 associated to this module. **Do not add other contaminants** to your 

--- a/webinterface/pages/texts/generic_texts.py
+++ b/webinterface/pages/texts/generic_texts.py
@@ -57,7 +57,7 @@ class WebpageTexts:
 
         input_file = """
             Output file of the software tool. More information on the accepted format can
-            be found [here](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/)
+            be found [here](https://proteobench.readthedocs.io/en/latest/available-modules/)
             """
 
         pull_req = """
@@ -67,7 +67,7 @@ class WebpageTexts:
         input_format = """
             Please select the software you used to generate the results. If it is not yet
             implemented in ProteoBench, you can use a tab-delimited format that is described
-            further [here](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/)
+            further [here](https://proteobench.readthedocs.io/en/latest/available-modules/)
         """
 
         parse_button = """
@@ -76,6 +76,6 @@ class WebpageTexts:
 
         meta_data_file = """
             Please add a file with meta data that contains all relevant information about
-            your search parameters. See [here](https://proteobench.readthedocs.io/en/latest/available-modules/4-quant-lfq-ion-dia-aif/)
+            your search parameters. See [here](https://proteobench.readthedocs.io/en/latest/available-modules/)
             for all compatible parameter files.
         """


### PR DESCRIPTION
- active and archived modules separation was missing
- module 8 is named (ion Astral) was renamed?