### PR TITLE
adapt proforma charge splitter

### DIFF
--- a/proteobench/io/parsing/utils.py
+++ b/proteobench/io/parsing/utils.py
@@ -24,11 +24,11 @@ def add_fixed_mod(proforma: str, mod_name: str, aas: str) -> str:
     str
         The modified peptide in ProForma format.
     """
-    proforma, charge = proforma.split("|")
+    proforma, charge = proforma.split("\/")
     peptidoform = pu.Peptidoform(proforma)
     peptidoform.add_fixed_modifications([(mod_name, aas)])
     peptidoform.apply_fixed_modifications()
-    return peptidoform.proforma + "|" + charge
+    return peptidoform.proforma + "\/" + charge
 
 
 def add_maxquant_fixed_modifications(params: ProteoBenchParameters, result_perf: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
we changed the charge notation to "pept/(charge)" from "pept|(charge)", but we forgot to adapt the separator in the function for adding fixed modifications to MaxQuant output causing failure when uploading mqpar files.