### PR TITLE
fix in_depth_plots de novo module

### DIFF
--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -314,9 +314,15 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
                 "N-term Ammonia-loss",
             ],
         )
-        mod_label = kwargs.get("mod_label", "M-Oxidation")
-        feature = kwargs.get("feature", "Missing Fragmentation Sites")
-        evaluation_type = kwargs.get("evaluation_type", "mass")
+        features = kwargs.get(
+            "features",
+            [
+                "Missing Fragmentation Sites",
+                "Peptide Length",
+                "% Explained Intensity"
+            ]
+        )
+        evaluation_types = kwargs.get("evaluation_type", ['mass', 'exact'])
         software_colors = kwargs.get(
             "software_colors",
             {
@@ -334,19 +340,28 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         plots["ptm_overview"] = self.plot_ptm_overview(
             performance_data, mod_labels=mod_labels, software_colors=software_colors
         )
-        plots["ptm_specific"] = self.plot_ptm_specific(
-            performance_data, mod_label=mod_label, software_colors=software_colors
-        )
+        
+        plots['ptm_specific'] = {}
+        for mod_label in mod_labels:
+            plots["ptm_specific"][mod_label] = self.plot_ptm_specific(
+                performance_data, mod_label=mod_label, software_colors=software_colors
+            )
 
         # Generate spectrum feature plot
-        plots["spectrum_feature"] = self.plot_spectrum_feature(
-            performance_data, feature=feature, evaluation_type=evaluation_type, software_colors=software_colors
-        )
+        plots['spectrum_feature'] = {}
+        for feature in features:
+            plots['spectrum_feature'][feature] = {}
+            for evaluation_type in evaluation_types:
+                plots["spectrum_feature"][feature][evaluation_type] = self.plot_spectrum_feature(
+                    performance_data, feature=feature, evaluation_type=evaluation_type, software_colors=software_colors
+                )
 
         # Generate species plot
-        plots["species_overview"] = self.plot_species_overview(
-            performance_data, evaluation_type=evaluation_type, software_colors=software_colors
-        )
+        plots["species_overview"] = {}
+        for evaluation_type in evaluation_types:
+            plots["species_overview"][evaluation_type] = self.plot_species_overview(
+                performance_data, evaluation_type=evaluation_type, software_colors=software_colors
+            )
 
         return plots
 
@@ -360,7 +375,7 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             List of plot configurations for organizing the UI display.
         """
         return [
-            {"plots": ["ptm_overview", "ptm_specific"], "columns": 2, "title": "PTM Analysis"},
+            {"plots": ["ptm_overview", "ptm_specific"], "columns": 1, "title": "PTM Analysis"},
             {"plots": ["spectrum_feature"], "columns": 1, "title": "Spectrum Features"},
             {"plots": ["species_overview"], "columns": 1, "title": "Species Analysis"},
         ]

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -333,7 +333,7 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         plots["ptm_overview"] = self.plot_ptm_overview(
             performance_data, mod_labels=mod_labels, software_colors=software_colors
         )
-        
+
         plots["ptm_specific"] = {}
         for mod_label in mod_labels:
             plots["ptm_specific"][mod_label] = self.plot_ptm_specific(

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -314,15 +314,8 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
                 "N-term Ammonia-loss",
             ],
         )
-        features = kwargs.get(
-            "features",
-            [
-                "Missing Fragmentation Sites",
-                "Peptide Length",
-                "% Explained Intensity"
-            ]
-        )
-        evaluation_types = kwargs.get("evaluation_type", ['mass', 'exact'])
+        features = kwargs.get("features", ["Missing Fragmentation Sites", "Peptide Length", "% Explained Intensity"])
+        evaluation_types = kwargs.get("evaluation_type", ["mass", "exact"])
         software_colors = kwargs.get(
             "software_colors",
             {
@@ -341,16 +334,16 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             performance_data, mod_labels=mod_labels, software_colors=software_colors
         )
         
-        plots['ptm_specific'] = {}
+        plots["ptm_specific"] = {}
         for mod_label in mod_labels:
             plots["ptm_specific"][mod_label] = self.plot_ptm_specific(
                 performance_data, mod_label=mod_label, software_colors=software_colors
             )
 
         # Generate spectrum feature plot
-        plots['spectrum_feature'] = {}
+        plots["spectrum_feature"] = {}
         for feature in features:
-            plots['spectrum_feature'][feature] = {}
+            plots["spectrum_feature"][feature] = {}
             for evaluation_type in evaluation_types:
                 plots["spectrum_feature"][feature][evaluation_type] = self.plot_spectrum_feature(
                     performance_data, feature=feature, evaluation_type=evaluation_type, software_colors=software_colors

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -228,8 +228,8 @@ class DeNovoUIObjects(BaseUIModule):
         )
 
         # Use default values for plot rendering (no user controls on this tab)
-        level = "precision"
-        evaluation_type = "exact"
+        levels = ["precision", "recall"]
+        evaluation_types = ["exact", "mass"]
         colorblind_mode = False
 
         modifications = [
@@ -263,9 +263,9 @@ class DeNovoUIObjects(BaseUIModule):
             # Create kwargs with De Novo-specific parameters (now using user selections)
             plot_kwargs = {
                 "mod_labels": modifications,
-                "feature": feature_names[0] if feature_names else "Missing Fragmentation Sites",
-                "level": level,
-                "evaluation_type": evaluation_type,
+                "feature": feature_names,
+                "level": levels,
+                "evaluation_type": evaluation_types,
                 "colorblind_mode": colorblind_mode,
             }
 
@@ -279,13 +279,17 @@ class DeNovoUIObjects(BaseUIModule):
 
                 for section in layout:
                     st.subheader(section.get("title", ""))
-                    cols = st.columns(section.get("columns", 1))
                     for idx, plot_name in enumerate(section["plots"]):
-                        with cols[idx % len(cols)]:
-                            if plot_name in plots:
-                                st.plotly_chart(plots[plot_name], use_container_width=True)
-                                if plot_name in descriptions:
-                                    st.caption(descriptions[plot_name])
+                        if plot_name in plots:
+                            if plot_name in descriptions:
+                                st.caption(descriptions[plot_name])
+                            self._display_indepth_plot(
+                                plot_name=plot_name,
+                                figs=plots[plot_name]
+                            )
+                            # st.plotly_chart(plots[plot_name], use_container_width=True)
+                                
+                                
             except Exception as e:
                 st.error(f"Error generating in-depth plots: {e}", icon="🚨")
                 import traceback
@@ -294,6 +298,93 @@ class DeNovoUIObjects(BaseUIModule):
                     st.code(traceback.format_exc())
         else:
             st.info("No datasets selected for plotting.")
+
+    def _display_ptm_overview(self, figs) -> None:
+        # Overview PTM plot
+        with st.expander("Description"):
+            st.markdown(self.variables.texts.Description.ptm_overview)
+        
+        st.plotly_chart(
+            figs,
+            use_container_width=True
+        )
+        
+    def _display_ptm_specific(self, figs) -> None:
+        # Specific PTM plots
+        with st.expander("Description"):
+            st.markdown(self.variables.texts.Description.ptm_specific)
+        
+        modification_labels = list(figs.keys())
+        tabs = st.tabs(
+            modification_labels
+        )
+        tab_dict = {
+            mod_label: tab for mod_label, tab in zip(modification_labels, tabs)
+        }
+        for mod_label, tab in tab_dict.items():
+            with tab:
+                st.header(mod_label)
+                st.plotly_chart(
+                    figs[mod_label],
+                    use_container_width=True,
+                )
+    
+    def _display_spectrum_features(self, figs) -> None:
+        feature_names = list(figs.keys())
+        exact_mode = st.toggle(
+            label='Exact evaluation mode',
+            value=False,
+            key=self.variables.evaluation_mode_toggle_tab3_features
+        )
+        if exact_mode:
+            evaluation_type = 'exact'
+        else:
+            evaluation_type = 'mass'
+        
+        with st.expander("Description"):
+            st.markdown(self.variables.texts.Description.spectrum_features_overview)
+        
+        tabs = st.tabs(feature_names)
+        tab_dict = {feature_name: tab for feature_name, tab in zip(feature_names, tabs)}
+        for feature_name, tab in tab_dict.items():
+            with tab:
+                st.header(feature_name)
+                st.plotly_chart(
+                    figs[feature_name][evaluation_type],
+                    use_container_width=True
+                )
+    
+    def _display_species_overview(self, figs) -> None:
+        with st.expander("Description"):
+            st.markdown(self.variables.texts.Description.species)
+
+        exact_mode = st.toggle(
+            label="Exact evaluation mode",
+            value=False,
+            key=self.variables.evaluation_mode_toggle_tab3_species
+        )
+        if exact_mode:
+            evaluation_type = "exact"
+        else:
+            evaluation_type = "mass"
+
+        st.plotly_chart(
+            figs[evaluation_type],
+            use_container_width=True,
+            key=self.variables.fig_species_overview
+        )
+
+    def _display_indepth_plot(self, plot_name: str, figs) -> None:
+        if plot_name == 'ptm_overview':
+            self._display_ptm_overview(figs)
+        elif plot_name == 'ptm_specific':
+            self._display_ptm_specific(figs)
+        elif plot_name == 'spectrum_feature':
+            self._display_spectrum_features(figs)
+        elif plot_name == 'species_overview':
+            self._display_species_overview(figs)
+        else:
+            raise Exception("Cannot display non-implemented in-depth plot.")
 
     @st.fragment
     def display_all_data_results_submitted(self) -> None:


### PR DESCRIPTION
Issue in 'compare results' tab:
- Description were gone
- Layout with 2 columns for ptm plots were not aligned
- Plots with multiple tabs were removed

Fixes:
- Changed the layout for the ptm-plots. They are now underneath each other.
- Reintroduced the plots with tabs
- Reintroduced the descriptions