### PR TITLE
Replace deprecated use_container_width with width='stretch'

### DIFF
--- a/webinterface/Home.py
+++ b/webinterface/Home.py
@@ -19,7 +19,7 @@ from UI_utils import (
 @st.dialog("Tool Breakdown", width="large")
 def _show_tool_breakdown(module_title, tool_counts):
     pie_fig = build_tool_pie_chart(module_title, tool_counts)
-    st.plotly_chart(pie_fig, use_container_width=True)
+    st.plotly_chart(pie_fig, width='stretch')
 
 # Path to the index.rst file
 file_path = Path(__file__).resolve().parent.parent / "docs" / "index.rst"
@@ -154,7 +154,7 @@ class StreamlitPageHome(StreamlitPage):
         if bar_fig is not None:
             event = st.plotly_chart(
                 bar_fig,
-                use_container_width=True,
+                width='stretch',
                 on_select="rerun",
                 selection_mode="points",
                 key="submissions_chart",

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -287,7 +287,7 @@ class DeNovoUIObjects(BaseUIModule):
                                 plot_name=plot_name,
                                 figs=plots[plot_name]
                             )
-                            # st.plotly_chart(plots[plot_name], use_container_width=True)
+                            # st.plotly_chart(plots[plot_name], width='stretch')
                                 
                                 
             except Exception as e:
@@ -306,7 +306,7 @@ class DeNovoUIObjects(BaseUIModule):
         
         st.plotly_chart(
             figs,
-            use_container_width=True
+            width='stretch'
         )
         
     def _display_ptm_specific(self, figs) -> None:
@@ -326,7 +326,7 @@ class DeNovoUIObjects(BaseUIModule):
                 st.header(mod_label)
                 st.plotly_chart(
                     figs[mod_label],
-                    use_container_width=True,
+                    width='stretch',
                 )
     
     def _display_spectrum_features(self, figs) -> None:
@@ -351,7 +351,7 @@ class DeNovoUIObjects(BaseUIModule):
                 st.header(feature_name)
                 st.plotly_chart(
                     figs[feature_name][evaluation_type],
-                    use_container_width=True
+                    width='stretch'
                 )
     
     def _display_species_overview(self, figs) -> None:
@@ -370,7 +370,7 @@ class DeNovoUIObjects(BaseUIModule):
 
         st.plotly_chart(
             figs[evaluation_type],
-            use_container_width=True,
+            width='stretch',
             key=self.variables.fig_species_overview
         )
 

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -241,7 +241,7 @@ def render_main_plot(plot_generator, data: pd.DataFrame, variables, plot_params:
             annotation=annotation,
             **plot_params
         )
-        st.plotly_chart(fig, use_container_width=True, key=plot_uuid)
+        st.plotly_chart(fig, width='stretch', key=plot_uuid)
     except Exception as e:
         st.error(f"Unable to plot the datapoints: {e}", icon="🚨")
         import traceback
@@ -287,10 +287,10 @@ def render_results_table(
             AgGrid(data, gridOptions=grid_options, height=400, fit_columns_on_grid_load=True)
         except ImportError:
             st.warning("AgGrid not available, falling back to dataframe", icon="⚠️")
-            st.dataframe(data, use_container_width=True, hide_index=True, column_config=column_config)
+            st.dataframe(data, width='stretch', hide_index=True, column_config=column_config)
     else:
         # Standard dataframe display
-        st.dataframe(data, use_container_width=True, hide_index=True, column_config=column_config)
+        st.dataframe(data, width='stretch', hide_index=True, column_config=column_config)
 
 
 def display_download_section(variables, sort_by: str = "id") -> None:

--- a/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
+++ b/webinterface/pages/base_pages/tabs/tab3_view_single_result.py
@@ -207,7 +207,7 @@ def display_plots_with_layout(plots: dict, plot_generator, variables, public_id:
                         st.caption(f"Data source: {public_id}")
 
                 # Display plot
-                st.plotly_chart(plots[plot_name], use_container_width=True)
+                st.plotly_chart(plots[plot_name], width='stretch')
 
         # Add separator after each section (except last)
         if section != layout_config[-1] and len(section["plots"]) > 0:

--- a/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
+++ b/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
@@ -162,9 +162,9 @@ def render_submitted_results_table(
             AgGrid(data, gridOptions=grid_options, height=400, fit_columns_on_grid_load=True)
         except ImportError:
             st.warning("AgGrid not available, falling back to dataframe", icon="⚠️")
-            st.dataframe(data, use_container_width=True, hide_index=True, column_config=column_config)
+            st.dataframe(data, width='stretch', hide_index=True, column_config=column_config)
     else:
-        st.dataframe(data, use_container_width=True, hide_index=True, column_config=column_config)
+        st.dataframe(data, width='stretch', hide_index=True, column_config=column_config)
 
     # Add download button for the results table
     random_uuid = uuid.uuid4()
@@ -227,7 +227,7 @@ def display_submitted_results(
             hide_annot=plot_params.get("hide_annot", False),
             **plot_params,
         )
-        st.plotly_chart(fig, use_container_width=True, key=plot_uuid)
+        st.plotly_chart(fig, width='stretch', key=plot_uuid)
     except Exception as e:
         st.error(f"Unable to plot the datapoints: {e}", icon="🚨")
         import traceback

--- a/webinterface/pages/base_pages/tabs/tab5_compare_results.py
+++ b/webinterface/pages/base_pages/tabs/tab5_compare_results.py
@@ -128,7 +128,7 @@ def _display_selection_plot(variables, ionmodule) -> List[str]:
     # Display plot with selection enabled
     event_dict = st.plotly_chart(
         fig_metric,
-        use_container_width=True,
+        width='stretch',
         on_select="rerun",
         selection_mode="points",
         key=st.session_state[plot_key],
@@ -363,7 +363,7 @@ def _display_precursor_overlap(
         yaxis_title="Number of Precursors",
         showlegend=True,
     )
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width='stretch')
 
     # create a merged table for download
     merged_precursors = pd.merge(
@@ -482,7 +482,7 @@ def _display_parameter_differences(
     else:
         if not show_all:
             st.markdown(f"**{len(comparison_df)} parameter(s) differ:**")
-        st.dataframe(comparison_df, use_container_width=True, hide_index=True)
+        st.dataframe(comparison_df, width='stretch', hide_index=True)
 
     # Performance metrics comparison
     st.markdown("#### Performance Metrics Comparison")
@@ -520,7 +520,7 @@ def _display_metrics_comparison(
 
     if metrics_comparison:
         metrics_df = pd.DataFrame(metrics_comparison)
-        st.dataframe(metrics_df, use_container_width=True, hide_index=True)
+        st.dataframe(metrics_df, width='stretch', hide_index=True)
     else:
         st.info("Metrics data not available for comparison.")
 


### PR DESCRIPTION
Replaces all `use_container_width=True` with `width='stretch'` across the webinterface as required by Streamlit (deprecated after 2025-12-31).

https://claude.ai/code/session_01PURbHEtd91ZsGrQ6tPLSmu