### PR TITLE
Add parameter filtering options

### DIFF
--- a/test/test_parameter_filters.py
+++ b/test/test_parameter_filters.py
@@ -1,0 +1,147 @@
+"""Tests for the parameter-based filtering logic in tab1_view_public_results."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# The webinterface package has transitive imports (streamlit_utils, streamlit)
+# that are not available in the test environment. Mock them before importing.
+sys.modules.setdefault("streamlit", MagicMock())
+sys.modules.setdefault("streamlit_utils", MagicMock())
+
+# Now we can import the pure-logic helpers from the module.
+from webinterface.pages.base_pages.tabs.tab1_view_public_results import (
+    _NOT_SPECIFIED,
+    _get_unique_values,
+    apply_parameter_filters,
+)
+
+
+@pytest.fixture
+def sample_datapoints():
+    """Create a sample DataFrame mimicking benchmark datapoints."""
+    return pd.DataFrame(
+        {
+            "id": ["dp1", "dp2", "dp3", "dp4"],
+            "software_name": ["MaxQuant", "Sage", "MaxQuant", "DIA-NN"],
+            "enable_match_between_runs": [True, False, True, False],
+            "search_engine": ["Andromeda", "Sage", "Andromeda", "DIA-NN"],
+            "enzyme": ["Trypsin", "Trypsin", "Lys-C", "Trypsin"],
+            "allowed_miscleavages": [2, 1, 2, 1],
+            "ident_fdr_psm": [0.01, 0.01, 0.05, 0.01],
+            "quantification_method": ["LFQ", "LFQ", "LFQ", "LFQ"],
+            "precursor_mass_tolerance": ["20 ppm", "10 ppm", "20 ppm", "10 ppm"],
+            "fragment_mass_tolerance": ["20 ppm", "20 ppm", "20 ppm", np.nan],
+        }
+    )
+
+
+class TestGetUniqueValues:
+    def test_sorts_values(self):
+        s = pd.Series(["B", "A", "C", "A"])
+        assert _get_unique_values(s) == ["A", "B", "C"]
+
+    def test_nan_mapped_to_not_specified(self):
+        s = pd.Series(["A", np.nan, "B"])
+        vals = _get_unique_values(s)
+        assert _NOT_SPECIFIED in vals
+        assert "A" in vals
+        assert "B" in vals
+
+    def test_not_specified_sorted_last(self):
+        s = pd.Series(["B", np.nan, "A"])
+        vals = _get_unique_values(s)
+        assert vals[-1] == _NOT_SPECIFIED
+
+    def test_numeric_converted_to_str(self):
+        s = pd.Series([0.01, 0.05, 0.01])
+        vals = _get_unique_values(s)
+        assert all(isinstance(v, str) for v in vals)
+        assert len(vals) == 2
+
+
+class TestApplyParameterFilters:
+    def test_multiselect_filter(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"software_name": ["MaxQuant"]},
+        )
+        assert len(result) == 2
+        assert set(result["software_name"]) == {"MaxQuant"}
+
+    def test_multiselect_multiple_values(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"software_name": ["MaxQuant", "Sage"]},
+        )
+        assert len(result) == 3
+
+    def test_radio_bool_enabled(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"enable_match_between_runs": "Enabled"},
+        )
+        assert len(result) == 2
+        assert all(result["enable_match_between_runs"])
+
+    def test_radio_bool_disabled(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"enable_match_between_runs": "Disabled"},
+        )
+        assert len(result) == 2
+        assert not any(result["enable_match_between_runs"])
+
+    def test_radio_bool_all(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"enable_match_between_runs": "All"},
+        )
+        assert len(result) == 4
+
+    def test_multiple_filters_combined(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {
+                "software_name": ["MaxQuant"],
+                "enable_match_between_runs": "Enabled",
+            },
+        )
+        assert len(result) == 2
+        assert all(result["software_name"] == "MaxQuant")
+        assert all(result["enable_match_between_runs"])
+
+    def test_nan_values_filterable(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"fragment_mass_tolerance": [_NOT_SPECIFIED]},
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["id"] == "dp4"
+
+    def test_empty_dataframe(self):
+        empty_df = pd.DataFrame(columns=["software_name", "enzyme"])
+        result = apply_parameter_filters(empty_df, {"software_name": ["MaxQuant"]})
+        assert result.empty
+
+    def test_unknown_column_ignored(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"nonexistent_column": ["value"]},
+        )
+        assert len(result) == 4
+
+    def test_no_selections_returns_all(self, sample_datapoints):
+        result = apply_parameter_filters(sample_datapoints, {})
+        assert len(result) == 4
+
+    def test_filter_to_zero_rows(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"software_name": ["NonExistent"]},
+        )
+        assert len(result) == 0

--- a/test/test_parameter_filters.py
+++ b/test/test_parameter_filters.py
@@ -36,6 +36,8 @@ def sample_datapoints():
             "quantification_method": ["LFQ", "LFQ", "LFQ", "LFQ"],
             "precursor_mass_tolerance": ["20 ppm", "10 ppm", "20 ppm", "10 ppm"],
             "fragment_mass_tolerance": ["20 ppm", "20 ppm", "20 ppm", np.nan],
+            "min_peptide_length": [7, 7, 8, 9],
+            "max_peptide_length": [30, 40, 50, 50],
         }
     )
 
@@ -145,3 +147,26 @@ class TestApplyParameterFilters:
             {"software_name": ["NonExistent"]},
         )
         assert len(result) == 0
+
+    def test_select_slider_full_range(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"min_peptide_length": (7, 9)},
+        )
+        assert len(result) == 4
+
+    def test_select_slider_partial_range(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"min_peptide_length": (8, 9)},
+        )
+        assert len(result) == 2
+        assert set(result["id"]) == {"dp3", "dp4"}
+
+    def test_select_slider_single_value_range(self, sample_datapoints):
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"max_peptide_length": (50, 50)},
+        )
+        assert len(result) == 2
+        assert set(result["id"]) == {"dp3", "dp4"}

--- a/test/test_parameter_filters.py
+++ b/test/test_parameter_filters.py
@@ -148,25 +148,46 @@ class TestApplyParameterFilters:
         )
         assert len(result) == 0
 
-    def test_select_slider_full_range(self, sample_datapoints):
+    def test_combined_range_full(self, sample_datapoints):
+        """Full range includes all datapoints."""
         result = apply_parameter_filters(
             sample_datapoints,
-            {"min_peptide_length": (7, 9)},
+            {"min_peptide_length__max_peptide_length": (7, 50)},
         )
         assert len(result) == 4
 
-    def test_select_slider_partial_range(self, sample_datapoints):
+    def test_combined_range_narrow(self, sample_datapoints):
+        """Narrowing the range excludes datapoints outside it."""
+        # dp1: min=7, max=30 -> included (7>=7, 30<=40)
+        # dp2: min=7, max=40 -> included (7>=7, 40<=40)
+        # dp3: min=8, max=50 -> excluded (50 > 40)
+        # dp4: min=9, max=50 -> excluded (50 > 40)
         result = apply_parameter_filters(
             sample_datapoints,
-            {"min_peptide_length": (8, 9)},
+            {"min_peptide_length__max_peptide_length": (7, 40)},
+        )
+        assert len(result) == 2
+        assert set(result["id"]) == {"dp1", "dp2"}
+
+    def test_combined_range_raise_lower_bound(self, sample_datapoints):
+        """Raising the lower bound excludes datapoints with small min values."""
+        # dp1: min=7 -> excluded (7 < 8)
+        # dp2: min=7 -> excluded (7 < 8)
+        # dp3: min=8, max=50 -> included
+        # dp4: min=9, max=50 -> included
+        result = apply_parameter_filters(
+            sample_datapoints,
+            {"min_peptide_length__max_peptide_length": (8, 50)},
         )
         assert len(result) == 2
         assert set(result["id"]) == {"dp3", "dp4"}
 
-    def test_select_slider_single_value_range(self, sample_datapoints):
+    def test_select_slider_range(self, sample_datapoints):
+        """select_slider with range tuple works."""
+        sample_datapoints["max_mods"] = [2, 3, 4, 5]
         result = apply_parameter_filters(
             sample_datapoints,
-            {"max_peptide_length": (50, 50)},
+            {"max_mods": (2, 3)},
         )
         assert len(result) == 2
-        assert set(result["id"]) == {"dp3", "dp4"}
+        assert set(result["id"]) == {"dp1", "dp2"}

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -29,11 +29,9 @@ _PARAMETER_FILTERS = [
     {"col": "quantification_method", "label": "Quantification method", "type": "multiselect"},
     {"col": "precursor_mass_tolerance", "label": "Precursor mass tol.", "type": "multiselect"},
     {"col": "fragment_mass_tolerance", "label": "Fragment mass tol.", "type": "multiselect"},
-    {"col": "min_peptide_length", "label": "Min peptide length", "type": "select_slider"},
-    {"col": "max_peptide_length", "label": "Max peptide length", "type": "select_slider"},
+    {"col_min": "min_peptide_length", "col_max": "max_peptide_length", "label": "Peptide length", "type": "combined_range"},
     {"col": "max_mods", "label": "Max mods per peptide", "type": "select_slider"},
-    {"col": "min_precursor_charge", "label": "Min precursor charge", "type": "select_slider"},
-    {"col": "max_precursor_charge", "label": "Max precursor charge", "type": "select_slider"},
+    {"col_min": "min_precursor_charge", "col_max": "max_precursor_charge", "label": "Precursor charge", "type": "combined_range"},
 ]
 
 
@@ -74,8 +72,23 @@ def apply_parameter_filters(
     mask = pd.Series(True, index=data.index)
 
     for spec in _PARAMETER_FILTERS:
-        col = spec["col"]
-        if col not in filter_selections or col not in data.columns:
+        if spec["type"] == "combined_range":
+            col_min = spec["col_min"]
+            col_max = spec["col_max"]
+            filter_key = f"{col_min}__{col_max}"
+            if filter_key not in filter_selections:
+                continue
+            selection = filter_selections[filter_key]
+            if isinstance(selection, (list, tuple)) and len(selection) == 2:
+                lo, hi = selection
+                if col_min in data.columns:
+                    mask &= data[col_min].fillna(lo) >= lo
+                if col_max in data.columns:
+                    mask &= data[col_max].fillna(hi) <= hi
+            continue
+
+        col = spec.get("col")
+        if col is None or col not in filter_selections or col not in data.columns:
             continue
 
         selection = filter_selections[col]
@@ -134,13 +147,27 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
     # Determine which filters are applicable for this dataset
     applicable: List[dict] = []
     for spec in _PARAMETER_FILTERS:
-        col = spec["col"]
-        if col not in data.columns:
-            continue
-        n_unique = data[col].dropna().nunique()
-        if n_unique < 2:
-            continue
-        applicable.append(spec)
+        if spec["type"] == "combined_range":
+            col_min, col_max = spec["col_min"], spec["col_max"]
+            has_min = col_min in data.columns and data[col_min].dropna().nunique() >= 1
+            has_max = col_max in data.columns and data[col_max].dropna().nunique() >= 1
+            if has_min or has_max:
+                # Need at least 2 distinct values across both columns combined
+                all_vals = set()
+                if has_min:
+                    all_vals.update(data[col_min].dropna().unique())
+                if has_max:
+                    all_vals.update(data[col_max].dropna().unique())
+                if len(all_vals) >= 2:
+                    applicable.append(spec)
+        else:
+            col = spec["col"]
+            if col not in data.columns:
+                continue
+            n_unique = data[col].dropna().nunique()
+            if n_unique < 2:
+                continue
+            applicable.append(spec)
 
     if not applicable:
         return data
@@ -151,7 +178,10 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
         # Reset button
         if st.button("Reset all filters", key=f"{key_prefix}_reset"):
             for spec in applicable:
-                sk = f"{key_prefix}_{spec['col']}"
+                if spec["type"] == "combined_range":
+                    sk = f"{key_prefix}_{spec['col_min']}__{spec['col_max']}"
+                else:
+                    sk = f"{key_prefix}_{spec['col']}"
                 if sk in st.session_state:
                     del st.session_state[sk]
             st.rerun()
@@ -159,12 +189,33 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
         # Lay out filters in a 3-column grid
         cols = st.columns(3)
         for idx, spec in enumerate(applicable):
-            col_name = spec["col"]
             label = spec["label"]
-            sk = f"{key_prefix}_{col_name}"
 
             with cols[idx % 3]:
-                if spec["type"] == "radio_bool":
+                if spec["type"] == "combined_range":
+                    col_min, col_max = spec["col_min"], spec["col_max"]
+                    filter_key = f"{col_min}__{col_max}"
+                    sk = f"{key_prefix}_{filter_key}"
+                    # Build option range from both columns
+                    all_vals = set()
+                    if col_min in data.columns:
+                        all_vals.update(data[col_min].dropna().unique())
+                    if col_max in data.columns:
+                        all_vals.update(data[col_max].dropna().unique())
+                    all_options = sorted(all_vals)
+                    full_range = (all_options[0], all_options[-1])
+                    default = st.session_state.get(sk, full_range)
+                    selected = st.select_slider(
+                        label,
+                        options=all_options,
+                        value=default,
+                        key=sk,
+                    )
+                    filter_selections[filter_key] = selected
+
+                elif spec["type"] == "radio_bool":
+                    col_name = spec["col"]
+                    sk = f"{key_prefix}_{col_name}"
                     default = st.session_state.get(sk, "All")
                     choice = st.radio(
                         label,
@@ -176,6 +227,8 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
                     filter_selections[col_name] = choice
 
                 elif spec["type"] == "multiselect":
+                    col_name = spec["col"]
+                    sk = f"{key_prefix}_{col_name}"
                     all_options = _get_unique_values(data[col_name])
                     default = st.session_state.get(sk, all_options)
                     selected = st.multiselect(
@@ -187,6 +240,8 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
                     filter_selections[col_name] = selected
 
                 elif spec["type"] == "select_slider":
+                    col_name = spec["col"]
+                    sk = f"{key_prefix}_{col_name}"
                     all_options = sorted(data[col_name].dropna().unique())
                     if len(all_options) < 2:
                         continue

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -7,10 +7,181 @@ across all ProteoBench module types (Quant, De Novo, etc.).
 
 import os
 import uuid
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
+import numpy as np
 import pandas as pd
 import streamlit as st
+
+
+# ---------------------------------------------------------------------------
+# Parameter-based filtering
+# ---------------------------------------------------------------------------
+
+_NOT_SPECIFIED = "Not specified"
+
+_PARAMETER_FILTERS = [
+    {"col": "software_name", "label": "Software tool", "type": "multiselect"},
+    {"col": "enable_match_between_runs", "label": "Match between runs", "type": "radio_bool"},
+    {"col": "search_engine", "label": "Search engine", "type": "multiselect"},
+    {"col": "enzyme", "label": "Enzyme", "type": "multiselect"},
+    {"col": "allowed_miscleavages", "label": "Allowed miscleavages", "type": "multiselect"},
+    {"col": "ident_fdr_psm", "label": "PSM FDR", "type": "multiselect"},
+    {"col": "quantification_method", "label": "Quantification method", "type": "multiselect"},
+    {"col": "precursor_mass_tolerance", "label": "Precursor mass tol.", "type": "multiselect"},
+    {"col": "fragment_mass_tolerance", "label": "Fragment mass tol.", "type": "multiselect"},
+]
+
+
+def _get_unique_values(series: pd.Series) -> List[str]:
+    """Return sorted unique string values from *series*, mapping NaN to _NOT_SPECIFIED."""
+    values = series.fillna(_NOT_SPECIFIED).astype(str).unique()
+    return sorted(values, key=lambda v: (v == _NOT_SPECIFIED, v))
+
+
+def apply_parameter_filters(
+    data: pd.DataFrame,
+    filter_selections: Dict[str, Any],
+) -> pd.DataFrame:
+    """
+    Apply parameter-based filters to a DataFrame of benchmark datapoints.
+
+    This is the pure filtering logic, separated from UI rendering so it can
+    be tested independently.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        The benchmark datapoints to filter.
+    filter_selections : dict
+        Mapping of column name to the selected filter value(s).
+        For ``multiselect`` filters the value is a list of allowed strings.
+        For ``radio_bool`` filters the value is one of ``"All"``,
+        ``"Enabled"``, or ``"Disabled"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The subset of *data* matching all active filters.
+    """
+    if data.empty:
+        return data
+
+    mask = pd.Series(True, index=data.index)
+
+    for spec in _PARAMETER_FILTERS:
+        col = spec["col"]
+        if col not in filter_selections or col not in data.columns:
+            continue
+
+        selection = filter_selections[col]
+
+        if spec["type"] == "radio_bool":
+            if selection == "Enabled":
+                mask &= data[col].astype(bool)
+            elif selection == "Disabled":
+                mask &= ~data[col].astype(bool)
+            # "All" → no filtering
+
+        elif spec["type"] == "multiselect":
+            if isinstance(selection, list):
+                str_col = data[col].fillna(_NOT_SPECIFIED).astype(str)
+                mask &= str_col.isin(selection)
+
+    return data.loc[mask]
+
+
+def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filter") -> pd.DataFrame:
+    """
+    Render parameter-based filter widgets and return the filtered DataFrame.
+
+    Displays an ``st.expander`` with multiselect / radio widgets for each
+    workflow parameter that has more than one unique non-null value in *data*.
+    Filtering is applied **after** the existing k-slider filter.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Benchmark datapoints (already filtered by the k-slider).
+    key_prefix : str, optional
+        Prefix for Streamlit session-state keys to avoid collisions when the
+        function is rendered on multiple tabs. Defaults to ``"param_filter"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The subset of *data* matching all active parameter filters.
+
+    Notes
+    -----
+    Session-state keys use the pattern ``{key_prefix}_{column_name}`` and do
+    not require UUID indirection because the column names are unique and stable.
+    """
+    if data.empty:
+        return data
+
+    total_count = len(data)
+
+    # Determine which filters are applicable for this dataset
+    applicable: List[dict] = []
+    for spec in _PARAMETER_FILTERS:
+        col = spec["col"]
+        if col not in data.columns:
+            continue
+        n_unique = data[col].dropna().nunique()
+        if n_unique < 2:
+            continue
+        applicable.append(spec)
+
+    if not applicable:
+        return data
+
+    filter_selections: Dict[str, Any] = {}
+
+    with st.expander("Filter by workflow parameters", expanded=False):
+        # Reset button
+        if st.button("Reset all filters", key=f"{key_prefix}_reset"):
+            for spec in applicable:
+                sk = f"{key_prefix}_{spec['col']}"
+                if sk in st.session_state:
+                    del st.session_state[sk]
+            st.rerun()
+
+        # Lay out filters in a 3-column grid
+        cols = st.columns(3)
+        for idx, spec in enumerate(applicable):
+            col_name = spec["col"]
+            label = spec["label"]
+            sk = f"{key_prefix}_{col_name}"
+
+            with cols[idx % 3]:
+                if spec["type"] == "radio_bool":
+                    default = st.session_state.get(sk, "All")
+                    choice = st.radio(
+                        label,
+                        ["All", "Enabled", "Disabled"],
+                        index=["All", "Enabled", "Disabled"].index(default),
+                        key=sk,
+                        horizontal=True,
+                    )
+                    filter_selections[col_name] = choice
+
+                elif spec["type"] == "multiselect":
+                    all_options = _get_unique_values(data[col_name])
+                    default = st.session_state.get(sk, all_options)
+                    selected = st.multiselect(
+                        label,
+                        options=all_options,
+                        default=default,
+                        key=sk,
+                    )
+                    filter_selections[col_name] = selected
+
+        filtered = apply_parameter_filters(data, filter_selections)
+        filtered_count = len(filtered)
+        st.caption(f"Showing {filtered_count} of {total_count} datapoints")
+
+    return filtered
 
 
 def initialize_uuid_state(key: str, default_value: Any = None) -> None:
@@ -402,6 +573,11 @@ def display_existing_results(
     # Initialize and filter data
     initialize_main_data_points(variables, ionmodule)
     filtered_data = filter_data_if_applicable(variables, ionmodule, use_slider)
+
+    # Apply parameter-based filters (key_prefix must be unique per module page)
+    filtered_data = generate_parameter_filters(
+        filtered_data, key_prefix=f"param_filter_{variables.all_datapoints}"
+    )
 
     # Get plot generator from module
     plot_generator = ionmodule.get_plot_generator()

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
-
 # ---------------------------------------------------------------------------
 # Parameter-based filtering
 # ---------------------------------------------------------------------------
@@ -30,6 +29,11 @@ _PARAMETER_FILTERS = [
     {"col": "quantification_method", "label": "Quantification method", "type": "multiselect"},
     {"col": "precursor_mass_tolerance", "label": "Precursor mass tol.", "type": "multiselect"},
     {"col": "fragment_mass_tolerance", "label": "Fragment mass tol.", "type": "multiselect"},
+    {"col": "min_peptide_length", "label": "Min peptide length", "type": "select_slider"},
+    {"col": "max_peptide_length", "label": "Max peptide length", "type": "select_slider"},
+    {"col": "max_mods", "label": "Max mods per peptide", "type": "select_slider"},
+    {"col": "min_precursor_charge", "label": "Min precursor charge", "type": "select_slider"},
+    {"col": "max_precursor_charge", "label": "Max precursor charge", "type": "select_slider"},
 ]
 
 
@@ -87,6 +91,11 @@ def apply_parameter_filters(
             if isinstance(selection, list):
                 str_col = data[col].fillna(_NOT_SPECIFIED).astype(str)
                 mask &= str_col.isin(selection)
+
+        elif spec["type"] == "select_slider":
+            if isinstance(selection, (list, tuple)) and len(selection) == 2:
+                lo, hi = selection
+                mask &= data[col].fillna(lo).between(lo, hi)
 
     return data.loc[mask]
 
@@ -177,6 +186,20 @@ def generate_parameter_filters(data: pd.DataFrame, key_prefix: str = "param_filt
                     )
                     filter_selections[col_name] = selected
 
+                elif spec["type"] == "select_slider":
+                    all_options = sorted(data[col_name].dropna().unique())
+                    if len(all_options) < 2:
+                        continue
+                    full_range = (all_options[0], all_options[-1])
+                    default = st.session_state.get(sk, full_range)
+                    selected = st.select_slider(
+                        label,
+                        options=all_options,
+                        value=default,
+                        key=sk,
+                    )
+                    filter_selections[col_name] = selected
+
         filtered = apply_parameter_filters(data, filter_selections)
         filtered_count = len(filtered)
         st.caption(f"Showing {filtered_count} of {total_count} datapoints")
@@ -230,10 +253,12 @@ def initialize_main_slider(slider_id_uuid: str, default_val_slider: int) -> None
     initialize_uuid_state(slider_id_uuid, default_val_slider)
 
 
-def generate_main_slider(slider_id_uuid: str, description_slider_md: str, default_val_slider: float, max_nr_observed: int = 6) -> None:
+def generate_main_slider(
+    slider_id_uuid: str, description_slider_md: str, default_val_slider: float, max_nr_observed: int = 6
+) -> None:
     """
     Create a slider input.
