### PR TITLE
barcharts with submission details

### DIFF
--- a/webinterface/Home.py
+++ b/webinterface/Home.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import streamlit as st
 from _base import StreamlitPage
 from UI_utils import (
+    build_submissions_figure,
+    build_tool_pie_chart,
     get_monthly_visitors,
     get_n_modules,
     get_n_modules_proposed,
@@ -12,6 +14,12 @@ from UI_utils import (
     get_n_supported_tools,
     stat_box,
 )
+
+
+@st.dialog("Tool Breakdown", width="large")
+def _show_tool_breakdown(module_title, tool_counts):
+    pie_fig = build_tool_pie_chart(module_title, tool_counts)
+    st.plotly_chart(pie_fig, use_container_width=True)
 
 # Path to the index.rst file
 file_path = Path(__file__).resolve().parent.parent / "docs" / "index.rst"
@@ -138,6 +146,23 @@ class StreamlitPageHome(StreamlitPage):
                 stat_box("Monthly unique visitors", monthly_uniq_visitors, fig_path / "user.png"),
                 unsafe_allow_html=True,
             )
+
+        # Submissions per module barplot
+        st.markdown("<br>", unsafe_allow_html=True)
+        st.subheader("Submissions per Module")
+        bar_fig, tool_data = build_submissions_figure()
+        if bar_fig is not None:
+            event = st.plotly_chart(bar_fig, use_container_width=True, on_select="rerun", key="submissions_chart")
+
+            # Show pie chart in a dialog popup when a bar is clicked
+            selection = event.get("selection", {}) if event else {}
+            points = selection.get("points", [])
+            if points:
+                module_title = points[0].get("x")
+                if module_title and module_title in tool_data and tool_data[module_title]:
+                    _show_tool_breakdown(module_title, tool_data[module_title])
+        else:
+            st.info("Submission data is currently unavailable.")
 
 
 if __name__ == "__main__":

--- a/webinterface/Home.py
+++ b/webinterface/Home.py
@@ -152,7 +152,13 @@ class StreamlitPageHome(StreamlitPage):
         st.subheader("Submissions per Module")
         bar_fig, tool_data = build_submissions_figure()
         if bar_fig is not None:
-            event = st.plotly_chart(bar_fig, use_container_width=True, on_select="rerun", key="submissions_chart")
+            event = st.plotly_chart(
+                bar_fig,
+                use_container_width=True,
+                on_select="rerun",
+                selection_mode="points",
+                key="submissions_chart",
+            )
 
             # Show pie chart in a dialog popup when a bar is clicked
             selection = event.get("selection", {}) if event else {}

--- a/webinterface/UI_utils.py
+++ b/webinterface/UI_utils.py
@@ -1,11 +1,17 @@
 import base64
+import io
+import json
+import logging
 import re
+import tarfile
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Dict, Optional
 
 import requests
 import streamlit as st
+from pages.utils.module_registry import get_all_modules
 
 SECRETS_FILE = Path(__file__).parent / ".streamlit" / "secrets.toml"
 GRAPHQL_URL = "https://api.github.com/graphql"
