### PR TITLE
Species weighted metrics as default

### DIFF
--- a/proteobench/plotting/plot_generator_lfq_PYE.py
+++ b/proteobench/plotting/plot_generator_lfq_PYE.py
@@ -695,7 +695,7 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
             Metric to use for calculations: "Median" or "Mean". Defaults to "Median".
         mode : str, optional
             Mode for metric calculation: "Global" or "Species-weighted". Currently both modes
-            use the same metrics for plasma. Defaults to "Global".
+            use the same metrics for plasma. Defaults to "Species-weighted".
         software_colors : Dict[str, str]
             Mapping of software names to colors.
         mapping : Dict[str, str]
@@ -814,7 +814,7 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
             Metric to use: "Median" or "Mean". Defaults to "Median".
         mode : str, optional
             Mode for metric calculation: "Global" or "Species-weighted". Currently both modes
-            use the same metrics for plasma. Defaults to "Global".
+            use the same metrics for plasma. Defaults to "Species-weighted".
         software_colors : Dict[str, str]
             Mapping of software names to colors.
         mapping : Dict[str, str]

--- a/proteobench/plotting/plot_generator_lfq_PYE.py
+++ b/proteobench/plotting/plot_generator_lfq_PYE.py
@@ -630,7 +630,7 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
         self,
         result_df: pd.DataFrame,
         metric: str = "Median",
