### PR TITLE
quick fix of the generic_texts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,6 @@ repos:
       - id: check-contributing-institutes-symlink
         name: check contributing-institutes logo is a symlink to docs/_static/img/
         language: script
-        entry: bash scripts/check_contributing_institutes_symlink.sh
+        entry: scripts/check_contributing_institutes_symlink.sh
         pass_filenames: false
         always_run: true

--- a/webinterface/pages/11_Quant_LFQ_DIA_ion_Plasma.py
+++ b/webinterface/pages/11_Quant_LFQ_DIA_ion_Plasma.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Type
 
 import pages.texts.proteobench_builder as pbb
 import streamlit as st
+from pages.base_pages.banner import display_banner
 from pages.base_pages.quant import QuantUIObjects
 from pages.pages_variables.Quant.lfq_DIA_ion_Plasma_variables import (
     VariablesDIAQuantPlasma,
@@ -53,7 +54,7 @@ class StreamlitUI:
         self._main_page()
 
     def _render_header(self) -> None:
-        """Render the shared title, documentation link, download link, and beta warning."""
+        """Render the shared title, documentation link, download link, and status warning banner."""
         st.title(self.variables_dia_quant.title)
         doc_col, download_col = st.columns(2)
         with doc_col:
@@ -72,10 +73,7 @@ class StreamlitUI:
                 icon="⬇️",
                 help="Download the raw input files used to benchmark this module",
             )
-        if self.variables_dia_quant.beta_warning:
-            st.warning(
-                "This module is in BETA phase. The figure presented below and the metrics calculation may change in the near future."
-            )
+        display_banner(self.variables_dia_quant)
 
     def _main_page(self) -> None:
         """

--- a/webinterface/pages/texts/generic_texts.py
+++ b/webinterface/pages/texts/generic_texts.py
@@ -55,8 +55,8 @@ class WebpageTexts:
             for more details.
             """
 
-        warning_alpha = """This module is in ALPHA phase. It has not yet passed peer review 
-            and should be used with caution.
+        warning_alpha = """This module is in ALPHA phase. It  remains to be fully discussed 
+            with experts and should be used with caution.
             """
 
         warning_beta = """This module is in BETA phase. The figure presented below and 

--- a/webinterface/pages/texts/generic_texts_denovo.py
+++ b/webinterface/pages/texts/generic_texts_denovo.py
@@ -55,8 +55,8 @@ class WebpageTexts:
             for more details.
             """
 
-        warning_alpha = """This module is in ALPHA phase. It has not yet passed peer review 
-            and should be used with caution.
+        warning_alpha = """This module is in ALPHA phase. It  remains to be fully discussed 
+            with experts and should be used with caution.
             """
 
         warning_beta = """This module is in BETA phase. The figure presented below and 
@@ -154,6 +154,8 @@ class WebpageTexts:
         """
 
     class Description:
+        """Descriptions for de novo in-depth plots and evaluation views."""
+
         ptm_overview = """
         This plot shows the **precision of predicted post-translational modifications (PTMs)** for each de novo sequencing tool. Each point represents a modification present in the dataset with its precision on the Y-axis.
 

--- a/webinterface/pages/texts/generic_texts_dia.py
+++ b/webinterface/pages/texts/generic_texts_dia.py
@@ -54,8 +54,8 @@ class WebpageTexts:
             for more details.
             """
 
-        warning_alpha = """This module is in ALPHA phase. It has not yet passed peer review 
-            and should be used with caution.
+        warning_alpha = """This module is in ALPHA phase. It  remains to be fully discussed 
+            with experts and should be used with caution.
             """
 
         warning_beta = """This module is in BETA phase. The figure presented below and 


### PR DESCRIPTION
This was just to align the alpha banner with what is in its documentation description (avoid "peer review").
Questions:

- I wonder why there are specific generic_texts_dia and generic_texts_denovo?
- The banner is missing in the plasma module (@rodvrees)

‼️ I am not sure about the change to ".pre-commit-config.yaml". 