@@ -230,13 +236,6 @@ def get_module_submission_data() -> Dict[str, Dict[str, int]]:
     Dict[str, Dict[str, int]]
         Mapping of results_repo name to {software_name: count} dict.
     """
-    import io
-    import json
-    import tarfile
-    from collections import Counter
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    from pages.utils.module_registry import get_all_modules
 
     modules_by_category = get_all_modules()
 
@@ -245,17 +244,16 @@ def get_module_submission_data() -> Dict[str, Dict[str, int]]:
         token = st.secrets["gh"]["token"]
         headers["Authorization"] = f"token {token}"
     except Exception:
+        logger.warning(
+            "Could not obtain GitHub token, proceeding with unauthenticated requests which may be rate-limited."
+        )
         pass
 
     repo_names = [
-        module.results_repo
-        for modules in modules_by_category.values()
-        for module in modules
-        if module.results_repo
+        module.results_repo for modules in modules_by_category.values() for module in modules if module.results_repo
     ]
 
     def _fetch_tool_breakdown(repo_name: str) -> tuple:
-        import logging
 
         logger = logging.getLogger(__name__)
 
@@ -277,9 +275,7 @@ def get_module_submission_data() -> Dict[str, Dict[str, int]]:
                             data = json.loads(f.read())
                             tools[data.get("software_name", "Unknown")] += 1
                         except (json.JSONDecodeError, KeyError, OSError):
-                            logger.warning(
-                                "Skipping malformed file %s in %s", member.name, repo_name, exc_info=True
-                            )
+                            logger.warning("Skipping malformed file %s in %s", member.name, repo_name, exc_info=True)
         except tarfile.TarError:
             logger.warning("Failed to read archive for %s", repo_name, exc_info=True)
             return repo_name, {}
@@ -310,10 +306,9 @@ def build_submissions_figure():
     tuple(plotly.graph_objects.Figure, Dict[str, Dict[str, int]]) or (None, None)
         The bar figure and a mapping of module title to per-tool counts.
     """
+    from pages.utils.module_registry import get_all_modules
     from plotly import graph_objects as go
     from plotly.subplots import make_subplots
-
-    from pages.utils.module_registry import get_all_modules
 
     modules_by_category = get_all_modules()
     submission_data = get_module_submission_data()

--- a/webinterface/UI_utils.py
+++ b/webinterface/UI_utils.py
@@ -255,23 +255,42 @@ def get_module_submission_data() -> Dict[str, Dict[str, int]]:
     ]
 
     def _fetch_tool_breakdown(repo_name: str) -> tuple:
+        import logging
+
+        logger = logging.getLogger(__name__)
+
         try:
             url = f"https://api.github.com/repos/Proteobench/{repo_name}/tarball/main"
             resp = requests.get(url, headers=headers, timeout=30)
             resp.raise_for_status()
-            tools = Counter()
+        except requests.RequestException:
+            logger.warning("Failed to download archive for %s", repo_name, exc_info=True)
+            return repo_name, {}
+
+        tools = Counter()
+        try:
             with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
                 for member in tar.getmembers():
                     if member.name.endswith(".json") and member.isfile():
-                        f = tar.extractfile(member)
-                        data = json.loads(f.read())
-                        tools[data.get("software_name", "Unknown")] += 1
-            return repo_name, dict(tools)
-        except Exception:
+                        try:
+                            f = tar.extractfile(member)
+                            data = json.loads(f.read())
+                            tools[data.get("software_name", "Unknown")] += 1
+                        except (json.JSONDecodeError, KeyError, OSError):
+                            logger.warning(
+                                "Skipping malformed file %s in %s", member.name, repo_name, exc_info=True
+                            )
+        except tarfile.TarError:
+            logger.warning("Failed to read archive for %s", repo_name, exc_info=True)
             return repo_name, {}
 
+        return repo_name, dict(tools)
+
+    if not repo_names:
+        return {}
+
     result: Dict[str, Dict[str, int]] = {}
-    with ThreadPoolExecutor(max_workers=len(repo_names)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(repo_names), 10)) as executor:
         futures = {executor.submit(_fetch_tool_breakdown, name): name for name in repo_names}
         for future in as_completed(futures):
             repo_name, tool_counts = future.result()

--- a/webinterface/UI_utils.py
+++ b/webinterface/UI_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import requests
+import streamlit as st
 
 SECRETS_FILE = Path(__file__).parent / ".streamlit" / "secrets.toml"
 GRAPHQL_URL = "https://api.github.com/graphql"
@@ -215,6 +216,193 @@ def get_monthly_visitors(api_endpoint: str, token: str, id_site: int) -> Optiona
     except (ValueError, KeyError):
         print("Error parsing Matomo API response")
         return None