-        mode: str = "Global",
+        mode: str = "Species-weighted",
         software_colors: Dict[str, str] = {
             "MaxQuant": "#8bc6fd",
             "AlphaPept": "#17212b",
@@ -745,7 +745,7 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
         self,
         result_df: pd.DataFrame,
         metric: str = "Median",
-        mode: str = "Global",
+        mode: str = "Species-weighted",
         # TODO: move software_colors to constants
         software_colors: Dict[str, str] = {
             "MaxQuant": "#8bc6fd",

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -306,7 +306,7 @@ class QuantUIObjects(BaseUIModule):
 
         # Extract returned values
         metric = results[2] if len(results) > 2 else "Median"
-        mode = results[3] if len(results) > 3 else "Global"
+        mode = results[3] if len(results) > 3 else "Species-weighted"
         colorblind_mode = results[4] if len(results) > 4 else False
 
         # Get the min_nr_observed value from the slider if available
@@ -418,7 +418,7 @@ class QuantUIObjects(BaseUIModule):
 
         # Extract returned values
         metric = results[2] if len(results) > 2 else "Median"
-        mode = results[3] if len(results) > 3 else "Global"
+        mode = results[3] if len(results) > 3 else "Species-weighted"
         colorblind_mode = results[4] if len(results) > 4 else False
 
         # Get current selections from session state

--- a/webinterface/pages/base_pages/quant.py
+++ b/webinterface/pages/base_pages/quant.py
@@ -399,7 +399,7 @@ class QuantUIObjects(BaseUIModule):
             )
             return st.radio(
                 "Select metric calculation approach",
-                ["Global", "Species-weighted"],
+                ["Species-weighted", "Global"],
                 help=help_text,
                 horizontal=True,
                 key=mode_uuid,

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -141,7 +141,7 @@ def display_metric_calc_approach_selector(variables) -> str:
     help_text = getattr(variables.texts.Help, "radio_mode", None) if hasattr(variables, "texts") else None
     mode = st.radio(
         "Select metric calculation approach",
-        ["Global", "Species-weighted"],
+        ["Species-weighted", "Global"],
         help=help_text,
         horizontal=True,
     )

--- a/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
+++ b/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
@@ -34,7 +34,7 @@ def generate_indepth_plots(
     public_id: Optional[str],
     public_hash: Optional[str],
     metric: str = "Median",
-    mode: str = "Global",
+    mode: str = "Species-weighted",
     colorblind_mode: bool = False,
 ) -> Optional[go.Figure]:
     """

--- a/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
+++ b/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
@@ -59,7 +59,7 @@ def generate_indepth_plots(
     metric : str, optional
         The metric to use for plotting (e.g., "Median", "Mean"). Defaults to "Median".
     mode : str, optional
-        The mode for metric calculation (e.g., "Global", "Species-specific"). Defaults to "Global".
+        The mode for metric calculation (e.g., "Global", "Species-specific"). Defaults to "Species-specific".
     colorblind_mode : bool, optional
         Whether to use colorblind-friendly colors. Defaults to False.
 

--- a/webinterface/pages/base_pages/tabs/tab5_compare_results.py
+++ b/webinterface/pages/base_pages/tabs/tab5_compare_results.py
@@ -24,15 +24,13 @@ def display_workflow_comparison(variables, ionmodule) -> None:
         Module for accessing data and methods.
     """
     st.header("Workflow Comparison")
-    st.markdown(
-        """
+    st.markdown("""
         **Compare two workflows side-by-side:**
         - Click on points in the plot below to select workflows for comparison
         - Select exactly two points to see detailed comparison of results and parameters
         - **Precursor overlap**: Bar plot showing number of shared and unique precursors
         - **Parameter differences**: Table highlighting what differs between workflows
-        """
-    )
+        """)
 
     # Initialize data
     _initialize_comparison_data(variables, ionmodule)
@@ -79,7 +77,8 @@ def _display_selection_plot(variables, ionmodule) -> List[str]:
         return []
 
     # Apply filter based on slider if available
-    if hasattr(variables, 'slider_id_uuid'):
+    min_prec = None
+    if hasattr(variables, "slider_id_uuid"):
         slider_key = variables.slider_id_uuid
         if slider_key in st.session_state:
             slider_uuid = st.session_state[slider_key]
@@ -104,6 +103,12 @@ def _display_selection_plot(variables, ionmodule) -> List[str]:
 
     st.subheader("Select Two Workflows to Compare")
     st.markdown("Click on points in the plot below. Your selections will be highlighted.")
+    default_slider = getattr(variables, "default_val_slider", 3)
+    st.info(
+        f"Below plot uses default settings: **{metric}** metric, **{mode}** mode, "
+        f"min. precursor quantifications = **{min_prec if min_prec is not None else default_slider}**.",
+        icon="ℹ️",
+    )
 
     # Create unique key for this plot
     plot_key = f"{variables.all_datapoints}_compare_plot"

--- a/webinterface/pages/base_pages/tabs/tab5_compare_results.py
+++ b/webinterface/pages/base_pages/tabs/tab5_compare_results.py
@@ -100,7 +100,7 @@ def _display_selection_plot(variables, ionmodule) -> List[str]:
 
     # Get metric settings
     metric = "Median"  # Default metric
-    mode = "Global"  # Default mode
+    mode = "Species-weighted"  # Default mode
 
     st.subheader("Select Two Workflows to Compare")
     st.markdown("Click on points in the plot below. Your selections will be highlighted.")


### PR DESCRIPTION
This pull request updates the default metric calculation approach throughout the codebase from "Global" to "Species-weighted". This change affects both the backend plotting logic and the web interface, ensuring consistency in how metrics are calculated and displayed to users.

**Default Calculation Mode Updates:**

* Changed the default `mode` parameter from `"Global"` to `"Species-weighted"` in plotting functions such as `plot_main_metric`, `_plot_plasma_scatterplot`, and `generate_indepth_plots` in `proteobench/plotting/plot_generator_lfq_PYE.py` and `webinterface/pages/base_pages/tabs/tab3_view_single_result.py`. [[1]](diffhunk://#diff-3de86d80c55dc64e683b1e4005a51f2b5c99de79552365688df61d2eb88469d6L633-R633) [[2]](diffhunk://#diff-3de86d80c55dc64e683b1e4005a51f2b5c99de79552365688df61d2eb88469d6L748-R748) [[3]](diffhunk://#diff-e3a4682837d487652fa24f13865bb8f476ddfb658a1e86f1a937ae1721657516L37-R37)
* Updated the default extraction of the `mode` variable from results in the `render_colorblind_selector` function in `webinterface/pages/base_pages/quant.py` to use `"Species-weighted"` instead of `"Global"`. [[1]](diffhunk://#diff-686c3890ac1785e37c970e3462da3c0f7bd7841cbb9c26d5646314f0687051a5L309-R309) [[2]](diffhunk://#diff-686c3890ac1785e37c970e3462da3c0f7bd7841cbb9c26d5646314f0687051a5L421-R421)
* Changed the default mode in the `_display_selection_plot` function in `webinterface/pages/base_pages/tabs/tab5_compare_results.py` to `"Species-weighted"`.

**User Interface Improvements:**

* Reordered the radio button options in the metric calculation approach selector so that `"Species-weighted"` appears before `"Global"` in `display_metric_calc_approach_selector` in `webinterface/pages/base_pages/tabs/tab1_view_public_results.py`, making it the default visible option.