### PR TITLE
Handle NaNs in Proteins column

### DIFF
--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -330,9 +330,17 @@ def _load_maxquant(input_csv: str) -> pd.DataFrame:
         The loaded dataframe.
     """
     data = pd.read_csv(input_csv, sep="\t", low_memory=False)
+    # If Proteins is NaN for some entries, fill with "Leading proteins" column if it exists (TODO: Why are some entries Nan and then leading proteins not?)
+    if "Proteins" in data.columns and "Leading proteins" in data.columns:
+        data["Proteins"] = data.apply(
+            lambda row: row["Leading proteins"] if pd.isna(row["Proteins"]) else row["Proteins"], axis=1
+        )
+    # If NaN remain, remove those rows because they cannot be used for precursor ion benchmarking:
+    if "Proteins" in data.columns:
+        data = data.dropna(subset=["Proteins"])
     # Check if Proteins column contains species information
     if "Proteins" in data.columns and not any(
-        data["Proteins"].str.contains("|", regex=False)
+        data["Proteins"].str.contains("|", regex=False, na=False)
     ):  # Not sure if this is best way to check for species information, problems is that we do not want to hardcode species names.
         # Map gene names to descriptions using the mapper.csv file
         mapper_path = os.path.join(os.path.dirname(__file__), "io_parse_settings/mapper.csv")

--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -333,7 +333,7 @@ def _load_maxquant(input_csv: str) -> pd.DataFrame:
     # If Proteins is NaN for some entries, fill with "Leading proteins" column if it exists (TODO: Why are some entries Nan and then leading proteins not?)
     if "Proteins" in data.columns and "Leading proteins" in data.columns:
         data["Proteins"] = data["Proteins"].fillna(data["Leading proteins"])
-    # If NaN remain, remove those rows because they cannot be used for precursor ion benchmarking:
+    # If NaN remain, remove those rows because they cannot be used for benchmarking:
     if "Proteins" in data.columns:
         data = data.dropna(subset=["Proteins"])
     # Check if Proteins column contains species information

--- a/proteobench/io/parsing/parse_ion.py
+++ b/proteobench/io/parsing/parse_ion.py
@@ -332,9 +332,7 @@ def _load_maxquant(input_csv: str) -> pd.DataFrame:
     data = pd.read_csv(input_csv, sep="\t", low_memory=False)
     # If Proteins is NaN for some entries, fill with "Leading proteins" column if it exists (TODO: Why are some entries Nan and then leading proteins not?)
     if "Proteins" in data.columns and "Leading proteins" in data.columns:
-        data["Proteins"] = data.apply(
-            lambda row: row["Leading proteins"] if pd.isna(row["Proteins"]) else row["Proteins"], axis=1
-        )
+        data["Proteins"] = data["Proteins"].fillna(data["Leading proteins"])
     # If NaN remain, remove those rows because they cannot be used for precursor ion benchmarking:
     if "Proteins" in data.columns:
         data = data.dropna(subset=["Proteins"])

--- a/proteobench/score/quantscoresHYE.py
+++ b/proteobench/score/quantscoresHYE.py
@@ -212,7 +212,6 @@ class QuantScoresHYE(ScoreBase):
         """
         # for all columns named parse_settings.species_dict.values() compute the sum over the rows and add it to a new column "unique"
         withspecies["unique"] = withspecies[species_expected_ratio.keys()].sum(axis=1)
-
         # now remove all rows with withspecies["unique"] > 1
         withspecies_unique = withspecies[withspecies["unique"] == 1].copy()
         # for species in parse_settings.species_dict.values(), set all values in new column "species" to species if withe species is True
@@ -221,9 +220,7 @@ class QuantScoresHYE(ScoreBase):
             withspecies_unique.loc[withspecies_unique[species] == True, "log2_expectedRatio"] = np.log2(
                 species_expected_ratio[species]["A_vs_B"]
             )
-
         withspecies_unique["epsilon"] = withspecies_unique["log2_A_vs_B"] - withspecies_unique["log2_expectedRatio"]
-
         # Compute per-species empirical centers for precision metrics
         withspecies_unique["log2_empirical_median"] = withspecies_unique.groupby("species")["log2_A_vs_B"].transform(
             "median"
@@ -239,5 +236,4 @@ class QuantScoresHYE(ScoreBase):
         withspecies_unique["epsilon_precision_mean"] = (
             withspecies_unique["log2_A_vs_B"] - withspecies_unique["log2_empirical_mean"]
         )
-
         return withspecies_unique


### PR DESCRIPTION
This pull request introduces improvements to data handling in the MaxQuant parser and minor cleanup in the computation of epsilon scores. The main updates enhance robustness when dealing with missing protein information and tidy up code formatting.

**MaxQuant parser improvements:**

* In `_load_maxquant` (`proteobench/io/parsing/parse_ion.py`): If the `Proteins` column contains NaN values, they are filled using the `Leading proteins` column when available. Remaining rows with NaN in `Proteins` are dropped to ensure data integrity for downstream analysis. The `str.contains` check is also updated to handle NaN values safely