+
+
+@st.cache_data(ttl=3600, show_spinner=False)
+def get_module_submission_data() -> Dict[str, Dict[str, int]]:
+    """
+    Fetch submission data per module by downloading repo archives.
+    Returns per-tool submission counts for each module.
+    Requests are made concurrently to minimize latency.
+
+    Returns
+    -------
+    Dict[str, Dict[str, int]]
+        Mapping of results_repo name to {software_name: count} dict.
+    """
+    import io
+    import json
+    import tarfile
+    from collections import Counter
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from pages.utils.module_registry import get_all_modules
+
+    modules_by_category = get_all_modules()
+
+    headers = {}
+    try:
+        token = st.secrets["gh"]["token"]
+        headers["Authorization"] = f"token {token}"
+    except Exception:
+        pass
+
+    repo_names = [
+        module.results_repo
+        for modules in modules_by_category.values()
+        for module in modules
+        if module.results_repo
+    ]
+
+    def _fetch_tool_breakdown(repo_name: str) -> tuple:
+        try:
+            url = f"https://api.github.com/repos/Proteobench/{repo_name}/tarball/main"
+            resp = requests.get(url, headers=headers, timeout=30)
+            resp.raise_for_status()
+            tools = Counter()
+            with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+                for member in tar.getmembers():
+                    if member.name.endswith(".json") and member.isfile():
+                        f = tar.extractfile(member)
+                        data = json.loads(f.read())
+                        tools[data.get("software_name", "Unknown")] += 1
+            return repo_name, dict(tools)
+        except Exception:
+            return repo_name, {}
+
+    result: Dict[str, Dict[str, int]] = {}
+    with ThreadPoolExecutor(max_workers=len(repo_names)) as executor:
+        futures = {executor.submit(_fetch_tool_breakdown, name): name for name in repo_names}
+        for future in as_completed(futures):
+            repo_name, tool_counts = future.result()
+            result[repo_name] = tool_counts
+
+    return result
+
+
+def build_submissions_figure():
+    """
+    Build a Plotly figure with faceted vertical bar charts showing submissions per module,
+    one subplot per category (DDA, DIA, etc.). Excludes archived modules.
+    Each bar stores its results_repo name in customdata for click-based pie chart interaction.
+
+    Returns
+    -------
+    tuple(plotly.graph_objects.Figure, Dict[str, Dict[str, int]]) or (None, None)
+        The bar figure and a mapping of module title to per-tool counts.
+    """
+    from plotly import graph_objects as go
+    from plotly.subplots import make_subplots
+
+    from pages.utils.module_registry import get_all_modules
+
+    modules_by_category = get_all_modules()
+    submission_data = get_module_submission_data()
+
+    # Build per-category data, excluding archived modules
+    category_data: Dict[str, list] = {}
+    tool_data_by_title: Dict[str, Dict[str, int]] = {}
+    for category, modules in modules_by_category.items():
+        rows = []
+        for module in modules:
+            if module.release_stage == "archived":
+                continue
+            if module.results_repo and module.results_repo in submission_data:
+                tool_counts = submission_data[module.results_repo]
+                total = sum(tool_counts.values())
+                rows.append({"label": module.title, "count": total})
+                tool_data_by_title[module.title] = tool_counts
+        if rows:
+            rows.sort(key=lambda r: r["count"], reverse=True)
+            category_data[category] = rows
+
+    if not category_data:
+        return None, None
+
+    categories = sorted(category_data.keys())
+    n_cats = len(categories)
+
+    palette = ["#F4A582", "#92C5DE", "#B2DF8A", "#CAB2D6", "#FDBF6F", "#FB9A99"]
+    color_map = {cat: palette[i % len(palette)] for i, cat in enumerate(categories)}
+
+    fig = make_subplots(
+        rows=1,
+        cols=n_cats,
+        subplot_titles=[f"{cat} Modules" for cat in categories],
+        shared_yaxes=False,
+        horizontal_spacing=0.08,
+    )
+
+    for col_idx, cat in enumerate(categories, start=1):
+        rows = category_data[cat]
+        labels = [r["label"] for r in rows]
+        values = [r["count"] for r in rows]
+
+        fig.add_trace(
+            go.Bar(
+                x=labels,
+                y=values,
+                marker_color=color_map[cat],
+                name=cat,
+                hovertemplate="<b>%{x}</b><br>Submissions: %{y}<br><i>Click for tool breakdown</i><extra></extra>",
+                showlegend=False,
+            ),
+            row=1,
+            col=col_idx,
+        )
+
+        fig.update_xaxes(tickangle=-45, row=1, col=col_idx)
+        fig.update_yaxes(title_text="# public workflow results" if col_idx == 1 else "", row=1, col=col_idx)
+
+    max_modules = max(len(v) for v in category_data.values())
+    fig.update_layout(
+        height=max(350, 200 + max_modules * 25),
+        margin=dict(l=40, r=20, t=40, b=120),
+    )
+
+    return fig, tool_data_by_title
+
+
+def build_tool_pie_chart(module_title: str, tool_counts: Dict[str, int]):
+    """
+    Build a Plotly pie chart showing tool breakdown for a given module.
+
+    Parameters
+    ----------
+    module_title : str
+        The module title for the chart heading.
+    tool_counts : Dict[str, int]
+        Mapping of software_name to submission count.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+    """
+    from plotly import graph_objects as go
+
+    labels = list(tool_counts.keys())
+    values = list(tool_counts.values())
+
+    fig = go.Figure(
+        data=[
+            go.Pie(
+                labels=labels,
+                values=values,
+                hovertemplate="<b>%{label}</b><br>Submissions: %{value}<br>(%{percent})<extra></extra>",
+                textinfo="label+value",
+                textposition="auto",
+            )
+        ]
+    )
+    fig.update_layout(
+        title=dict(text=f"Tool breakdown: {module_title}", font=dict(size=14)),
+        height=350,
+        margin=dict(l=20, r=20, t=50, b=20),
+        showlegend=True,
+        legend=dict(orientation="h", yanchor="bottom", y=-0.2, xanchor="center", x=0.5),
+    )
+
+    return fig
 
 
 if __name__ == "__main__":