-    
+
     Parameters
     ----------
     slider_id_uuid : str
@@ -251,10 +276,10 @@ def generate_main_slider(slider_id_uuid: str, description_slider_md: str, defaul
     slider_key = st.session_state[slider_id_uuid]
 
     default_value = st.session_state.get(slider_key, default_val_slider)
-    
+
     # Generate slider options based on max_nr_observed
     slider_options = list(range(1, max_nr_observed + 1))
-    
+
     st.select_slider(
         label="Minimal precursor quantifications (# samples)",
         options=slider_options,
@@ -321,20 +346,22 @@ def display_metric_calc_approach_selector(variables) -> str:
 
 def display_colorblindmode_selector(variables, use_submitted: bool = False) -> str:
     """Display colorblind mode selector toggle.
-    
+
     Parameters
     ----------
     variables : VariablesClass
         Variables object containing selector UUIDs
     use_submitted : bool, optional
         If True, use the submitted selector UUID, by default False
-    
+
     Returns
     -------
     bool
         Current state of the colorblind mode toggle
     """
-    key = variables.colorblind_mode_selector_submitted_uuid if use_submitted else variables.colorblind_mode_selector_uuid
+    key = (
+        variables.colorblind_mode_selector_submitted_uuid if use_submitted else variables.colorblind_mode_selector_uuid
+    )
     if key not in st.session_state.keys():
         st.session_state[key] = uuid.uuid4()
     _id_of_key = st.session_state[key]
@@ -407,10 +434,7 @@ def render_main_plot(plot_generator, data: pd.DataFrame, variables, plot_params:
 
     try:
         fig = plot_generator.plot_main_metric(
-            result_df=data, 
-            hide_annot=plot_params.get("hide_annot", False),
-            annotation=annotation,
-            **plot_params
+            result_df=data, hide_annot=plot_params.get("hide_annot", False), annotation=annotation, **plot_params
         )
         st.plotly_chart(fig, use_container_width=True, key=plot_uuid)
     except Exception as e:
@@ -539,7 +563,9 @@ def display_download_section(variables, sort_by: str = "id") -> None:
                 icon="⚠️",
             )
     elif selected_hash is not None:
-        st.info("Storage directory is not configured. Set `storage.dir` in secrets.toml to enable downloads.", icon="ℹ️")
+        st.info(
+            "Storage directory is not configured. Set `storage.dir` in secrets.toml to enable downloads.", icon="ℹ️"
+        )
 
 
 def display_existing_results(
@@ -575,9 +601,7 @@ def display_existing_results(
     filtered_data = filter_data_if_applicable(variables, ionmodule, use_slider)
 
     # Apply parameter-based filters (key_prefix must be unique per module page)
-    filtered_data = generate_parameter_filters(
-        filtered_data, key_prefix=f"param_filter_{variables.all_datapoints}"
-    )
+    filtered_data = generate_parameter_filters(filtered_data, key_prefix=f"param_filter_{variables.all_datapoints}")
 
     # Get plot generator from module
     plot_generator = ionmodule.get_plot_generator()

--- a/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
+++ b/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
@@ -211,6 +211,13 @@ def display_submitted_results(
     # Filter data using slider if applicable
     filtered_data = filter_submitted_data_if_applicable(variables, ionmodule, use_slider=True)
 
+    # Apply parameter-based filters
+    from .tab1_view_public_results import generate_parameter_filters
+
+    filtered_data = generate_parameter_filters(
+        filtered_data, key_prefix=f"param_filter_{variables.all_datapoints_submitted}"
+    )
+
     # Get plot generator from module
     plot_generator = ionmodule.get_plot_generator()
 


### PR DESCRIPTION
This pull request introduces parameter-based filtering for benchmark datapoints in the public results and submitted results tabs. The main changes include adding reusable, testable filtering logic, integrating new filter widgets into the UI, and providing comprehensive tests for the filtering behavior. Whether this is actually useful needs to be discussed

**Parameter-based filtering logic and UI integration:**

* Added `_NOT_SPECIFIED`, `_PARAMETER_FILTERS`, `_get_unique_values`, `apply_parameter_filters`, and `generate_parameter_filters` to `tab1_view_public_results.py` to enable flexible, reusable filtering of datapoints by workflow parameters, with support for handling NaN values and multiple filter types.
* Integrated the new parameter filter UI into the `display_existing_results` function in `tab1_view_public_results.py`, applying filters after the k-slider and before data visualization.
* Integrated the same parameter filter UI into the `display_submitted_results` function in `tab4_view_public_and_new_results.py`, enabling consistent filtering for submitted results.

**Testing:**

* Added `test/test_parameter_filters.py` with extensive tests for the filtering logic, including edge cases such as handling NaN, empty DataFrames, unknown columns, and combined filters.




**Note**
Probably will not be merged for a while because of the following reason: with the current non-homogenized parameters, the usefulness of these filters are quite low. We should consider homogenizing parameters. It will have benefits in various downstream applications of ProteoBench