### PR TITLE
Fix879_pmultiqc

### DIFF
--- a/webinterface/pages/2_Quant_LFQ_DDA_ion_QExactive.py
+++ b/webinterface/pages/2_Quant_LFQ_DDA_ion_QExactive.py
@@ -134,10 +134,7 @@ class StreamlitUI:
             st.title("pMultiQC Report for selected dataset.")
             # self.quant_uiobjects.display_multqc_plot()
 
-
-
             self.quant_uiobjects.display_pmultiqc_report()
-                
 
         # Tab 4: Results (New Submissions)
         with tab_results_new:

--- a/webinterface/pages/2_Quant_LFQ_DDA_ion_QExactive.py
+++ b/webinterface/pages/2_Quant_LFQ_DDA_ion_QExactive.py
@@ -3,13 +3,10 @@ Streamlit UI for the DDA quantification - precursor ions module.
 """
 
 import logging
-import subprocess
-from pathlib import Path
 from typing import Any, Dict, Type
 
 import pages.texts.proteobench_builder as pbb
 import streamlit as st
-import streamlit.components.v1 as components
 from pages.base_pages.quant import QuantUIObjects
 from pages.pages_variables.Quant.lfq_DDA_ion_QExactive_variables import (
     VariablesDDAQuant,

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -179,32 +179,17 @@ class QuantUIObjects:
         Build pmultiqc based on intermediate data and save self-contained html file.
         """
         if self.variables_quant.result_perf in st.session_state.keys():
-            tmp = st.session_state[self.variables_quant.result_perf]
-            tmp_path = Path("tmp_pmultiqc")
-            tmp_path.mkdir(parents=True, exist_ok=True)
-            tmp.to_csv(tmp_path / "result_performance.csv", index=False)
-            ret_code = subprocess.run(
-                [
-                    "multiqc",
-                    "--parse_proteobench",
-                    "./tmp_pmultiqc",
-                    "-o",
-                    "./report",
-                    "-f",
-                    "--clean-up",
-                ],
-                check=False,
-            )
-            logger.info("pMultiQC command exited with return code: %d", ret_code.returncode)
-            if ret_code.returncode == 0:
-                logger.info("Intermediate for pMultiQC data saved to: %s", tmp_path)
-                file_path = Path("report/multiqc_report.html").resolve()
+            tab3_1_pmultiqc_report.create_pmultiqc_report_section(self.variables_quant)
+
+            file_path = Path("report/multiqc_report.html").resolve()
+            download_disactivate = True
+            html_content = ""
+            if file_path.exists():
+                download_disactivate = False
                 with open(file_path, "r", encoding="utf-8") as f:
                     html_content = f.read()
                 logger.info("pMultiQC report generated at: %s", file_path)
-                tab3_1_pmultiqc_report.show_download_button(html_content)
-            else:
-                st.error("pMultiQC report generation failed.", icon="🚨")
+            tab3_1_pmultiqc_report.show_download_button(html_content, disabled=download_disactivate)
         else:
             st.warning("No intermediate data available for pMultiQC report. Please first submit data.")
 

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -173,19 +173,25 @@ class QuantUIObjects:
             public_hash=selected_hash,
         )
 
+    @st.fragment
     def display_pmultiqc_report(self):
         """Display the pMultiQC report download option of the page in Tab 3.1.
 
         Build pmultiqc based on intermediate data and save self-contained html file.
         """
         if self.variables_quant.result_perf in st.session_state.keys():
-            html_content = tab3_1_pmultiqc_report.create_pmultiqc_report_section(self.variables_quant)
-            download_disactivate = True
-            if html_content:
-                download_disactivate = False
+            html_content = st.session_state.get("tab31_pmultiqc_html_content", "")
+            if not html_content:
+                html_content = tab3_1_pmultiqc_report.create_pmultiqc_report_section(self.variables_quant)
+                st.session_state["tab31_pmultiqc_html_content"] = html_content
                 logger.info(
                     "pMultiQC report generated.",
                 )