--- a/webinterface/UI_utils.py
+++ b/webinterface/UI_utils.py
@@ -16,6 +16,8 @@ from pages.utils.module_registry import get_all_modules
 SECRETS_FILE = Path(__file__).parent / ".streamlit" / "secrets.toml"
 GRAPHQL_URL = "https://api.github.com/graphql"
 
+logger = logging.getLogger(__name__)
+
 
 def get_base64_image(path):
     with open(path, "rb") as image_file:
@@ -254,8 +256,6 @@ def get_module_submission_data() -> Dict[str, Dict[str, int]]:
     ]
 
     def _fetch_tool_breakdown(repo_name: str) -> tuple:
-
-        logger = logging.getLogger(__name__)
 
         try:
             url = f"https://api.github.com/repos/Proteobench/{repo_name}/tarball/main"

--- a/webinterface/UI_utils.py
+++ b/webinterface/UI_utils.py
@@ -13,9 +13,6 @@ import requests
 import streamlit as st
 from pages.utils.module_registry import get_all_modules
 
-SECRETS_FILE = Path(__file__).parent / ".streamlit" / "secrets.toml"
-GRAPHQL_URL = "https://api.github.com/graphql"
-
 logger = logging.getLogger(__name__)
 
 

--- a/webinterface/pages/utils/module_registry.py
+++ b/webinterface/pages/utils/module_registry.py
@@ -26,6 +26,7 @@ class ModuleMetadata:
     keywords: List[str]
     title: str
     doc_url: str
