### PR TITLE
add dev dependency ipywidgets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ name = "proteobench"
 readme = "README.md"
 
 [project.optional-dependencies]
-dev = ["black~=23.0", "jupyterlab", "notebook", "tqdm", "wget", "nox", "pytest"]
+dev = ["black~=23.0", "jupyterlab", "ipywidgets", "notebook", "tqdm", "wget", "nox", "pytest"]
 docs = [
   "sphinx",
   "sphinx-design",


### PR DESCRIPTION
The following files import `ipywidgets`

```shell
% git grep -P 'import ipywidgets as widgets' 
jupyter_notebooks/analysis/post_analysis/quant/lfq/ion/dda/comparison_across_datapoints.ipynb:    "import ipywidgets as widgets\n",
jupyter_notebooks/analysis/post_analysis/quant/lfq/ion/dda/indepth.qmd:import ipywidgets as widgets
jupyter_notebooks/analysis/post_analysis/quant/lfq/ion/dda/indepth_module_analysis.ipynb:    "import ipywidgets as widgets\n",
jupyter_notebooks/submission/Server resubmission.ipynb:    "import ipywidgets as widgets\n",
```