+            else:
+                logger.info('using cached pMultiQC report from session_state["tab31_pmultiqc_html_content"].')
+            download_disactivate = True
+            if html_content:
+                download_disactivate = False
             tab3_1_pmultiqc_report.show_download_button(html_content, disabled=download_disactivate)
         else:
             st.warning("No intermediate data available for pMultiQC report. Please first submit data.")

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -179,16 +179,13 @@ class QuantUIObjects:
         Build pmultiqc based on intermediate data and save self-contained html file.
         """
         if self.variables_quant.result_perf in st.session_state.keys():
-            tab3_1_pmultiqc_report.create_pmultiqc_report_section(self.variables_quant)
-
-            file_path = Path("report/multiqc_report.html").resolve()
+            html_content = tab3_1_pmultiqc_report.create_pmultiqc_report_section(self.variables_quant)
             download_disactivate = True
-            html_content = ""
-            if file_path.exists():
+            if html_content:
                 download_disactivate = False
-                with open(file_path, "r", encoding="utf-8") as f:
-                    html_content = f.read()
-                logger.info("pMultiQC report generated at: %s", file_path)
+                logger.info(
+                    "pMultiQC report generated.",
+                )
             tab3_1_pmultiqc_report.show_download_button(html_content, disabled=download_disactivate)
         else:
             st.warning("No intermediate data available for pMultiQC report. Please first submit data.")

--- a/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
+++ b/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import streamlit as st
 
@@ -21,28 +22,39 @@ def show_download_button(html_content: str, disabled: bool) -> None:
 
 
 @st.fragment
-def create_pmultiqc_report_section(variables_quant) -> None:
+def create_pmultiqc_report_section(variables_quant) -> str:
     """
     Create a section in the Streamlit app to display the pMultiQC report.
     """
+    html_content = ""
     if st.button("Create pMultiQC Report"):
-        tmp = st.session_state[variables_quant.result_perf]
-        tmp_path = Path("tmp_pmultiqc")
-        tmp_path.mkdir(parents=True, exist_ok=True)
-        tmp.to_csv(tmp_path / "result_performance.csv", index=False)
-        ret_code = subprocess.run(
-            [
-                "multiqc",
-                "--parse_proteobench",
-                "./tmp_pmultiqc",
-                "-o",
-                "./report",
-                "-f",
-                "--clean-up",
-            ],
-            check=False,
-        )
-        if ret_code.returncode == 0:
-            st.success("pMultiQC report generated successfully.")
-        else:
-            st.error("Error generating pMultiQC report. Please check the logs.")
+        df_intermediate_results = st.session_state[variables_quant.result_perf]
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            tmp_data = (tmp_dir / "data").resolve()
+            tmp_data.mkdir(parents=True, exist_ok=True)
+            st.write(tmp_data)
+            df_intermediate_results.to_csv(tmp_data / "result_performance.csv", index=False)
+            file_out = tmp_dir
+            ret_code = subprocess.run(
+                [
+                    "multiqc",
+                    "--parse_proteobench",
+                    f"{tmp_data}",
+                    "-o",
+                    f"{file_out}",
+                    "-f",
+                    "--clean-up",
+                ],
+                check=False,
+            )
+            html_path = Path(file_out) / "multiqc_report.html"
+            st.write(ret_code.returncode)
+            st.write(html_path.exists())
+            if html_path.exists() and ret_code.returncode == 0:
+                with open(html_path, "r", encoding="utf-8") as f:
+                    html_content = f.read()
+                st.success("pMultiQC report generated successfully.")
+            else:
+                st.error("Error generating pMultiQC report. Please check the logs.")
+    return html_content

--- a/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
+++ b/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
@@ -1,8 +1,11 @@
+import subprocess
+from pathlib import Path
+
 import streamlit as st
 
 
-@st.fragment()
-def show_download_button(html_content: str) -> None:
+@st.fragment
+def show_download_button(html_content: str, disabled: bool) -> None:
     """
     Display a download button for the pMultiQC report.
     """
@@ -12,4 +15,34 @@ def show_download_button(html_content: str) -> None:
         label="Download pMultiQC Report",
         file_name="pMultiQC_report.html",
         data=html_content,
+        disabled=disabled,
+        mime="text/html",
     )
+
+
+@st.fragment
+def create_pmultiqc_report_section(variables_quant) -> None:
+    """
+    Create a section in the Streamlit app to display the pMultiQC report.
+    """
+    if st.button("Create pMultiQC Report"):
+        tmp = st.session_state[variables_quant.result_perf]
+        tmp_path = Path("tmp_pmultiqc")
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        tmp.to_csv(tmp_path / "result_performance.csv", index=False)
+        ret_code = subprocess.run(
+            [
+                "multiqc",
+                "--parse_proteobench",
+                "./tmp_pmultiqc",
+                "-o",
+                "./report",
+                "-f",
+                "--clean-up",
+            ],
+            check=False,
+        )
+        if ret_code.returncode == 0:
+            st.success("pMultiQC report generated successfully.")
+        else:
+            st.error("Error generating pMultiQC report. Please check the logs.")

--- a/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
+++ b/webinterface/pages/base_pages/tab3_1_pmultiqc_report.py
@@ -5,7 +5,6 @@ from tempfile import TemporaryDirectory
 import streamlit as st
 
 
-@st.fragment
 def show_download_button(html_content: str, disabled: bool) -> None:
     """
     Display a download button for the pMultiQC report.
@@ -21,7 +20,6 @@ def show_download_button(html_content: str, disabled: bool) -> None:
     )
 
 
-@st.fragment
 def create_pmultiqc_report_section(variables_quant) -> str:
     """
     Create a section in the Streamlit app to display the pMultiQC report.
@@ -33,7 +31,6 @@ def create_pmultiqc_report_section(variables_quant) -> str:
             tmp_dir = Path(tmp_dir)
             tmp_data = (tmp_dir / "data").resolve()
             tmp_data.mkdir(parents=True, exist_ok=True)
-            st.write(tmp_data)
             df_intermediate_results.to_csv(tmp_data / "result_performance.csv", index=False)
             file_out = tmp_dir
             ret_code = subprocess.run(
@@ -49,8 +46,6 @@ def create_pmultiqc_report_section(variables_quant) -> str:
                 check=False,
             )
             html_path = Path(file_out) / "multiqc_report.html"
-            st.write(ret_code.returncode)
-            st.write(html_path.exists())
             if html_path.exists() and ret_code.returncode == 0:
                 with open(html_path, "r", encoding="utf-8") as f:
                     html_content = f.read()


### PR DESCRIPTION
Only generate pmultiqc report on user-request

- dumps mulitqc report to temporary directory
- then loads report into memory and provides it to download
- report is not permantenlty stored after submission


- [ ] need to check how temporary submission are handled on the server (are files persistent)
- [ ] could the report be intergrated if it exists into the submission?
