### PR TITLE
Remove unused json fields

### DIFF
--- a/proteobench/modules/denovo/denovo_base.py
+++ b/proteobench/modules/denovo/denovo_base.py
@@ -344,8 +344,11 @@ class DeNovoModule:
 
         path_write_individual_point = os.path.join(self.t_dir_pr, current_datapoint["intermediate_hash"] + ".json")
         logging.info(f"Writing the json (single point) to: {path_write_individual_point}")
+        datapoint_dict = current_datapoint.to_dict()
+        for key in ("color", "hover_text", "scatter_size", "marker"):
+            datapoint_dict.pop(key, None)
         with open(path_write_individual_point, "w") as f:
-            json.dump(current_datapoint.to_dict(), f, indent=2)
+            json.dump(datapoint_dict, f, indent=2)
 
         commit_name = f"Added new run with id {branch_name}"
         commit_message = f"User comments: {submission_comments}"

--- a/proteobench/modules/quant/quant_base_module.py
+++ b/proteobench/modules/quant/quant_base_module.py
@@ -415,8 +415,11 @@ class QuantModule:
 
         path_write_individual_point = os.path.join(self.t_dir_pr, current_datapoint["intermediate_hash"] + ".json")
         logging.info(f"Writing the json (single point) to: {path_write_individual_point}")
+        datapoint_dict = current_datapoint.to_dict()
+        for key in ("color", "hover_text", "scatter_size", "marker"):
+            datapoint_dict.pop(key, None)
         with open(path_write_individual_point, "w") as f:
-            json.dump(current_datapoint.to_dict(), f, indent=2)
+            json.dump(datapoint_dict, f, indent=2)
 
         commit_name = f"Added new run with id {branch_name}"
         commit_message = f"User comments: {submission_comments}"
@@ -466,9 +469,12 @@ class QuantModule:
         fname = os.path.join(self.t_dir_pr, "results.json")
         logging.info(f"Writing the json to: {fname}")
 
+        cols_to_drop = [c for c in ("color", "hover_text", "scatter_size", "marker") if c in all_datapoints.columns]
+        all_datapoints_clean = all_datapoints.drop(columns=cols_to_drop)
+
         f = open(os.path.join(self.t_dir_pr, "results.json"), "w")
 
-        all_datapoints.to_json(f, orient="records", indent=2)
+        all_datapoints_clean.to_json(f, orient="records", indent=2)
 
         return os.path.join(self.t_dir_pr, "results.json")
 

--- a/resubmit_datapoints.py
+++ b/resubmit_datapoints.py
@@ -1342,9 +1342,6 @@ def reprocess_datapoint(
                 _PRESERVE_FIELDS = (
                     "id",  # contains original submission timestamp
                     "intermediate_hash",  # keeps JSON filename stable for clean PR diffs
-                    "color",
-                    "hover_text",
-                    "scatter_size",
                     "submission_comments",
                 )
                 for _field in _PRESERVE_FIELDS:
@@ -1355,7 +1352,10 @@ def reprocess_datapoint(
 
                 new_dp_hash = intermediate_hash
                 result["new_hash"] = new_dp_hash
-                result["json_data"] = new_datapoint.to_dict()
+                datapoint_dict = new_datapoint.to_dict()
+                for _key in ("color", "hover_text", "scatter_size", "marker"):
+                    datapoint_dict.pop(_key, None)
+                result["json_data"] = datapoint_dict
                 result["repo_suffix"] = repo_suffix
 
             except Exception as e:


### PR DESCRIPTION
This pull request updates the handling of JSON serialization for datapoints to ensure that certain visualization-related fields are excluded from saved and processed JSON files. The changes affect datapoint processing in both the denovo and quant modules, as well as the datapoint resubmission script.

**Datapoint JSON serialization cleanup:**

- Exclude the fields `"color"`, `"hover_text"`, `"scatter_size"`, and `"marker"` from individual datapoint JSON files in both `denovo_base.py` and `quant_base_module.py` when cloning pull requests. This prevents unnecessary visualization metadata from being stored in the output JSONs. [[1]](diffhunk://#diff-e71c9065f62880cfca5a39abf7b51af3488efae739d0d5df5ca69b553105d267R347-R351) [[2]](diffhunk://#diff-14b1b406f0307479af41380c47c1e36b14cf7df1c43a9b851dad8a12f3b955ccR418-R422)
- Remove the same set of fields from the aggregated results JSON in `quant_base_module.py` by dropping these columns before serialization, ensuring only relevant data is saved.

**Datapoint reprocessing adjustments:**

- Update the `reprocess_datapoint` function in `resubmit_datapoints.py` to no longer preserve the visualization fields in the list of fields to keep, and ensure these fields are removed from the serialized JSON data. [[1]](diffhunk://#diff-d7c48fef3b713e769dc656f7e1e3a6d169cc0d113c76fd4f2817b6fddfe14df8L1345-L1347) [[2]](diffhunk://#diff-d7c48fef3b713e769dc656f7e1e3a6d169cc0d113c76fd4f2817b6fddfe14df8L1358-R1358)