### PR TITLE
resize plasma points

### DIFF
--- a/docs/available-modules/active-modules/10-quant-lfq-ion-dia-ZenoTOF.md
+++ b/docs/available-modules/active-modules/10-quant-lfq-ion-dia-ZenoTOF.md
@@ -22,7 +22,9 @@ Peptide separations were done using an IonOpticks Aurora® XS Ultimate column (2
 An OptiFlow Pro Nano ion source was used with a NanoCal probe (<1 µL electrode), with source parameters as following: GS1: 10 psi, Nano cel temperature: 250 °C and Nano spray voltage: 2500V.
 
 The 15-min Zeno SWATH DIA experiments used 85 variable windows spanning the TOF MS mass range 400-900 Da and MS/MS mass range 140-1750 Da, with Zeno trap pulsing turned on, with MS/MS accumulation times of 16 ms. Before each Zeno SWATH MS DIA cycle an additional MS1 survey scan from 400-1500 Da was recorded for 50 ms.
-The files have been uploaded to the ProteomeXchange repository, with PXD accession number (PXD070049). Since the corresponding manuscript is still under review, the data can be accessed as following: Log in to the PRIDE website using the following details: Project accession: PXD070049 - Token: hcXc5dENPPrf. Alternatively, reviewer can access the dataset by logging in to the PRIDE website using the following account details: Username: reviewer_pxd070049@ebi.ac.uk - Password: LF0Bpyt0gt1g
+The files have been uploaded to the ProteomeXchange repository, with PXD accession number (PXD070049). 
+
+All files can be downloaded here [proteobench.cubimed.rub.de/raws/DIA-ZenoSWATH/](https://proteobench.cubimed.rub.de/raws/DIA-ZenoSWATH/)
 
 **It is imperative not to rename the files once downloaded!**
 

--- a/proteobench/plotting/plot_generator_lfq_PYE.py
+++ b/proteobench/plotting/plot_generator_lfq_PYE.py
@@ -853,6 +853,20 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
         # Human plasma metrics don't have mode variants (single species)
         opacity_metric_key = f"{metric_lower}_abs_epsilon_human_plasma"
 
+        # Pre-pass: collect raw dynamic-range values for data-driven size normalization.
+        # This ensures the full [8, 40] marker-size range is used regardless of where
+        # values cluster, maximising visual separation for small differences.
+        raw_size_vals = []
+        for _, row in result_df.iterrows():
+            m = self._get_metrics_at_cutoff(row.get("results"), default_cutoff_min_prec)
+            if m is not None:
+                sv = m.get("dynamic_range_human_plasma_mean", 0.0)
+                if sv > 0:
+                    raw_size_vals.append(sv)
+        size_min = min(raw_size_vals) if raw_size_vals else 0.0
+        size_max = max(raw_size_vals) if raw_size_vals else 1.0
+        size_data_range = size_max - size_min if size_max > size_min else 1.0
+
         # Create scatter plot with all four visual dimensions
         # Group by software to create separate traces (allows colorblind markers)
         software_data = {}
@@ -885,12 +899,13 @@ class LFQPYEPlotGenerator(PlotGeneratorBase):
             software_data[software]["x"].append(x_val)
             software_data[software]["y"].append(y_val)
 
-            # Size scaling: normalize dynamic range to reasonable marker sizes (5-30)
+            # Size scaling: min-max normalise across the loaded data so the full
+            # [8, 40] range is always used, making even small differences visible.
             if size_val > 0:
-                normalized_size = 5 + (size_val / 3) * 25
+                normalized_size = 8 + ((size_val - size_min) / size_data_range) * 10
             else:
                 normalized_size = 8
-            software_data[software]["sizes"].append(min(normalized_size, 30))
+            software_data[software]["sizes"].append(normalized_size)
 
             # Opacity: lower error = higher opacity (higher alpha)
             opacity = max(0.2, 0.9 - (opacity_val * 0.7))

--- a/webinterface/pages/base_pages/tabs/tab2_upload_results.py
+++ b/webinterface/pages/base_pages/tabs/tab2_upload_results.py
@@ -315,6 +315,9 @@ def set_highlight_column_in_submitted_data(variables) -> None:
     elif "Highlight" in df.columns:
         # Not sure how 'Highlight' column became object dtype
         df["Highlight"] = df["Highlight"].astype(bool).fillna(False)
+    # Mark newly submitted data points so they appear in highlight_color in Tab 4
+    if "old_new" in df.columns:
+        df.loc[df["old_new"] == "new", "Highlight"] = True
     # only needed for last elif, but to be sure apply always:
     st.session_state[variables.all_datapoints_submitted] = df
 


### PR DESCRIPTION
This pull request improves the clarity and usability of plasma scatterplots and enhances the user experience when highlighting newly submitted data. The most significant changes are grouped below:

**Plotting improvements in plasma scatterplots:**

* Marker sizes in the `_plot_plasma_scatterplot` function are now normalized using a data-driven min-max approach, ensuring the full `[8, 40]` marker-size range is utilized regardless of data clustering. This maximizes visual separation and makes even small differences in dynamic range more apparent.
* The marker size scaling formula has been updated to use the new normalization, and the arbitrary cap on marker size has been removed, allowing for better differentiation.

**Highlighting newly submitted data:**

* In the `set_highlight_column_in_submitted_data` function, data points marked as "new" in the `old_new` column are now automatically set to be highlighted, ensuring they appear in a distinct color in the UI.