+    results_repo: Optional[str] = None  # e.g. "Results_quant_ion_DDA"
 
 
 @st.cache_resource
@@ -104,6 +105,12 @@ def get_all_modules() -> Dict[str, List[ModuleMetadata]]:
                 # Fallback
                 file_path = f"pages/{page_name}.py"
 
+            # Extract results repo name from github_link_pr
+            # e.g. "github.com/Proteobot/Results_quant_ion_DDA.git" -> "Results_quant_ion_DDA"
+            results_repo = None
+            if hasattr(variables, "github_link_pr") and variables.github_link_pr:
+                results_repo = variables.github_link_pr.rstrip(".git").split("/")[-1]
+
             # Create metadata object
             metadata = ModuleMetadata(
                 label=variables.sidebar_label,
@@ -114,6 +121,7 @@ def get_all_modules() -> Dict[str, List[ModuleMetadata]]:
                 keywords=variables.keywords,
                 title=variables.title,
                 doc_url=variables.doc_url,
+                results_repo=results_repo,
             )
 
             # Add to appropriate category

--- a/webinterface/pages/utils/module_registry.py
+++ b/webinterface/pages/utils/module_registry.py
@@ -109,7 +109,7 @@ def get_all_modules() -> Dict[str, List[ModuleMetadata]]:
             # e.g. "github.com/Proteobot/Results_quant_ion_DDA.git" -> "Results_quant_ion_DDA"
             results_repo = None
             if hasattr(variables, "github_link_pr") and variables.github_link_pr:
-                results_repo = variables.github_link_pr.rstrip(".git").split("/")[-1]
+                results_repo = variables.github_link_pr.removesuffix(".git").split("/")[-1]
 
             # Create metadata object
             metadata = ModuleMetadata(


### PR DESCRIPTION
This pull request introduces interactive data visualizations to the home page, allowing users to explore module submission statistics and tool usage breakdowns. The main changes include new functions for fetching and visualizing submission data, enhancements to the module registry to support these features, and integration of interactive charts with dialog popups.

**Interactive submission and tool breakdown visualizations:**

* Added `build_submissions_figure` and `build_tool_pie_chart` functions in `UI_utils.py` to generate interactive bar and pie charts for module submissions and tool breakdowns. Submission data is fetched concurrently from GitHub and cached for efficiency.
* Integrated an interactive bar chart on the home page (`Home.py`) that displays submissions per module, with the ability to click on a bar to view a pie chart breakdown of tool usage in a dialog popup. [[1]](diffhunk://#diff-69607e7fa40c05946b8982aed0570f115c73a20a031a5f76d0c7a10d6748d1dbR150-R166) [[2]](diffhunk://#diff-69607e7fa40c05946b8982aed0570f115c73a20a031a5f76d0c7a10d6748d1dbR18-R23)

**Module registry enhancements:**

* Modified the `ModuleMetadata` class in `module_registry.py` to include a new `results_repo` field, which stores the associated results repository name for each module.
* Updated the `get_all_modules` function to extract the results repository name from the module's `github_link_pr` and populate the new `results_repo` field. [[1]](diffhunk://#diff-26398521bdde8297407a7c56f716f7b6723d0fe405598dc06f476fd34b74bfceR108-R113) [[2]](diffhunk://#diff-26398521bdde8297407a7c56f716f7b6723d0fe405598dc06f476fd34b74bfceR124)

**Supporting code updates:**

* Imported the new chart-building functions in `Home.py` and added missing imports in `UI_utils.py` to support the new visualizations. [[1]](diffhunk://#diff-69607e7fa40c05946b8982aed0570f115c73a20a031a5f76d0c7a10d6748d1dbR8-R9) [[2]](diffhunk://#diff-5ae93b719545ead998599971e86b587b71c4fa4ecfc524d95b2ec72cc4af8afcR8)