### PR TITLE
add open source info in table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,9 @@ Old datapoints have `{metric}_abs_epsilon` without mode suffix. New datapoints h
 
 Each software tool + module combination has a TOML file in `proteobench/io/parsing/io_parse_settings/Quant/lfq/<DDA|DIA>/<ion|peptidoform>/<instrument>/`. The master mapping is in `io_parse_settings/parse_settings_files.toml` (maps module_id sections to TOML filenames). Each directory also has a `module_settings.toml`.
 
+`io_parse_settings/tool_metadata.toml` is a platform-wide metadata file. Currently it contains one section:
+- `[open_source].tools`: list of tool names whose source code is publicly available. Used by `get_open_source_tools()` in `parse_settings.py` to populate the `open_source` (✅) column in the Benchmark Results table. Names must match the `software_name` values set in `io/params/*.py`.
+
 **Software-specific TOML structure:**
 - `[mapper]`: column renames (e.g., `"Sequence" = "Sequence"`)
 - `[condition_mapper]`: raw file name -> condition ("A"/"B"). Keys are normalized at init via `_clean_run_name()` — extensions like `.mzML`, `.raw` are stripped automatically.
@@ -234,7 +237,7 @@ Streamlit multi-page app. Entry point: `Home.py` (inherits from `StreamlitPage` 
 **UI utilities** in `webinterface/pages/base_pages/utils/`:
 - `inputs.py`: `generate_input_widget()` — dynamic form field factory from JSON config (5 widget types: text_input, text_area, number_input, selectbox, checkbox)
 - `metricplot.py`: `render_metric_plot()` — interactive Plotly scatter with click-to-select (extracts ProteoBench ID from hovertext)
-- `resulttable.py`: `render_aggrid()` — ag-grid table with column-level color coding
+- `resulttable.py`: `render_aggrid()` — ag-grid table with column-level color coding; `add_open_source_column()` — inserts an `open_source` (✅) column after `software_name` for tools listed in `tool_metadata.toml`; `OPEN_SOURCE_TOOLS` — lowercase set loaded at import time via `get_open_source_tools()`
 - `general.py`: `clean_dataframe_for_export()` — CSV export cleanup
 
 **Session state management:** All keys defined in `pages_variables/` dataclasses with module-specific prefixes (e.g., `"lfq_ion_dda_quant"`, `"_dia_quant"`). Categories: data DataFrames, UI element UUIDs, form parameters, metadata.
@@ -340,9 +343,10 @@ Separate workflow for webinterface:
 3. Add an `extract_params` function in `io/params/newtool.py`
 4. Register it in `QuantModule.EXTRACT_PARAMS_DICT` in `modules/quant/quant_base_module.py`
 5. Add a color entry in `LFQHYEPlotGenerator.plot_main_metric()` `software_colors` dict
-6. Add test data file to `test/data/quant/<module>/` and parameter files to `test/params/`
-7. Add the tool to test parametrization in the relevant `test_module_quant_*.py`
-8. Run `cd docs && python parse_tables.py` to update parameter documentation
+6. If the tool is open source, add its `software_name` to the `[open_source].tools` list in `io/parsing/io_parse_settings/tool_metadata.toml`
+7. Add test data file to `test/data/quant/<module>/` and parameter files to `test/params/`
+8. Add the tool to test parametrization in the relevant `test_module_quant_*.py`
+9. Run `cd docs && python parse_tables.py` to update parameter documentation
 
 ### Adding a new benchmark module
 

--- a/docs/developer-guide/adding-module.rst
+++ b/docs/developer-guide/adding-module.rst
@@ -56,8 +56,9 @@ The backend is organized into six main components that you can extend or customi
    - :file:`proteobench/io/parsing/parse_settings.py` handles format conversion
    - Settings defined in TOML files in :file:`proteobench/io/parsing/io_parse_settings/`
    - For new software tools, extend :func:`~proteobench.io.parsing.parse_ion.load_input_file`
-   - If the new tool is open source, add its ``software_name`` to the ``[open_source].tools``
-     list in :file:`proteobench/io/parsing/io_parse_settings/tool_metadata.toml` so it is
+   - If the new tool is :ref:`open source <open-source-software>`, add its ``software_name``
+     to the ``[open_source].tools`` list in
+     :file:`proteobench/io/parsing/io_parse_settings/tool_metadata.toml` so it is
      marked with ✅ in the Benchmark Results table
 
 **3. Score calculation** - Compute benchmarking metrics

--- a/docs/developer-guide/adding-module.rst
+++ b/docs/developer-guide/adding-module.rst
@@ -56,6 +56,9 @@ The backend is organized into six main components that you can extend or customi
    - :file:`proteobench/io/parsing/parse_settings.py` handles format conversion
    - Settings defined in TOML files in :file:`proteobench/io/parsing/io_parse_settings/`
    - For new software tools, extend :func:`~proteobench.io.parsing.parse_ion.load_input_file`
+   - If the new tool is open source, add its ``software_name`` to the ``[open_source].tools``
+     list in :file:`proteobench/io/parsing/io_parse_settings/tool_metadata.toml` so it is
+     marked with ✅ in the Benchmark Results table
 
 **3. Score calculation** - Compute benchmarking metrics
    - Base class: :class:`~proteobench.score.score_base.ScoreBase` (ABC)

--- a/docs/general-information/1-glossary.md
+++ b/docs/general-information/1-glossary.md
@@ -6,14 +6,24 @@ Here are the terms specific to ProteoBench:
 ## Benchmark module
 A benchmark module compares the performance of different data analysis workflows based on module-specific, predefined metrics. It provides a specific set of input files (e.g., mass spectrometry files and a sequence database) and it requires specific workflow output files (e.g., identified peptides). Based on these workflow output files, metrics are calculated as defined by the module and can be compared to previously validated benchmark runs. As each benchmark module defines specific workflow input files and metrics, it evaluates only a limited set of characteristics of the data analysis workflow.
 
+## Benchmark run
+The result of running a workflow with specific parameter values and calculating the benchmark metrics based on the workflow output. 
+
+### Validated benchmark run
+A benchmark run accepted by the ProteoBench team to be made publicly available as part of the ProteoBench repository. For validation, the submission must include the workflow output files, structured metadata, unstructured metadata, and (if applicable) workflow configuration files. The workflow metadata must include all information needed to fully understand and re-execute the workflow; i.e., the benchmark run must be fully reproducible. 
+
 ## Metric
 A single number resulting from an aggregated calculation of the workflow output which allows for a comparison between different benchmark runs.
+
+(open-source-software)=
+## Open source software
+We consider a tool open source if the code is available in its latest version, we consider the tool open source, whatever the licence.
 
 ## Workflow
 A combination of data analysis tools with associated parameters that takes workflow input files (provided by a benchmark module) and generates workflow output files. Based on the workflow output files, metrics can be calculated describing the workflow performance.
 
-## Benchmark run
-The result of running a workflow with specific parameter values and calculating the benchmark metrics based on the workflow output. 
+## Workflow configuration files
+Files that contain parameters for a workflow or for a data analysis tool within a workflow. These files can be specific to the workflow or to the data analysis tool and help to re-execute it with the same parameters (e.g., mqpar.xml).
 
 ## Workflow metadata
 A set of parameter values (e.g., missed cleavages, mass tolerance), workflow properties (e.g., software name, software version), and workflow configuration files that include all information required to fully understand and re-execute a given workflow. This should include the workflow options, as well as a detailed description of the click sequence and/or potential supplemental parameters unique to the workflow.
@@ -24,8 +34,3 @@ A fixed set of metadata to be provided through a form with every benchmark run t
 ### Unstructured workflow metadata
 Additional metadata that is specific to a workflow and can therefore not be presented in a structured submission form and requires a free-form text field instead. The metadata does not need to be written as full text, but should be fully comprehensible.
 
-## Workflow configuration files
-Files that contain parameters for a workflow or for a data analysis tool within a workflow. These files can be specific to the workflow or to the data analysis tool and help to re-execute it with the same parameters (e.g., mqpar.xml).
-
-## Validated benchmark run
-A benchmark run accepted by the ProteoBench team to be made publicly available as part of the ProteoBench repository. For validation, the submission must include the workflow output files, structured metadata, unstructured metadata, and (if applicable) workflow configuration files. The workflow metadata must include all information needed to fully understand and re-execute the workflow; i.e., the benchmark run must be fully reproducible. 

--- a/proteobench/io/parsing/io_parse_settings/tool_metadata.toml
+++ b/proteobench/io/parsing/io_parse_settings/tool_metadata.toml
@@ -1,0 +1,20 @@
+# Tool metadata for ProteoBench
+# Centralised classification of tools used across the platform.
+
+[open_source]
+# Software tools whose source code is publicly available.
+# Names must match the 'software_name' values set in proteobench/io/params/*.py
+tools = [
+    "AdaNovo",
+    "AlphaDIA",
+    "AlphaPept",
+    "Casanovo",
+    "DeepNovo",
+    "i2MassChroQ",
+    "InstaNovo",
+    "MetaMorpheus",
+    "Pi-HelixNovo",
+    "Pi-PrimeNovo",
+    "PointNovo",
+    "Sage",
+]

--- a/proteobench/io/parsing/io_parse_settings/tool_metadata.toml
+++ b/proteobench/io/parsing/io_parse_settings/tool_metadata.toml
@@ -17,4 +17,5 @@ tools = [
     "Pi-PrimeNovo",
     "PointNovo",
     "Sage",
+    "ProlineStudio",
 ]

--- a/proteobench/io/parsing/parse_settings.py
+++ b/proteobench/io/parsing/parse_settings.py
@@ -31,6 +31,18 @@ GROUND_TRUTH_DIR_LOCAL_DENOVO = os.path.join(
 GROUND_TRUTH_FILENAME = "De_Novo_module_ground_truth.csv.gz"
 GROUND_TRUTH_URL = "https://proteobench.cubimed.rub.de/datasets/module_data/De_Novo_module_ground_truth.csv.gz"
 
+_TOOL_METADATA_PATH = os.path.join(
+    Path(__file__).resolve().parent,
+    "io_parse_settings",
+    "tool_metadata.toml",
+)
+
+
+def get_open_source_tools() -> set:
+    """Return the set of open-source tool names (lower-cased) from tool_metadata.toml."""
+    metadata = toml.load(_TOOL_METADATA_PATH)
+    return {name.lower() for name in metadata.get("open_source", {}).get("tools", [])}
+
 
 class ParseSettingsBuilder:
     """

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -12,6 +12,8 @@ from typing import Any, Callable, Dict, Optional
 import pandas as pd
 import streamlit as st
 
+from ..utils.resulttable import add_open_source_column
+
 
 def initialize_uuid_state(key: str, default_value: Any = None) -> None:
     """
@@ -268,6 +270,8 @@ def render_results_table(
     if len(data) == 0:
         st.info("No datapoints available to display.", icon="ℹ️")
         return
+
+    data = add_open_source_column(data)
 
     st.subheader("Benchmark Results")
 

--- a/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
+++ b/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
@@ -13,6 +13,7 @@ import streamlit as st
 import streamlit_utils
 
 from ..utils.general import clean_dataframe_for_export
+from ..utils.resulttable import add_open_source_column
 
 
 def initialize_uuid_state(key: str, default_value: Any = None) -> None:
@@ -144,6 +145,8 @@ def render_submitted_results_table(
     if len(data) == 0:
         st.info("No submitted datapoints available to display.", icon="ℹ️")
         return
+
+    data = add_open_source_column(data)
 
     st.subheader("Submitted Benchmark Results")
 

--- a/webinterface/pages/base_pages/utils/resulttable.py
+++ b/webinterface/pages/base_pages/utils/resulttable.py
@@ -1,7 +1,41 @@
 import pandas as pd
-from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
+
+from proteobench.io.parsing.parse_settings import get_open_source_tools
 
 # this file contains utility functions for rendering the result table in tab1_results and tab4_display_results_submitted
+
+# === Open Source Tools ===
+# Loaded from proteobench/io/parsing/io_parse_settings/tool_metadata.toml
+OPEN_SOURCE_TOOLS = get_open_source_tools()
+
+
+def add_open_source_column(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add an 'open_source' column indicating whether the software is open source.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing a 'software_name' column.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of the DataFrame with an 'open_source' column inserted after 'software_name'.
+        Open source tools are marked with '✅', others with an empty string.
+    """
+    if "software_name" not in df.columns:
+        return df
+    df = df.copy()
+    df["open_source"] = df["software_name"].apply(
+        lambda x: "✅" if str(x).lower() in OPEN_SOURCE_TOOLS else ""
+    )
+    cols = df.columns.tolist()
+    cols.remove("open_source")
+    idx = cols.index("software_name") + 1
+    cols.insert(idx, "open_source")
+    return df[cols]
+
 
 # === Table Color Constants ===
 COLOR_IDENTIFIER = "#F0F2F6"
@@ -11,7 +45,7 @@ COLOR_TECHNICAL = "#FFFFFF"
 COLOR_ADDITIONAL = "#F0F2F6"
 
 
-def _get_style_js(bg_color: str) -> JsCode:
+def _get_style_js(bg_color: str):
     """
     Generates JavaScript for styling cells with a background color.
 
@@ -25,6 +59,8 @@ def _get_style_js(bg_color: str) -> JsCode:
     JsCode
         A JavaScript code block that defines the style.
     """
+    from st_aggrid import JsCode
+
     return JsCode(
         f"""
     function(params) {{
@@ -69,6 +105,8 @@ def render_aggrid(df: pd.DataFrame, grid_options, key):
     max_height = 800
     dynamic_height = max(min_height, min(calculated_height, max_height))
 
+    from st_aggrid import AgGrid
+
     AgGrid(
         df,
         gridOptions=grid_options,
@@ -94,6 +132,8 @@ def configure_aggrid(df: pd.DataFrame):
     dict
         AgGrid gridOptions dictionary.
     """
+    from st_aggrid import GridOptionsBuilder
+
     gb = GridOptionsBuilder.from_dataframe(df)
     identifier_cols = ["selected", "id"]
     parameter_cols = [


### PR DESCRIPTION
I stored the information of what tools are open source in `proteobench/io/parsing/io_parse_settings/tool_metadata.toml`
I still have to add our definition of open source in the documentation.