### PR TITLE
Denovo module updates

### DIFF
--- a/docs/available-modules/active-modules/11-denovo-dda-hcd.md
+++ b/docs/available-modules/active-modules/11-denovo-dda-hcd.md
@@ -44,32 +44,35 @@ We recommend downloading the parsed and combined dataset from the ProteoBench se
 
 ## Metric calculation
 
-The performance is evaluated at both the amino acid and peptide level. As introduced by [DeepNovo](https://www.pnas.org/doi/10.1073/pnas.1705691114), a correct amino acid whose mass differs by less than 0.1 Da from the corresponding ground truth amino acid. Additionally, this predicted amino acid must have either a prefix or suffix that differs by no more than 0.5 Da in mass from the corresponding amino acid sequence in the ground truth peptide. Correct peptides are defined as sequences where all amino acid predictions meet these criteria, ensuring that only fully accurate predictions are considered correct at the peptide level. In the module, this mode of evaluation is called '**mass-based**'. However, a more strict evaluation mode can be selected and is termed '**exact mode**'. In this mode, the two sequences should be exactly the same, where also cases such as deamidated-Q and E are considered incorrect. Only isoleucine and leucine substitutions are allowed.
+The performance is evaluated at both the amino acid and peptide level. As introduced by [DeepNovo](https://www.pnas.org/doi/10.1073/pnas.1705691114), a correct amino acid whose mass differs by less than 0.1 Da from the corresponding ground truth amino acid. Additionally, this predicted amino acid must have either a prefix or suffix that differs by no more than 0.5 Da in mass from the corresponding amino acid sequence in the ground truth peptide. Correct peptides are defined as sequences where all amino acid predictions meet these criteria, ensuring that only fully accurate predictions are considered correct at the peptide level. In the module, this mode of evaluation is called '**mass-based**'. However, a more strict evaluation mode can be selected and is termed '**exact mode**'. In this mode, the two sequences should be exactly the same. However, you can specify to allow mistakes made between isoleucine-leucine and deamidated-DE - NQ.
 
 ### Main benchmarking plot
 
 The main accuracy plot provides a **global overview of de novo sequencing performance** across the evaluated tools. It visualizes the relationship between **peptide-level identification performance** and **amino-acid level sequence accuracy**. Each point in the plot corresponds to a de novo sequencing tool and shows the amino acid and peptide level accuracy. The plot combines two levels of evaluation:
 
 **X-axis – Peptide-level metric**  
-The x-axis displays either peptide-level **precision** or **recall**, depending on the selected setting.
+The x-axis displays either peptide-level **precision** or **AUC**, depending on the selected setting.
 
 **Y-axis – Amino-acid level metric**  
 The y-axis always shows the corresponding **amino-acid level metric**, measuring how accurately the individual residues in the predicted sequences match the ground truth.
 
 This design allows the plot to simultaneously capture both **identification reliability** and **sequence-level correctness**.
 
-The **Precision vs Recall** setting determines which peptide-level metric is shown on the x-axis.
+The **Precision vs AUC** setting determines which peptide-level metric is shown on the x-axis.
 Precision measures how many reported peptide predictions are correct:
 
     Precision = correct predictions ÷ predictions above threshold
 
 This view emphasizes the **reliability of reported identifications**. Tools that achieve high precision produce predictions that are more likely to be correct.
 
-Recall measures how many spectra were successfully identified:
+AUC is the **area under the precision-coverage curve**. This curve is constructed by ranking a tool's predictions by their reported confidence score and, at each score threshold, computing:
 
-    Recall = correct predictions ÷ total number of spectra
+    Coverage = (correct + incorrect) ÷ total spectra
+    Precision = correct ÷ (correct + incorrect)
 
-This view emphasizes the **coverage of the dataset**, indicating how many spectra a tool can successfully sequence.
+As the threshold is relaxed from the highest-confidence prediction to the lowest, coverage increases monotonically from 0 to 1, while precision typically decreases as lower-confidence predictions are included. AUC condenses this trade-off into a single value between 0 and 1: a tool that keeps precision high even as coverage approaches 1 will have an AUC close to 1, while a tool whose precision drops sharply as more predictions are included will have a lower AUC.
+
+This view emphasizes **overall sequencing performance across the full range of a tool's confidence in its predictions**, rather than reliability at a single, fixed threshold.
 
 The **evaluation mode** determines how predictions are classified as correct.
 

--- a/docs/available-modules/active-modules/11-denovo-dda-hcd.md
+++ b/docs/available-modules/active-modules/11-denovo-dda-hcd.md
@@ -44,7 +44,7 @@ We recommend downloading the parsed and combined dataset from the ProteoBench se
 
 ## Metric calculation
 
-The performance is evaluated at both the amino acid and peptide level. As introduced by [DeepNovo](https://www.pnas.org/doi/10.1073/pnas.1705691114), a correct amino acid whose mass differs by less than 0.1 Da from the corresponding ground truth amino acid. Additionally, this predicted amino acid must have either a prefix or suffix that differs by no more than 0.5 Da in mass from the corresponding amino acid sequence in the ground truth peptide. Correct peptides are defined as sequences where all amino acid predictions meet these criteria, ensuring that only fully accurate predictions are considered correct at the peptide level. In the module, this mode of evaluation is called '**mass-based**'. However, a more strict evaluation mode can be selected and is termed '**exact mode**'. In this mode, the two sequences should be exactly the same. However, you can specify to allow mistakes made between isoleucine-leucine and deamidated-DE - NQ.
+The performance is evaluated at both the amino acid and peptide level. As introduced by [DeepNovo](https://www.pnas.org/doi/10.1073/pnas.1705691114), a correct amino acid whose mass differs by less than 0.1 Da from the corresponding ground truth amino acid. Additionally, this predicted amino acid must have either a prefix or suffix that differs by no more than 0.5 Da in mass from the corresponding amino acid sequence in the ground truth peptide. Correct peptides are defined as sequences where all amino acid predictions meet these criteria, ensuring that only fully accurate predictions are considered correct at the peptide level. In the module, this mode of evaluation is called '**mass-based**', where the tolerances for the particular token and prefix/suffix are set at 20 and 50 ppm respectively. However, a more strict evaluation mode can be selected and is termed '**exact mode**'. In this mode, the two sequences should be exactly the same. However, you can specify to allow mistakes made between isoleucine-leucine and deamidated-DE - NQ.
 
 ### Main benchmarking plot
 
@@ -76,13 +76,30 @@ This view emphasizes **overall sequencing performance across the full range of a
 
 The **evaluation mode** determines how predictions are classified as correct.
 
-In **exact** evaluation mode, a prediction is considered correct only if the predicted peptide sequence **exactly matches the ground-truth sequence**, including both amino acids and modifications. This represents the **strictest accuracy definition**. In **mass-based** evaluation mode, predictions are considered correct when they match the ground-truth sequence based on **cumulative fragment masses**, even if the exact amino-acid sequence differs.
+In **exact** evaluation mode, a prediction is considered correct only if the predicted peptide sequence **exactly matches the ground-truth sequence**, including both amino acids and modifications. This represents the **strictest accuracy definition**. This exact matching can be relaxed by allowing 2 specific ambiguities: Isoleucine-leucine ambiguity and deamidated-DE - NQ ambiguity. In **mass-based** evaluation mode, predictions are considered correct when they match the ground-truth sequence based on **cumulative fragment masses**, even if the exact amino-acid sequence differs.
 The algorithm identifies the longest **mass-matching prefix and suffix** between the predicted and reference peptide sequences. Two mass tolerances are used during this process:
 
 - **Cumulative mass threshold** – maximum allowed difference between cumulative fragment masses (50 ppm)  
 - **Individual mass threshold** – maximum allowed difference between individual amino-acid masses (20 ppm)
 
-This evaluation accounts for typical ambiguities in mass spectrometry data. Match-based evaluation therefore counts both **exact matches and mass-equivalent matches**, while exact evaluation only counts **perfect sequence matches**.
+This evaluation accounts for typical ambiguities in mass spectrometry data. Match-based evaluation therefore counts both **exact matches and mass-equivalent matches**, while exact evaluation only counts **perfect sequence matches** (while optionally allowing two specific commonly occuring ambiguities).
+
+
+#### Precision-coverage curves
+
+The main benchmarking view described above plots a single, threshold-independent summary per tool: precision (at every reported prediction) or AUC (integrated across every possible threshold). A second view, selectable via a **Scatter / Precision-Coverage Curves** tab switcher above the plot, shows the full curve that the AUC value is derived from, so you can inspect *how* a tool's precision degrades as more of its lower-confidence predictions are included, rather than only its integrated summary.
+
+This view shows two side-by-side plots — peptide-level and amino-acid level — with one line per tool. Each curve is built by ranking a tool's predictions by their reported confidence score (from highest to lowest) and, after including each successive prediction, recomputing:
+
+    Coverage = number of predictions included ÷ total number of spectra
+    Precision = correct predictions included ÷ total predictions included
+
+Predictions that tie on score cannot be meaningfully split by any threshold — either all of a tied group clears it or none does — so the curve has one point per *distinct* score value rather than one point per prediction. AUC (average precision) is always computed by integrating this full-resolution curve, before any further reduction described below, so the reported AUC value is unaffected by how the curve is displayed.
+
+Since the ground-truth dataset contains hundreds of thousands of spectra, storing every curve point for every tool would not scale as more tools are compared side by side. The stored/plotted curve is therefore capped at 500 points, sampled at evenly-spaced values along the coverage axis (not evenly-spaced by row index, since tied-score groups can otherwise leave the curve very unevenly spaced) — this only affects the resolution of the displayed line, never the AUC metric itself.
+
+Both this view and the main scatter plot respond to the same **evaluation mode** (exact/mass-based) and ambiguity toggle selections. As with the main plot, datapoints submitted before this curve was stored are silently hidden from this view.
+
 
 
 ### In-depth plots
@@ -94,7 +111,7 @@ The in-depth section provides a more detailed picture of the (relative) performa
 
 Firstly, the ability of the tool to accurately predict several **PTM's** can be evaluated. Since the ground-truth dataset was generated by searching against specific modifications, only these are supported. In Table 2, an overview of supported PTMs and their statistics are stated. Two types of plots are created for this: (i) an overview plot and (ii) PTM-specific plots. In the overview plot, the precision across all modifications are plotted together where precision is defined as the proportion of correctly predicted modifications over all peptides containing this modification in the ground-truth. A correct prediction does not require a fully correctly predicted peptide, only the specific amino acid with its PTM at the correct position. In the PTM-specific plots, this precision is plotted against the precision calculated as the proportion over all peptides containing this modification in the predicted peptide list. By doing so, biased precision estimates are handled in cases when the *de novo* tool would predict PTMs abundantly yet erroneously.
 
-**Table 3. PTMs in the ground-truth dataset**
+**Table 2. PTMs in the ground-truth dataset**
 
 | PTM                      | Occurrences | Fixed |
 | ------------------------ | ----------- | ----- |
@@ -122,6 +139,18 @@ The precision is calculated on the peptide level as the proportion of correct pe
 Protein sequences can differ considerably between species. Therefore, particularly for deep learning methods, models trained on data from one species might not be directly applicable to predict peptide sequences from other species. To roughly explore these differences, precision is calculated as above for each species separately.
 
 Beware, this set up was meant to work as training-test split procedure, where the data of eight species was used to train a model and evaluated on the unseen spectra from the excluded species. Here, we do not use it as intented since training the models is not directly supported in ProteoBench. If the user wants to use this feature as intented, the predictions should be generated accordingly as described. The results should be concatenated into a single result file in the format compatible with ProteoBench (see below).
+
+#### In-FASTA evaluation
+
+A wrong prediction is not necessarily a meaningless one: the predicted sequence might still be a real peptide, just the wrong one for that particular spectrum. To capture this, every prediction is placed into one of three categories:
+
+- **Correct** – the prediction matches the ground-truth peptide exactly (allowing isoleucine/leucine ambiguity, since the two cannot be distinguished by mass).
+- **In FASTA** – the prediction does not match the ground truth, but the predicted sequence is nonetheless found elsewhere in the reference proteome of the species the spectrum originates from.
+- **Not in FASTA** – the prediction matches neither the ground-truth peptide nor any other protein in that species' proteome. Spectra for which the tool made no prediction at all also fall into this category.
+
+Only predictions of at least 8 amino acids are checked against the proteome; below this length, a match can easily occur by chance and would not be a meaningful signal. Note that this categorization always uses the I/L-ambiguity exact match to determine "correct", independently of the **evaluation mode** and ambiguity toggles selected for the main benchmarking plot.
+
+For each tool, the proportion of predictions in each category is shown as a stacked bar. A large **In FASTA** share indicates that, even where a tool's prediction is wrong, it is often still calling a genuinely existing peptide from the correct organism — suggestive of a real but different peptide (e.g. from a co-eluting or chimeric spectrum) rather than a sequencing error. A large **Not in FASTA** share instead points to predictions that are not just wrong, but not proteome-supported either.
 
 ## How to use
 
@@ -169,8 +198,8 @@ Once uploaded to ProteoBench, the following columns from `results.mztab` are con
 
 - spectra_ref: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `index=<number>`
 - sequence: The predicted *de novo* sequence.
-- search_engine_score[1]: The peptide confidence score. Used for precision-recall curve construction.
-- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-recall curve construction.
+- search_engine_score[1]: The peptide confidence score. Used for precision-coverage curve construction.
+- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 ### [Casanovo](https://casanovo.readthedocs.io/en/latest/)
 
@@ -182,8 +211,8 @@ Once uploaded to ProteoBench, the following columns from `results.mztab` are con
 
 - spectra_ref: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `index=<number>`
 - sequence: The predicted *de novo* sequence.
-- search_engine_score[1]: The peptide confidence score. Used for precision-recall curve construction.
-- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-recall curve construction.
+- search_engine_score[1]: The peptide confidence score. Used for precision-coverage curve construction.
+- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 ### [ContraNovo](https://github.com/BEAM-Labs/ContraNovo)
 
@@ -195,8 +224,8 @@ Once uploaded to ProteoBench, the following columns from `results.mztab` are con
 
 - spectra_ref: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `scan=<number>`.
 - sequence: The predicted *de novo* sequence.
-- search_engine_score[1]: The peptide confidence score. Used for precision-recall curve construction.
-- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-recall curve construction.
+- search_engine_score[1]: The peptide confidence score. Used for precision-coverage curve construction.
+- opt_ms_run[1]_aa_scores: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 ### [DeepNovo](https://github.com/nh2tran/DeepNovo)
 
@@ -208,8 +237,8 @@ Once uploaded to ProteoBench, the following columns from the `.tab` file are con
 
 - scan: The scan number, used directly as the spectrum identifier to map the ground-truth identifications.
 - output_seq: The predicted *de novo* sequence.
-- output_score: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
-- aa_score: Amino acid-level confidence scores. Used for precision-recall curve construction (*Currently not implemented*).
+- output_score: The peptide confidence score. Used for precision-coverage curve construction.
+- aa_score: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 DeepNovo uses special tokens for modified amino acids in the output sequence: `Cmod` (carbamidomethylated cysteine), `Mmod` (oxidized methionine), `Nmod` (deamidated asparagine), `Qmod` (deamidated glutamine). These tokens are automatically converted to the appropriate ProForma notation by ProteoBench.
 
@@ -223,8 +252,8 @@ Once uploaded to ProteoBench, the following columns from `results.csv` are consi
 
 - spectrum_id: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the trailing number after the last colon (e.g., `filename:1234` yields `1234`).
 - predictions: The predicted *de novo* sequence.
-- log_probs: The peptide-level log probability score. Used for precision-recall curve construction (*Currently not implemented*).
-- token_log_probs: Amino acid-level log probability scores. Used for precision-recall curve construction (*Currently not implemented*).
+- log_probs: The peptide-level log probability score. Used for precision-coverage curve construction.
+- token_log_probs: Amino acid-level log probability scores. Used for precision-coverage curve construction.
 
 ### [NovoB](https://github.com/ProteomeTeam/NovoB)
 
@@ -236,7 +265,7 @@ Once uploaded to ProteoBench, the following columns from the output CSV file are
 
 - spectrum_id: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the first integer found in the identifier string.
 - sequence: The predicted *de novo* sequence.
-- score: The peptide confidence score. Used for precision-recall curve construction.
+- score: The peptide confidence score. Used for precision-coverage curve construction.
 
 NovoB uses a mixed case convention for modified amino acids: all cysteines (`C`) are treated as carbamidomethylated, while variable modifications are encoded as lowercase letters — `m` (oxidized methionine), `n` (deamidated asparagine), `q` (deamidated glutamine), `s` (phosphorylated serine), `t` (phosphorylated threonine), `y` (phosphorylated tyrosine). These are automatically converted to the appropriate ProForma notation by ProteoBench. Note that NovoB does not provide amino acid-level confidence scores.
 
@@ -249,8 +278,8 @@ To generate data compatible with ProteoBench:
 Once uploaded to ProteoBench, the following columns from `results.tsv` are considered:
 - TITLE: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `scan=<number>`
 - DENOVO: The predicted *de novo* sequence.
-- Score: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
-- Positional Score: Amino acid-level confidence scores. Used for precision-recall curve construction (*Currently not implemented*).
+- Score: The peptide confidence score. Used for precision-coverage curve construction.
+- Positional Score: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 ### [π-HelixNovo](https://github.com/PHOENIXcenter/pi-HelixNovo)
 
@@ -261,9 +290,9 @@ To generate data compatible with ProteoBench:
 Once uploaded to ProteoBench, the following columns from `results.tsv` are considered:
 - 0: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `scan=<number>`
 - 1: The predicted *de novo* sequence.
-- 2: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
+- 2: The peptide confidence score. Used for precision-coverage curve construction.
 
-The positional scores for this model are set equal to the amino acid scores. Note that other versions of π-HelixNovo have this option.
+π-HelixNovo does not report a per-residue confidence score, so ProteoBench broadcasts the peptide-level score to every amino-acid position instead (the same fallback used for any tool without amino acid-level scores). Note that other versions of π-HelixNovo have this option.
 
 ### [π-PrimeNovo](https://github.com/PHOENIXcenter/pi-PrimeNovo)
 
@@ -274,9 +303,9 @@ To generate data compatible with ProteoBench:
 Once uploaded to ProteoBench, the following columns from `results.tsv` are considered:
 - label: Contains the spectrum identifier to map the ground-truth identifications with. The spectrum identifier is extracted as the number in `scan=<number>`
 - prediction: The predicted *de novo* sequence.
-- score: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
+- score: The peptide confidence score. Used for precision-coverage curve construction.
 
-The positional scores for this model are set equal to the amino acid scores.
+π-PrimeNovo does not report a per-residue confidence score, so ProteoBench broadcasts the peptide-level score to every amino-acid position instead (the same fallback used for any tool without amino acid-level scores).
 
 ### [PointNovo](https://github.com/irleader/PointNovo)
 
@@ -288,8 +317,8 @@ Once uploaded to ProteoBench, the following columns from the output file are con
 
 - feature_id: The spectrum identifier, used directly to map the ground-truth identifications.
 - predicted_sequence: The predicted *de novo* sequence.
-- predicted_score: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
-- predicted_position_score: Amino acid-level confidence scores. Used for precision-recall curve construction (*Currently not implemented*).
+- predicted_score: The peptide confidence score. Used for precision-coverage curve construction.
+- predicted_position_score: Amino acid-level confidence scores. Used for precision-coverage curve construction.
 
 PointNovo uses spelled-out modification names: `C(Carbamidomethylation)`, `M(Oxidation)`, `N(Deamidation)`, `Q(Deamidation)`. These are automatically converted to the appropriate ProForma notation by ProteoBench.
 
@@ -303,8 +332,8 @@ Once uploaded to ProteoBench, the following columns from the combined output are
 
 - index: The spectrum index, used directly as the spectrum identifier to map the ground-truth identifications.
 - sequence: The predicted *de novo* sequence.
-- peptide_score: The peptide confidence score. Used for precision-recall curve construction (*Currently not implemented*).
-- aa_scores: Amino acid-level confidence scores from the probability file. Used for precision-recall curve construction (*Currently not implemented*).
+- peptide_score: The peptide confidence score. Used for precision-coverage curve construction.
+- aa_scores: Amino acid-level confidence scores from the probability file. Used for precision-coverage curve construction.
 
 SMSNet uses the same lowercase convention as NovoB: all cysteines (`C`) are carbamidomethylated, and lowercase letters denote variable modifications — `m` (oxidized methionine), `n` (deamidated asparagine), `q` (deamidated glutamine). These are automatically converted to the appropriate ProForma notation by ProteoBench.
 
@@ -392,6 +421,13 @@ After uploading an output file, a table is generated. The table is built by left
 | `aa_matches_dn` | Boolean array indexed to the **predicted** sequence length; `True` at each position where the amino acid is a mass-based match |
 | `aa_exact_gt` | Boolean array indexed to the ground-truth sequence; `True` at each position where the amino acid is an exact match |
 | `aa_exact_dn` | Boolean array indexed to the predicted sequence; `True` at each position where the amino acid is an exact match |
+| `match_type_il`, `aa_exact_gt_il`, `aa_exact_dn_il` | Same as `match_type`/`aa_exact_gt`/`aa_exact_dn`, but computed with isoleucine/leucine treated as equivalent |
+| `match_type_deam`, `aa_exact_gt_deam`, `aa_exact_dn_deam` | Same, but with deamidated Q/N treated as equivalent to E/D |
+| `match_type_both`, `aa_exact_gt_both`, `aa_exact_dn_both` | Same, with both ambiguities allowed at once |
+| `bare` | Predicted sequence with all isoleucines replaced by leucine, used to check proteome membership (see `category` below) |
+| `category` | `"correct"` — matches the ground truth exactly (I/L ambiguity allowed); `"in_fasta"` — no match, but the (I/L-normalized) predicted sequence is found elsewhere in that spectrum's species proteome (only checked for predictions of at least 8 amino acids); `"not_in_fasta"` — neither, including spectra with no prediction |
+
+`aa_matches_gt`/`aa_matches_dn`/`pep_match` are mass-based and therefore identical regardless of the ambiguity toggles (I/L are already isomeric and deamidated Q/N are already isobaric with E/D under mass-based matching), so they are not duplicated per ambiguity combination the way `match_type`/`aa_exact_gt`/`aa_exact_dn` are.
 
 **Spectrum characteristics** (pre-computed in the ground-truth file)
 

--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -359,11 +359,15 @@ class DenovoDatapoint(DatapointBase):
     def get_indepth_metrics(self, df: pd.DataFrame):
         extra_metrics = {}
 
+        extra_metrics["in_FASTA"] = self.get_infasta_metrics(df)
         extra_metrics["PTM"] = self.get_ptm_metrics(df)
         extra_metrics["Spectrum"] = self.get_spectrum_metrics(df)
         extra_metrics["Species"] = self.get_species_metrics(df)
 
         return extra_metrics
+
+    def get_infasta_metrics(self, df: pd.DataFrame):
+        # IMPLEMENT
 
     def get_ptm_metrics(self, df: pd.DataFrame):
         mod_counts = {}

--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 import proteobench
 from proteobench.datapoint.datapoint_base import DatapointBase
+from proteobench.score.denovoscores import AMBIGUITY_COMBOS, get_ambiguity_suffix
 
 
 def calculate_prc(scores_correct, scores_all, n_spectra, threshold=None):
@@ -42,30 +43,58 @@ def calculate_prc(scores_correct, scores_all, n_spectra, threshold=None):
     return {"precision": precision, "recall": recall, "coverage": coverage}
 
 
-def get_prc_curve(t, n_spectra):
-    prs = []
-    recs = []
-    covs = []
+def get_prc_curve(scores_correct, scores_all, n_spectra) -> pd.DataFrame:
+    """
+    Sweep score thresholds and return the resulting precision-vs-coverage curve
+    (used to compute the AUC/average-precision main-plot metric).
+    """
+    scores_all = np.asarray(scores_all, dtype=float)
+    scores_correct = np.asarray(scores_correct, dtype=float)
 
-    for threshold in np.linspace(t.score.max(), t.score.min()):
+    precisions, coverages = [], []
+    if len(scores_all) == 0:
+        return pd.DataFrame({"precision": precisions, "coverage": coverages})
+
+    for threshold in np.linspace(scores_all.max(), scores_all.min()):
         if np.isnan(threshold):
             continue
 
+        # A threshold with nothing above it (e.g. the sweep's own starting point, the max
+        # score) would divide by zero in calculate_prc's precision/coverage; skip it.
+        ci = int((scores_all > threshold).sum())
+        if ci == 0:
+            continue
+
         prc_dict = calculate_prc(
-            scores_correct=t[t.match].score.to_numpy(),
-            scores_all=t.score.to_numpy(),
+            scores_correct=scores_correct,
+            scores_all=scores_all,
             n_spectra=n_spectra,
             threshold=threshold,
         )
-        pr, rec, cov = prc_dict["precision"], prc_dict["recall"], prc_dict["coverage"]
-        prs.append(pr)
-        recs.append(rec)
-        covs.append(cov)
+        precisions.append(prc_dict["precision"])
+        coverages.append(prc_dict["coverage"])
 
-    return pd.DataFrame({"precision": prs, "recall": recs, "coverage": covs})
+    return pd.DataFrame({"precision": precisions, "coverage": coverages})
 
 
-def collapse_aa_scores(df: pd.DataFrame, evaluation_type: str):
+def calculate_auc(scores_correct, scores_all, n_spectra) -> float:
+    """
+    Area under the precision-vs-coverage curve (average precision), reported as the
+    "AUC" main-plot metric. Returns NaN when the curve has fewer than two points (e.g.
+    a tool whose per-token scores are all identical, which happens for tools that don't
+    provide real per-residue scores and get a broadcast peptide score instead).
+    """
+    curve = get_prc_curve(scores_correct, scores_all, n_spectra)
+    if len(curve) < 2:
+        return float("nan")
+    curve = curve.sort_values("coverage")
+    # np.trapezoid replaces np.trapz as of numpy 2.0 (removed outright in later numpy);
+    # the project's numpy floor predates that, so pick whichever is available.
+    trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz
+    return float(trapezoid(curve["precision"], curve["coverage"]))
+
+
+def collapse_aa_scores(df: pd.DataFrame, evaluation_type: str, exact_dn_column: str = "aa_exact_dn"):
     df_aa = {}
 
     if evaluation_type == "mass":
@@ -73,7 +102,7 @@ def collapse_aa_scores(df: pd.DataFrame, evaluation_type: str):
         df_aa["aa_match"] = list(chain(*df["aa_matches_dn"].tolist()))
     elif evaluation_type == "exact":
         df_aa["aa_score"] = list(chain(*df["aa_scores"].tolist()))
-        df_aa["aa_match"] = list(chain(*df["aa_exact_dn"].tolist()))
+        df_aa["aa_match"] = list(chain(*df[exact_dn_column].tolist()))
     else:
         raise Exception("Evaluation type should be mass or exact, but {} was provided.".format(evaluation_type))
 
@@ -218,6 +247,21 @@ class DenovoDatapoint(DatapointBase):
                     self=DenovoDatapoint(), df=intermediate, level=l, evaluation=e_type
                 )
 
+            # Ambiguity-toggle variants (I/L, deamidated Q/N vs E/D) only affect exact-mode
+            # matching -- mass mode already can't distinguish these (I/L are isomeric,
+            # deamidated Q/N are isobaric with E/D), so its metrics are identical regardless
+            # and aren't recomputed per combination. Precomputed here (once, at benchmarking
+            # time) rather than at plot time, since only the aggregated `results` dict -- not
+            # the raw intermediate dataframe -- is persisted for a submitted datapoint.
+            results[l]["exact"]["ambiguity"] = {}
+            for suffix, flags in AMBIGUITY_COMBOS.items():
+                if not suffix:
+                    continue  # baseline combination; already stored as results[l]["exact"]
+                combo_key = suffix.lstrip("_")
+                results[l]["exact"]["ambiguity"][combo_key] = DenovoDatapoint.get_metrics(
+                    self=DenovoDatapoint(), df=intermediate, level=l, evaluation="exact", **flags
+                )
+
         results["in_depth"] = DenovoDatapoint.get_indepth_metrics(self=DenovoDatapoint(), df=intermediate)
         result_datapoint.results = results
         result_datapoint.precision_peptide = result_datapoint.results["peptide"][evaluation_type]["precision"]
@@ -228,28 +272,51 @@ class DenovoDatapoint(DatapointBase):
         results_series = pd.Series(dataclasses.asdict(result_datapoint))
         return results_series
 
-    def get_metrics(self, df: pd.DataFrame, level: str, evaluation: str):
+    def get_metrics(
+        self,
+        df: pd.DataFrame,
+        level: str,
+        evaluation: str,
+        allow_il: bool = False,
+        allow_deamidation: bool = False,
+    ):
         """
         Compute various statistical metrics from the provided DataFrame for the benchmark.
+
+        Parameters
+        ----------
+        allow_il : bool
+            Only meaningful when `evaluation="exact"`: read the match/exactness columns
+            computed with I/L treated as equivalent. Ignored for `evaluation="mass"`,
+            since mass-based matching can't distinguish I/L regardless.
+        allow_deamidation : bool
+            Only meaningful when `evaluation="exact"`: read the match/exactness columns
+            computed with deamidated Q/N treated as equivalent to E/D. Ignored for
+            `evaluation="mass"` for the same reason as `allow_il`.
         """
 
         if evaluation == "mass":
             evaluation_list = ["mass", "exact"]
+            match_col = "match_type"
+            exact_dn_column = "aa_exact_dn"
         elif evaluation == "exact":
             evaluation_list = ["exact"]
+            suffix = get_ambiguity_suffix(allow_il, allow_deamidation)
+            match_col = f"match_type{suffix}"
+            exact_dn_column = f"aa_exact_dn{suffix}"
         else:
             raise Exception("Only `exact` and `mass` evaluation types are supported. Should never happen.")
 
         if level == "peptide":
             n = len(df)
             df_filtered = df.dropna(subset="peptidoform")
-            scores_correct = df_filtered.loc[df_filtered["match_type"].isin(evaluation_list), "score"].tolist()
+            scores_correct = df_filtered.loc[df_filtered[match_col].isin(evaluation_list), "score"].tolist()
             scores_all = df_filtered["score"].tolist()
 
         elif level == "aa":
             n_aa = df["aa_matches_gt"].apply(len).sum()
             df_filtered = df.dropna(subset="peptidoform")
-            df_aa = collapse_aa_scores(df_filtered, evaluation_type=evaluation)
+            df_aa = collapse_aa_scores(df_filtered, evaluation_type=evaluation, exact_dn_column=exact_dn_column)
             scores_correct = df_aa.loc[df_aa["aa_match"], "aa_score"].tolist()
             scores_all = df_aa["aa_score"].tolist()
             n = n_aa
@@ -260,6 +327,7 @@ class DenovoDatapoint(DatapointBase):
             )
 
         res = calculate_prc(scores_correct=scores_correct, scores_all=scores_all, n_spectra=n, threshold=None)
+        res["auc"] = calculate_auc(scores_correct=scores_correct, scores_all=scores_all, n_spectra=n)
         return res
 
     def get_indepth_metrics(self, df: pd.DataFrame):

--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -366,8 +366,21 @@ class DenovoDatapoint(DatapointBase):
 
         return extra_metrics
 
-    def get_infasta_metrics(self, df: pd.DataFrame):
-        # IMPLEMENT
+    def get_infasta_metrics(self, df: pd.DataFrame) -> dict:
+        """
+        Aggregate the per-PSM FASTA category (``correct`` / ``in_fasta`` / ``not_in_fasta``,
+        assigned once by `DenovoScores.add_fasta_category` at the end of
+        `generate_intermediate`) into counts and proportions for this single datapoint.
+        Precomputed here -- like every other in-depth metric -- so multiple datapoints can be
+        plotted together from their stored `results` dicts alone, without re-deriving anything
+        (e.g. via a live groupby) from each datapoint's raw intermediate dataframe, which isn't
+        persisted.
+        """
+        categories = ("correct", "in_fasta", "not_in_fasta")
+        n = len(df)
+        counts = df["category"].value_counts().reindex(categories, fill_value=0).astype(int).to_dict()
+        proportions = {cat: (counts[cat] / n if n else float("nan")) for cat in categories}
+        return {"counts": counts, "proportions": proportions, "n_spectra": n}
 
     def get_ptm_metrics(self, df: pd.DataFrame):
         mod_counts = {}

--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -21,70 +21,93 @@ from proteobench.datapoint.datapoint_base import DatapointBase
 from proteobench.score.denovoscores import AMBIGUITY_COMBOS, get_ambiguity_suffix
 
 
-def calculate_prc(scores_correct, scores_all, n_spectra, threshold=None):
-    if threshold is None:
-        c = len(scores_correct)
-        ci = len(scores_all)
-    else:
-        c = sum([score > threshold for score in scores_correct])
-        ci = sum([score > threshold for score in scores_all])
-
-    u = n_spectra - ci
-
-    # precision
-    precision = c / ci
-
-    # recall (This is an alternative definition and the line will stop at x=y)
-    recall = c / n_spectra
-
-    # coverage
-    coverage = ci / n_spectra
-
-    return {"precision": precision, "recall": recall, "coverage": coverage}
-
-
-def get_prc_curve(scores_correct, scores_all, n_spectra) -> pd.DataFrame:
+def calculate_prc(scores_all, is_correct, n_spectra) -> dict:
     """
-    Sweep score thresholds and return the resulting precision-vs-coverage curve
-    (used to compute the AUC/average-precision main-plot metric).
+    Single-point precision/recall/coverage over every prediction (no score threshold).
+    """
+    is_correct = np.asarray(is_correct, dtype=bool)
+    ci = len(scores_all)
+    c = int(is_correct.sum())
+
+    return {
+        "precision": c / ci,
+        "recall": c / n_spectra,
+        "coverage": ci / n_spectra,
+    }
+
+
+def get_prc_curve(scores_all, is_correct, n_spectra) -> pd.DataFrame:
+    """
+    Full-resolution precision-vs-coverage curve, with one point per DISTINCT score value
+    rather than one per prediction. Ties are common (many tools emit coarse or repeated
+    confidence scores), and a threshold can never split a tied group -- either all of a
+    group's predictions clear it, or none do -- so the only well-defined curve vertices are
+    "coverage/precision immediately after including an entire tied-score group." Collapsing
+    to those vertices also makes the within-tie ordering irrelevant to the result (the
+    cumulative count after a full group is the same regardless of the arbitrary order ties
+    were processed in), and, as a side effect, shrinks the curve for any tool whose scores
+    are heavily quantized. Both the AUC integration and the stored/plotted curve (after
+    `downsample_curve`) are derived from this same result.
     """
     scores_all = np.asarray(scores_all, dtype=float)
-    scores_correct = np.asarray(scores_correct, dtype=float)
+    is_correct = np.asarray(is_correct, dtype=bool)
 
-    precisions, coverages = [], []
     if len(scores_all) == 0:
-        return pd.DataFrame({"precision": precisions, "coverage": coverages})
+        return pd.DataFrame({"precision": [], "coverage": []})
 
-    for threshold in np.linspace(scores_all.max(), scores_all.min()):
-        if np.isnan(threshold):
-            continue
+    order = np.argsort(-scores_all)
+    sorted_scores = scores_all[order]
+    sorted_correct = is_correct[order]
 
-        # A threshold with nothing above it (e.g. the sweep's own starting point, the max
-        # score) would divide by zero in calculate_prc's precision/coverage; skip it.
-        ci = int((scores_all > threshold).sum())
-        if ci == 0:
-            continue
+    rank = np.arange(1, len(scores_all) + 1)
+    cum_correct = np.cumsum(sorted_correct)
+    precision = cum_correct / rank
+    coverage = rank / n_spectra
 
-        prc_dict = calculate_prc(
-            scores_correct=scores_correct,
-            scores_all=scores_all,
-            n_spectra=n_spectra,
-            threshold=threshold,
-        )
-        precisions.append(prc_dict["precision"])
-        coverages.append(prc_dict["coverage"])
+    # Keep only the last (highest-rank) row of each run of equal scores -- the sole point in
+    # that run where "included" actually changes as the threshold crosses this score value.
+    is_last_in_group = np.append(sorted_scores[:-1] != sorted_scores[1:], True)
 
-    return pd.DataFrame({"precision": precisions, "coverage": coverages})
+    return pd.DataFrame({"precision": precision[is_last_in_group], "coverage": coverage[is_last_in_group]})
 
 
-def calculate_auc(scores_correct, scores_all, n_spectra) -> float:
+# Stored/plotted curves are capped at a fixed number of points, sampled at evenly-spaced
+# COVERAGE values (not evenly-spaced row positions -- ties can leave the deduplicated curve's
+# rows very unevenly spaced in coverage, e.g. one huge tied group followed by many distinct
+# scores close together, so only sampling by coverage value itself gives a genuinely even
+# spread). Capping by a fixed count, rather than a fixed stride, is what actually bounds
+# storage: a stride scales with the size of the ground truth (e.g. ~780k spectra), which is
+# exactly what made this unscalable across many tools' worth of curves loaded at once; a fixed
+# count does not, regardless of how large the dataset or how many tools are being compared.
+# AUC is always integrated over the full-resolution curve in `get_prc_curve`, before this
+# runs, so downsampling only affects how many points the plotted line has, never any metric.
+CURVE_STORAGE_MAX_POINTS = 500
+
+
+def downsample_curve(curve: pd.DataFrame, max_points: int = CURVE_STORAGE_MAX_POINTS) -> pd.DataFrame:
     """
-    Area under the precision-vs-coverage curve (average precision), reported as the
-    "AUC" main-plot metric. Returns NaN when the curve has fewer than two points (e.g.
+    Sample at most `max_points` rows of a curve at evenly-spaced coverage values, always
+    including the first and last point.
+    """
+    if len(curve) <= max_points:
+        return curve.reset_index(drop=True)
+
+    coverage = curve["coverage"].to_numpy()
+    targets = np.linspace(coverage[0], coverage[-1], max_points)
+    # For each evenly-spaced target coverage, the row that was actually "current" at that
+    # coverage level: the last row at or before it.
+    idx = np.searchsorted(coverage, targets, side="right") - 1
+    idx = np.unique(np.clip(idx, 0, len(curve) - 1))
+    return curve.iloc[idx].reset_index(drop=True)
+
+
+def calculate_auc(curve: pd.DataFrame) -> float:
+    """
+    Area under an already-computed precision-vs-coverage curve (average precision), reported
+    as the "AUC" main-plot metric. Returns NaN when the curve has fewer than two points (e.g.
     a tool whose per-token scores are all identical, which happens for tools that don't
     provide real per-residue scores and get a broadcast peptide score instead).
     """
-    curve = get_prc_curve(scores_correct, scores_all, n_spectra)
     if len(curve) < 2:
         return float("nan")
     curve = curve.sort_values("coverage")
@@ -310,15 +333,15 @@ class DenovoDatapoint(DatapointBase):
         if level == "peptide":
             n = len(df)
             df_filtered = df.dropna(subset="peptidoform")
-            scores_correct = df_filtered.loc[df_filtered[match_col].isin(evaluation_list), "score"].tolist()
             scores_all = df_filtered["score"].tolist()
+            is_correct = df_filtered[match_col].isin(evaluation_list).tolist()
 
         elif level == "aa":
             n_aa = df["aa_matches_gt"].apply(len).sum()
             df_filtered = df.dropna(subset="peptidoform")
             df_aa = collapse_aa_scores(df_filtered, evaluation_type=evaluation, exact_dn_column=exact_dn_column)
-            scores_correct = df_aa.loc[df_aa["aa_match"], "aa_score"].tolist()
             scores_all = df_aa["aa_score"].tolist()
+            is_correct = df_aa["aa_match"].tolist()
             n = n_aa
 
         else:
@@ -326,8 +349,11 @@ class DenovoDatapoint(DatapointBase):
                 "Only `aa` and `peptide` levels for accuracy calculation are supported. Should never happen."
             )
 
-        res = calculate_prc(scores_correct=scores_correct, scores_all=scores_all, n_spectra=n, threshold=None)
-        res["auc"] = calculate_auc(scores_correct=scores_correct, scores_all=scores_all, n_spectra=n)
+        res = calculate_prc(scores_all=scores_all, is_correct=is_correct, n_spectra=n)
+        full_curve = get_prc_curve(scores_all=scores_all, is_correct=is_correct, n_spectra=n)
+        res["auc"] = calculate_auc(full_curve)
+        stored_curve = downsample_curve(full_curve)
+        res["curve"] = {"coverage": stored_curve["coverage"].tolist(), "precision": stored_curve["precision"].tolist()}
         return res
 
     def get_indepth_metrics(self, df: pd.DataFrame):

--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -394,27 +394,27 @@ class DenovoDatapoint(DatapointBase):
         for mod_label, unimod_tag in mod_labels_gt.items():
             mod_count = 0
             correct = 0
-            for i, row in df[df[mod_label]].iterrows():
+            for row in df[df[mod_label]].itertuples():
                 mod_count, correct = self.evaluate_ptm(
                     mod_label=mod_label,
                     mod_tag=unimod_tag,
-                    peptidoform=row["peptidoform_ground_truth"],
-                    match_array=row["aa_exact_gt"],
+                    peptidoform=row.peptidoform_ground_truth,
+                    match_array=row.aa_exact_gt,
                 )
                 mod_counts[mod_label]["counts_gt"] += mod_count
                 mod_counts[mod_label]["correct_gt"] += correct
 
         # On predicted
+        df_filtered = df.dropna()  # Due to no predictions for certain spectra
         for mod_label, unimod_tag in mod_labels_dn.items():
-            df_filtered = df.dropna()  # Due to no predictions for certain spectra
             mod_count = 0
             correct = 0
-            for i, row in df_filtered[df_filtered[mod_label]].iterrows():
+            for row in df_filtered[df_filtered[mod_label]].itertuples():
                 mod_count, correct = self.evaluate_ptm(
                     mod_label=mod_label,
                     mod_tag=unimod_tag,
-                    peptidoform=row["peptidoform"],
-                    match_array=row["aa_exact_dn"],
+                    peptidoform=row.peptidoform,
+                    match_array=row.aa_exact_dn,
                 )
                 mod_counts[mod_label.split("(denovo)")[0].strip()]["counts_dn"] += mod_count
                 mod_counts[mod_label.split("(denovo)")[0].strip()]["correct_dn"] += correct

--- a/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_custom.toml
+++ b/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_custom.toml
@@ -2,7 +2,6 @@
 "spectrum_id" = "spectrum_id"
 "sequence" = "sequence"
 "score" = "score"
-"aa_scores" = "aa_scores"
 
 [spectrum_id_mapper]
 "pattern" = "scan=(\\d+)"

--- a/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_custom.toml
+++ b/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_custom.toml
@@ -4,8 +4,14 @@
 "score" = "score"
 "aa_scores" = "aa_scores"
 
-[spectrum_id]
+[spectrum_id_mapper]
 "pattern" = "scan=(\\d+)"
 
 [sequence_mapper]
 [sequence_mapper.replacement_dict]
+
+[upload_info]
+"datapoint_file" = "*.csv"
+"datapoint_file_description" = "Upload the de novo sequencing output CSV file defined in custom format"
+"params_file" = ""
+"params_file_description" = ""

--- a/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_peaks.toml
+++ b/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_peaks.toml
@@ -1,0 +1,23 @@
+[mapper]
+"Scan" = "spectrum_id"
+"Peptide" = "sequence"
+"ALC (%)" = "score"
+"local confidence (%)" = "aa_scores"
+
+[spectrum_id_mapper]
+
+[sequence_mapper]
+
+[modification_parser]
+"parse_column" = "sequence"
+"before_aa" = false
+"isalpha" = true
+"isupper" = true
+"pattern" = "\\(([^)]+)\\)"
+"modification_dict" = {"(+57.02)" = "UNIMOD:4", "(+15.99)" = "UNIMOD:35", "(+.98)" = "UNIMOD:7"}
+
+[upload_info]
+"datapoint_file" = "*.csv"
+"datapoint_file_description" = "Upload the PEAKS Studio de novo output (probably called -de novo peptides.csv-)"
+"params_file" = ""
+"params_file_description" = ""

--- a/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_pihelixnovo.toml
+++ b/proteobench/io/parsing/io_parse_settings/denovo/DDA/HCD/parse_settings_pihelixnovo.toml
@@ -15,6 +15,7 @@
 "isupper" = true
 "pattern" = "([\\d+-.]+)"
 "modification_dict" = {"+57.021" = "UNIMOD:4", "+15.995" = "UNIMOD:35", "+0.984" = "UNIMOD:7", "+42.011" = "UNIMOD:1", "+43.006" = "UNIMOD:5", "-17.027" = "UNIMOD:385", "+43.006-17.027" = "Formula:H-2C1O1"}
+
 [upload_info]
 "datapoint_file" = "*.tsv"
 "datapoint_file_description" = "Upload the Pi-HelixNovo de novo sequencing output TSV file."

--- a/proteobench/io/parsing/io_parse_settings/parse_settings_files.toml
+++ b/proteobench/io/parsing/io_parse_settings/parse_settings_files.toml
@@ -108,6 +108,7 @@
 "NovoB" = "parse_settings_novob.toml"
 "PointNovo" = "parse_settings_pointnovo.toml"
 "SMSNet" = "parse_settings_smsnet.toml"
+"PEAKS" = "parse_settings_peaks.toml"
 "Custom" = "parse_settings_custom.toml"
 
 [entrapment_DIA_ion_Astral]

--- a/proteobench/io/parsing/parse_denovo.py
+++ b/proteobench/io/parsing/parse_denovo.py
@@ -357,6 +357,7 @@ def _load_custom(input_path: str) -> pd.DataFrame:
     """
     return pd.read_csv(input_path, low_memory=False)
 
+
 def _load_peaks(input_path: str) -> pd.DataFrame:
     """
     Load a de novo output file in PEAKS format.
@@ -373,12 +374,13 @@ def _load_peaks(input_path: str) -> pd.DataFrame:
     """
     df = pd.read_csv(input_path, low_memory=False)
     # Drop unmappable entries
-    df = df[df['Scan']!='-']
-    
-    df['local confidence (%)'] = df["local confidence (%)"].apply(lambda x: [float(i) for i in x.split()])
-    df['ALC (%)'] = df['ALC (%)'].astype(float)
-    df['Scan'] = df['Scan'].astype(int)
+    df = df[df["Scan"] != "-"]
+
+    df["local confidence (%)"] = df["local confidence (%)"].apply(lambda x: [float(i) for i in x.split()])
+    df["ALC (%)"] = df["ALC (%)"].astype(float)
+    df["Scan"] = df["Scan"].astype(int)
     return df
+
 
 _LOAD_FUNCTIONS = {
     "AdaNovo": _load_adanovo,

--- a/proteobench/io/parsing/parse_denovo.py
+++ b/proteobench/io/parsing/parse_denovo.py
@@ -357,6 +357,28 @@ def _load_custom(input_path: str) -> pd.DataFrame:
     """
     return pd.read_csv(input_path, low_memory=False)
 
+def _load_peaks(input_path: str) -> pd.DataFrame:
+    """
+    Load a de novo output file in PEAKS format.
+
+    Parameters
+    ----------
+    input_path: str
+        The path to the output file
+
+    Returns
+    -------
+    pd.DataFrame
+        The loaded dataframe
+    """
+    df = pd.read_csv(input_path, low_memory=False)
+    # Drop unmappable entries
+    df = df[df['Scan']!='-']
+    
+    df['local confidence (%)'] = df["local confidence (%)"].apply(lambda x: [float(i) for i in x.split()])
+    df['ALC (%)'] = df['ALC (%)'].astype(float)
+    df['Scan'] = df['Scan'].astype(int)
+    return df
 
 _LOAD_FUNCTIONS = {
     "AdaNovo": _load_adanovo,
@@ -371,4 +393,5 @@ _LOAD_FUNCTIONS = {
     "PointNovo": _load_pointnovo,
     "SMSNet": _load_smsnet,
     "Custom": _load_custom,
+    "PEAKS": _load_peaks,
 }

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -42,7 +42,8 @@ QUADRANT_LABELS = {
     "low": {"text": "<b>Low performance</b>"},
     "alt_candidate": {
         "text": (
-            "<b>Alternative candidate</b><br>" "<span style='font-size:10px'>(Often correct, but when incorrect, suggest a completely different peptide)</span>"
+            "<b>Alternative candidate</b><br>"
+            "<span style='font-size:10px'>(Often correct, but when incorrect, suggest a completely different peptide)</span>"
         )
     },
 }

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -37,12 +37,12 @@ QUADRANT_COLORSCALE = [
 QUADRANT_LABELS = {
     "good": {"text": "<b>Good performance</b>"},
     "near_miss": {
-        "text": "<b>Near-miss</b><br><span style='font-size:10px'>Often suggests a very similar peptide</span>"
+        "text": "<b>Near-miss</b><br><span style='font-size:10px'>Often incorrect, but predictions are very similar to ground-truth peptide</span>"
     },
     "low": {"text": "<b>Low performance</b>"},
     "alt_candidate": {
         "text": (
-            "<b>Alternative candidate</b><br>" "<span style='font-size:10px'>(Suggests fully different peptide)</span>"
+            "<b>Alternative candidate</b><br>" "<span style='font-size:10px'>(Often correct, but when incorrect, suggest a completely different peptide)</span>"
         )
     },
 }

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -2,7 +2,7 @@
 Module for plotting results of de novo models
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -13,6 +13,39 @@ from plotly.subplots import make_subplots
 from proteobench.plotting.plot_generator_base import PlotGeneratorBase
 
 EPSILON = 0.0001
+
+# Main-metric-plot quadrant treatment: fixed axes (padded slightly past 0/1 so points at the
+# edges aren't clipped), a boundary at the data midpoint splitting the plot into four named
+# regions, and a continuous background gradient (not four flat quadrant colors) since "how far
+# into the corner" is itself meaningful -- a point deep in Q1 is doing better than one just
+# past the boundary, even though both are "good performance."
+MAIN_PLOT_AXIS_RANGE = [-0.05, 1.1]
+QUADRANT_BOUNDARY = 0.5
+# Precision-coverage curve view: a smaller pad than the scatter's, just enough that a curve
+# endpoint sitting exactly at 0 or 1 isn't clipped by the axis border.
+PR_CURVE_AXIS_RANGE = [-0.03, 1.03]
+# Single sequential hue, light (low) to dark blue (high) -- a magnitude encoding ("how good"),
+# not a category or polarity one, so one hue avoids both a rainbow and a red/green pair that
+# would be indistinguishable to red-green colorblind users.
+QUADRANT_COLORSCALE = [
+    [0.0, "#f4efe4"],
+    [0.35, "#cfe0e8"],
+    [0.65, "#8fb9cf"],
+    [0.85, "#4d87ac"],
+    [1.0, "#1f5678"],
+]
+QUADRANT_LABELS = {
+    "good": {"text": "<b>Good performance</b>"},
+    "near_miss": {
+        "text": "<b>Near-miss</b><br><span style='font-size:10px'>Often suggests a very similar peptide</span>"
+    },
+    "low": {"text": "<b>Low performance</b>"},
+    "alt_candidate": {
+        "text": (
+            "<b>Alternative candidate</b><br>" "<span style='font-size:10px'>(Suggests fully different peptide)</span>"
+        )
+    },
+}
 
 SOFTWARE_COLORS = {
     "AdaNovo": "#88CCEE",
@@ -46,40 +79,84 @@ SOFTWARE_MARKERS = {
 }
 
 
-def flatten_results_column(df):
-    results = {
-        "engine": [],
-        "peptide_mass_precision": [],
-        "peptide_mass_recall": [],
-        "peptide_mass_coverage": [],
-        "peptide_exact_precision": [],
-        "peptide_exact_recall": [],
-        "peptide_exact_coverage": [],
-        "aa_mass_precision": [],
-        "aa_mass_recall": [],
-        "aa_mass_coverage": [],
-        "aa_exact_precision": [],
-        "aa_exact_recall": [],
-        "aa_exact_coverage": [],
-    }
-    for i, row in df.iterrows():
+_LEVELS = ("peptide", "aa")
+_EVALUATION_TYPES = ("mass", "exact")
+_METRICS = ("precision", "recall", "coverage", "auc")
+
+
+def _get_metrics_leaf(row: pd.Series, level: str, evaluation_type: str, ambiguity_combo: Optional[str] = None) -> dict:
+    """
+    Return the `{precision, recall, coverage, auc}` dict for one level/evaluation-type,
+    optionally reading an ambiguity-toggle combination instead of the baseline.
+
+    Ambiguity combinations only exist under exact-mode matching (mass-mode metrics are
+    identical regardless, since I/L are isomeric and deamidated Q/N are isobaric with E/D
+    either way), so `ambiguity_combo` is ignored for `evaluation_type == "mass"`.
+    """
+    leaf = row["results"][level][evaluation_type]
+    if evaluation_type == "exact" and ambiguity_combo:
+        return leaf["ambiguity"][ambiguity_combo]
+    return leaf
+
+
+def datapoint_has_required_fields(
+    results_dict: dict,
+    evaluation_type: str,
+    needs_auc: bool,
+    ambiguity_combo: Optional[str],
+    needs_curve: bool = False,
+) -> bool:
+    """
+    Check whether a datapoint's `results` dict has the fields the main plot needs for the
+    currently selected evaluation type, metric (precision or AUC), and ambiguity combination.
+
+    Used to silently hide datapoints submitted before a given field existed (e.g. `auc`,
+    `curve`, or the `ambiguity` sub-dict) rather than erroring, mirroring the HYE plot
+    generator's handling of legacy datapoints missing newer metric fields.
+    """
+    try:
+        for level in _LEVELS:
+            leaf = _get_metrics_leaf({"results": results_dict}, level, evaluation_type, ambiguity_combo)
+            if needs_auc and "auc" not in leaf:
+                return False
+            if needs_curve and "curve" not in leaf:
+                return False
+    except (TypeError, KeyError):
+        return False
+    return True
+
+
+def flatten_results_column(df: pd.DataFrame, ambiguity_combo: Optional[str] = None) -> pd.DataFrame:
+    """
+    Flatten each row's nested `results` dict into flat `{level}_{evaluation_type}_{metric}`
+    columns for plotting.
+
+    Parameters
+    ----------
+    ambiguity_combo : str, optional
+        One of `"il"`, `"deam"`, `"both"` to read the corresponding exact-mode ambiguity
+        combination instead of the baseline; `None` (default) reads the baseline. Ignored
+        for mass-mode fields, which don't have ambiguity combinations (see
+        `_get_metrics_leaf`).
+    """
+    results = {"engine": []}
+    for level in _LEVELS:
+        for evaluation_type in _EVALUATION_TYPES:
+            for metric in _METRICS:
+                results[f"{level}_{evaluation_type}_{metric}"] = []
+
+    for _, row in df.iterrows():
         results["engine"].append(row["software_name"])
+        for level in _LEVELS:
+            for evaluation_type in _EVALUATION_TYPES:
+                leaf = _get_metrics_leaf(row, level, evaluation_type, ambiguity_combo)
+                for metric in _METRICS:
+                    # `.get(..., nan)`, not `[...]`: a legacy datapoint may lack "auc" even
+                    # when it's not the metric currently being plotted (datapoint_has_
+                    # required_fields already decided visibility for the active selection;
+                    # this must not crash just because it computes every column eagerly).
+                    results[f"{level}_{evaluation_type}_{metric}"].append(leaf.get(metric, float("nan")))
 
-        results["peptide_mass_precision"].append(row["results"]["peptide"]["mass"]["precision"])
-        results["peptide_mass_recall"].append(row["results"]["peptide"]["mass"]["recall"])
-        results["peptide_mass_coverage"].append(row["results"]["peptide"]["mass"]["coverage"])
-
-        results["peptide_exact_precision"].append(row["results"]["peptide"]["exact"]["precision"])
-        results["peptide_exact_recall"].append(row["results"]["peptide"]["exact"]["recall"])
-        results["peptide_exact_coverage"].append(row["results"]["peptide"]["exact"]["coverage"])
-
-        results["aa_mass_precision"].append(row["results"]["aa"]["mass"]["precision"])
-        results["aa_mass_recall"].append(row["results"]["aa"]["mass"]["recall"])
-        results["aa_mass_coverage"].append(row["results"]["aa"]["mass"]["coverage"])
-
-        results["aa_exact_precision"].append(row["results"]["aa"]["exact"]["precision"])
-        results["aa_exact_recall"].append(row["results"]["aa"]["exact"]["recall"])
-        results["aa_exact_coverage"].append(row["results"]["aa"]["exact"]["coverage"])
     return pd.DataFrame(results)
 
 
@@ -99,8 +176,11 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             DataFrame containing the results to plot.
         **kwargs : dict
             Additional parameters:
-            - level: str (default "precision") - metric type ("precision" or "recall")
+            - level: str (default "precision") - metric type ("precision" or "auc")
             - evaluation_type: str (default "mass") - evaluation type ("mass" or "exact")
+            - allow_il: bool (default True) - under exact evaluation, treat I/L as equivalent
+            - allow_deamidation: bool (default False) - under exact evaluation, treat
+              deamidated Q/N as equivalent to E/D
             - colorblind_mode: bool (default False) - whether to use different shapes for software tools
             - software_colors: Dict[str, str] - color mapping for software tools
             - software_markers: Dict[str, str] - marker mapping for software tools (used when colorblind_mode is True)
@@ -116,6 +196,8 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         # Extract parameters from kwargs with defaults
         level = kwargs.get("level", "precision")
         evaluation_type = kwargs.get("evaluation_type", "mass")
+        allow_il = kwargs.get("allow_il", True)
+        allow_deamidation = kwargs.get("allow_deamidation", False)
         colorblind_mode = kwargs.get("colorblind_mode", False)
         software_colors = kwargs.get(
             "software_colors",
@@ -129,15 +211,32 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         highlight_color = kwargs.get("highlight_color", "#d30067")
         label = kwargs.get("label", "None")
 
+        # Ambiguity combinations only exist under exact-mode matching; mass-mode metrics
+        # are identical regardless (I/L are isomeric, deamidated Q/N isobaric with E/D).
+        ambiguity_combo = None
+        if evaluation_type == "exact":
+            if allow_il and allow_deamidation:
+                ambiguity_combo = "both"
+            elif allow_il:
+                ambiguity_combo = "il"
+            elif allow_deamidation:
+                ambiguity_combo = "deam"
+
         # Use result_df as the main dataframe (renamed from benchmark_metrics_df)
-        benchmark_metrics_df = result_df
+        benchmark_metrics_df = result_df.reset_index(drop=True)
+
+        # Silently hide datapoints submitted before the selected field existed (AUC, or the
+        # ambiguity combination), rather than erroring on a missing key.
+        needs_auc = level == "auc"
+        benchmark_metrics_df = benchmark_metrics_df[
+            benchmark_metrics_df["results"].apply(
+                lambda r: datapoint_has_required_fields(r, evaluation_type, needs_auc, ambiguity_combo)
+            )
+        ].reset_index(drop=True)
 
         # Define layout
-        benchmark_metrics_df = benchmark_metrics_df.reset_index(drop=True)
-        results_df = flatten_results_column(benchmark_metrics_df)
+        results_df = flatten_results_column(benchmark_metrics_df, ambiguity_combo=ambiguity_combo)
         benchmark_metrics_df = pd.concat([benchmark_metrics_df, results_df], axis=1)
-        results_min = results_df.min()
-        results_max = results_df.max()
 
         # Add hover text with detailed information for each data point
         hover_texts = []
@@ -212,22 +311,90 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         else:
             benchmark_metrics_df["marker"] = "circle"
 
-        layout_xaxis_range = [
-            results_min[f"peptide_{evaluation_type}_{level}"]
-            - results_min[f"peptide_{evaluation_type}_{level}"] * 0.05,
-            results_max[f"peptide_{evaluation_type}_{level}"]
-            + results_max[f"peptide_{evaluation_type}_{level}"] * 0.05,
-        ]
-        layout_yaxis_range = [
-            results_min[f"aa_{evaluation_type}_{level}"] - results_min[f"aa_{evaluation_type}_{level}"] * 0.05,
-            results_max[f"aa_{evaluation_type}_{level}"] + results_max[f"aa_{evaluation_type}_{level}"] * 0.05,
-        ]
-        layout_xaxis_title = f"Peptide {level.capitalize()}"
-        layout_yaxis_title = f"Amino Acid {level.capitalize()}"
+        # Fixed axis range (not the data's own min/max): both precision and AUC are bounded
+        # in [0, 1], so a shared, fixed range keeps the quadrant boundary and background
+        # gradient below anchored to the same meaningful midpoint every time, and padding
+        # past 0/1 (rather than clipping exactly at them) keeps points at the edges visible.
+        layout_xaxis_range = list(MAIN_PLOT_AXIS_RANGE)
+        layout_yaxis_range = list(MAIN_PLOT_AXIS_RANGE)
+        level_title = "AUC" if level == "auc" else level.capitalize()
+        layout_xaxis_title = f"Peptide {level_title}"
+        layout_yaxis_title = f"Amino Acid {level_title}"
 
         fig = go.Figure(
             layout_yaxis_range=layout_yaxis_range,
             layout_xaxis_range=layout_xaxis_range,
+        )
+
+        # Continuous background gradient, lightest at the origin and deepest at (1, 1), so
+        # "how far into the corner" reads visually even within a single quadrant. Added first
+        # so the scatter markers below are drawn on top of it, not the other way around.
+        grid_coords = np.linspace(MAIN_PLOT_AXIS_RANGE[0], MAIN_PLOT_AXIS_RANGE[1], 60)
+        grid_z = [[(x + y) / 2 for x in grid_coords] for y in grid_coords]
+        fig.add_trace(
+            go.Heatmap(
+                x=grid_coords,
+                y=grid_coords,
+                z=grid_z,
+                zmin=0,
+                zmax=1,
+                colorscale=QUADRANT_COLORSCALE,
+                showscale=False,
+                opacity=0.45,
+                hoverinfo="skip",
+            )
+        )
+
+        # Dashed boundary lines at the data midpoint, splitting the plot into the four named
+        # regions (drawn above the gradient/markers so they stay crisp at any zoom).
+        fig.add_shape(
+            type="line",
+            x0=QUADRANT_BOUNDARY,
+            x1=QUADRANT_BOUNDARY,
+            y0=MAIN_PLOT_AXIS_RANGE[0],
+            y1=MAIN_PLOT_AXIS_RANGE[1],
+            line=dict(color="rgba(90,90,90,0.6)", width=1, dash="dash"),
+            layer="above",
+        )
+        fig.add_shape(
+            type="line",
+            x0=MAIN_PLOT_AXIS_RANGE[0],
+            x1=MAIN_PLOT_AXIS_RANGE[1],
+            y0=QUADRANT_BOUNDARY,
+            y1=QUADRANT_BOUNDARY,
+            line=dict(color="rgba(90,90,90,0.6)", width=1, dash="dash"),
+            layer="above",
+        )
+
+        # Quadrant labels, placed inside each region near its outer edge.
+        left_x = (MAIN_PLOT_AXIS_RANGE[0] + QUADRANT_BOUNDARY) / 2
+        right_x = (QUADRANT_BOUNDARY + MAIN_PLOT_AXIS_RANGE[1]) / 2
+        top_y = MAIN_PLOT_AXIS_RANGE[1] - 0.05
+        bottom_y = MAIN_PLOT_AXIS_RANGE[0] + 0.03
+        for x, y, quadrant_key in (
+            (right_x, top_y, "good"),
+            (left_x, top_y, "near_miss"),
+            (left_x, bottom_y, "low"),
+            (right_x, bottom_y, "alt_candidate"),
+        ):
+            fig.add_annotation(
+                x=x,
+                y=y,
+                text=QUADRANT_LABELS[quadrant_key]["text"],
+                showarrow=False,
+                font=dict(size=12, color="rgba(60,60,60,0.85)"),
+                align="center",
+            )
+
+        # Corner cue: further into the top-right is strictly better on both axes.
+        fig.add_annotation(
+            x=MAIN_PLOT_AXIS_RANGE[1],
+            y=MAIN_PLOT_AXIS_RANGE[1],
+            xanchor="right",
+            yanchor="top",
+            text="↗ better performance",
+            showarrow=False,
+            font=dict(size=11, color="#1f5678"),
         )
 
         # Get all unique color-software combinations (necessary for highlighting)
@@ -290,6 +457,90 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
 
         fig.update_layout(clickmode="event+select")
 
+        return fig
+
+    def plot_precision_coverage_curves(self, result_df: pd.DataFrame, **kwargs) -> go.Figure:
+        """
+        Generate the precision-vs-coverage curve view: peptide-level and amino-acid-level
+        curves side by side, one line per software tool. An alternative to `plot_main_metric`
+        showing the full threshold-swept curve behind a single-point precision/AUC value,
+        rather than a single-point summary of it.
+
+        Parameters
+        ----------
+        result_df : pd.DataFrame
+            DataFrame containing the results to plot.
+        **kwargs : dict
+            Additional parameters:
+            - evaluation_type: str (default "mass") - evaluation type ("mass" or "exact")
+            - allow_il: bool (default True) - under exact evaluation, treat I/L as equivalent
+            - allow_deamidation: bool (default False) - under exact evaluation, treat
+              deamidated Q/N as equivalent to E/D
+            - software_colors: Dict[str, str] - color mapping for software tools
+
+        Returns
+        -------
+        go.Figure
+            A 1x2 subplot figure: peptide-level curve (left), amino-acid-level curve (right).
+        """
+        evaluation_type = kwargs.get("evaluation_type", "mass")
+        allow_il = kwargs.get("allow_il", True)
+        allow_deamidation = kwargs.get("allow_deamidation", False)
+        software_colors = kwargs.get("software_colors", SOFTWARE_COLORS)
+
+        ambiguity_combo = None
+        if evaluation_type == "exact":
+            if allow_il and allow_deamidation:
+                ambiguity_combo = "both"
+            elif allow_il:
+                ambiguity_combo = "il"
+            elif allow_deamidation:
+                ambiguity_combo = "deam"
+
+        # Silently hide datapoints submitted before the stored curve existed, same as
+        # plot_main_metric does for `auc`/`ambiguity`.
+        benchmark_metrics_df = result_df.reset_index(drop=True)
+        benchmark_metrics_df = benchmark_metrics_df[
+            benchmark_metrics_df["results"].apply(
+                lambda r: datapoint_has_required_fields(
+                    r, evaluation_type, needs_auc=False, ambiguity_combo=ambiguity_combo, needs_curve=True
+                )
+            )
+        ].reset_index(drop=True)
+
+        fig = make_subplots(
+            rows=1,
+            cols=2,
+            subplot_titles=("Peptide-level", "Amino-acid-level"),
+            horizontal_spacing=0.12,
+        )
+
+        for col_idx, level in enumerate(_LEVELS, start=1):
+            for _, row in benchmark_metrics_df.iterrows():
+                curve = _get_metrics_leaf(row, level, evaluation_type, ambiguity_combo).get("curve")
+                if not curve or not curve.get("coverage"):
+                    continue  # degenerate curve (e.g. all-identical scores) or legacy datapoint
+                software = row["software_name"]
+                fig.add_trace(
+                    go.Scatter(
+                        x=curve["coverage"],
+                        y=curve["precision"],
+                        mode="lines",
+                        name=software,
+                        legendgroup=software,
+                        showlegend=(col_idx == 1),
+                        line=dict(color=software_colors.get(software, "gray")),
+                        hovertemplate=f"{software}<br>Coverage: %{{x:.3f}}<br>Precision: %{{y:.3f}}<extra></extra>",
+                    ),
+                    row=1,
+                    col=col_idx,
+                )
+
+        for col_idx in (1, 2):
+            fig.update_xaxes(title_text="Coverage", range=PR_CURVE_AXIS_RANGE, row=1, col=col_idx)
+            fig.update_yaxes(title_text="Precision", range=PR_CURVE_AXIS_RANGE, row=1, col=col_idx)
+
+        fig.update_layout(width=900, height=480)
         return fig
 
     def generate_in_depth_plots(
@@ -581,7 +832,12 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
 
         for mod_label in mod_labels:
             x.append(mod_label)
-            y.append(mod_dict[mod_label]["correct_gt"] / mod_dict[mod_label]["counts_gt"] + EPSILON)
+            # EPSILON must guard the denominator (as plot_ptm_specific does), not be added
+            # to the final ratio -- `a / b + EPSILON` is `(a / b) + EPSILON` in Python, which
+            # still raises ZeroDivisionError when counts_gt is 0 (a modification that never
+            # occurs in the ground truth for the current view, e.g. a rare PTM on a small
+            # per-species selection).
+            y.append(mod_dict[mod_label]["correct_gt"] / (mod_dict[mod_label]["counts_gt"] + EPSILON))
         return x, y
 
     def plot_spectrum_feature(

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -692,33 +692,43 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             **Y-axis** - the metric at **amino-acid level**: the individual amino acids that are
             correctly predicted are counted, so partially correct sequences still contribute.
 
-            A tool in the **upper right corner** therefore performs well at both levels. A point
-            that sits high but not far to the right predicts many individual amino acids correctly
-            without getting whole sequences right.
+            The background is shaded from light (bottom-left) to dark (top-right): the further into
+            the top-right corner a point sits, the better it performs on both axes at once. Dashed
+            lines at the midpoint of each axis split the plot into four named regions:
+
+            - **Good performance** (top-right) - both the peptide- and amino-acid-level metrics are
+              high.
+            - **Near-miss** (top-left) - the peptide-level metric is low but the amino-acid-level
+              metric is high. Often just one or a few residues off from the true sequence.
+            - **Low performance** (bottom-left) - both metrics are low.
+            - **Alternative candidate** (bottom-right) - the peptide-level metric is high but the
+              amino-acid-level metric is low, suggesting a fully different peptide rather than a
+              near miss when the prediction is wrong. This region is expected to be sparse.
 
             **Select the classification metric** - which metric is shown on both axes:
 
-            - **Precision** - the fraction of the reported predictions that is correct:
-              `precision = correct predictions / reported predictions`. It describes how reliable
-              the reported sequences are.
-            - **Recall** - the fraction of the spectra that received a correct prediction:
-              `recall = correct predictions / total spectra`. It describes the coverage of the
-              dataset.
-
-            The two differ whenever a tool does not report a prediction for every spectrum: a tool
-            can reach a high precision by only reporting its confident predictions, while its recall
-            stays low.
+            - **Precision** - the fraction of the reported predictions that is correct, over every
+              prediction with no score threshold applied: `precision = correct predictions /
+              reported predictions`. Evaluates how reliable the reported sequences are at a tool's
+              single, fixed operating point.
+            - **AUC** - the area under the tool's precision-vs-coverage curve (average precision),
+              swept across every possible score threshold; the underlying curve is shown in the
+              adjacent "Precision-Coverage Curves" tab. Evaluates a tool's overall ranking quality
+              rather than one operating point, and is `N/A` for tools that don't report a real
+              per-residue confidence score.
 
             **Select the stringency of evaluation** - when a prediction counts as correct:
 
             - **Exact** - the predicted sequence must match the ground truth exactly, including the
-              modifications and their positions. This is the strictest criterion.
+              modifications and their positions. Two toggles relax this for ambiguities inherent to
+              the data: **allow I/L mismatches** (isoleucine and leucine are isobaric) and **allow
+              deamidation mismatches** (deamidated Q/N are essentially isobaric with E/D).
             - **Mass-based** - a prediction also counts as correct when it matches the ground truth
               through the longest mass-matching prefix and suffix, using a cumulative mass tolerance
-              of 50 ppm and an individual amino-acid tolerance of 20 ppm. This accepts
-              interpretations that cannot be distinguished by mass, such as isobaric amino acids
-              (for example I and L). Mass-based numbers are therefore always equal to or higher than
-              the exact numbers.
+              of 50 ppm and an individual amino-acid tolerance of 20 ppm. This already cannot
+              distinguish I/L or deamidation regardless of the toggles above, so both are forced on
+              and disabled. Mass-based numbers are therefore always equal to or higher than the
+              exact numbers.
 
             **Colorblind Mode** - distinguishes the software tools by marker shape in addition to
             colour.

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -83,6 +83,21 @@ _LEVELS = ("peptide", "aa")
 _EVALUATION_TYPES = ("mass", "exact")
 _METRICS = ("precision", "recall", "coverage", "auc")
 
+# FASTA-category breakdown (correct / in_fasta / not_in_fasta), computed once per datapoint by
+# `DenovoDatapoint.get_infasta_metrics` from the "category" column `DenovoScores.add_fasta_category`
+# assigns during scoring. Colors match the exploratory notebook this feature was designed in.
+INFASTA_CATEGORIES = ("correct", "in_fasta", "not_in_fasta")
+INFASTA_COLORS = {
+    "correct": "#4C9A6D",  # muted green
+    "in_fasta": "#F2A541",  # muted amber
+    "not_in_fasta": "#D1495B",  # muted rose
+}
+INFASTA_LABELS = {
+    "correct": "Correct",
+    "in_fasta": "In FASTA",
+    "not_in_fasta": "Not in FASTA",
+}
+
 
 def _get_metrics_leaf(row: pd.Series, level: str, evaluation_type: str, ambiguity_combo: Optional[str] = None) -> dict:
     """
@@ -615,6 +630,9 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
                 performance_data, evaluation_type=evaluation_type, software_colors=software_colors
             )
 
+        # Generate FASTA-category overview plot
+        plots["in_fasta_overview"] = self.plot_infasta_overview(performance_data)
+
         return plots
 
     def get_in_depth_plot_layout(self) -> list:
@@ -630,6 +648,7 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             {"plots": ["ptm_overview", "ptm_specific"], "columns": 1, "title": "PTM Analysis"},
             {"plots": ["spectrum_feature"], "columns": 1, "title": "Spectrum Features"},
             {"plots": ["species_overview"], "columns": 1, "title": "Species Analysis"},
+            {"plots": ["in_fasta_overview"], "columns": 1, "title": "FASTA Analysis"},
         ]
 
     def get_in_depth_plot_descriptions(self) -> Dict[str, str]:
@@ -649,6 +668,8 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             "spectrum_feature": "Analysis of precision relative to spectrum features such as missing "
             "fragmentation sites, peptide length, or explained intensity.",
             "species_overview": "Breakdown of precision across different species in the dataset.",
+            "in_fasta_overview": "Breakdown of predictions into correctly sequenced, incorrect but present "
+            "elsewhere in the species' proteome, and not present in the proteome at all.",
         }
 
     def get_metrics_help_markdown(self) -> str:
@@ -1093,6 +1114,54 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             # ticktext=[v for v in sorted(set(df['y_bar']))],
             row=2,
             col=1,
+        )
+        return fig
+
+    def plot_infasta_overview(self, benchmark_metrics_df: pd.DataFrame) -> go.Figure:
+        """
+        Stacked bar chart of the FASTA-category breakdown (correct / in FASTA / not in FASTA)
+        for each datapoint, one bar per tool. Reads the per-datapoint proportions precomputed
+        by `DenovoDatapoint.get_infasta_metrics` at benchmarking time (stored under
+        `results["in_depth"]["in_FASTA"]`) -- never a live groupby over raw intermediate data,
+        which isn't persisted for a submitted datapoint in the first place.
+        """
+        fig = go.Figure()
+
+        tools = []
+        proportions_per_category = {category: [] for category in INFASTA_CATEGORIES}
+        for _, row in benchmark_metrics_df.iterrows():
+            try:
+                infasta = row["results"]["in_depth"]["in_FASTA"]
+            except (KeyError, TypeError):
+                # Legacy datapoint submitted before this metric existed -- silently skipped,
+                # matching how the main plot hides datapoints missing newer fields.
+                continue
+            tools.append(row["software_name"])
+            for category in INFASTA_CATEGORIES:
+                proportions_per_category[category].append(infasta["proportions"].get(category, 0.0))
+
+        for category in INFASTA_CATEGORIES:
+            fig.add_bar(
+                name=INFASTA_LABELS[category],
+                x=tools,
+                y=proportions_per_category[category],
+                marker_color=INFASTA_COLORS[category],
+                marker_line_width=0,
+                text=[f"{v:.0%}" if v >= 0.03 else "" for v in proportions_per_category[category]],
+                textposition="inside",
+                textfont=dict(color="white", size=13),
+                hovertemplate="%{y:.1%}<extra>%{fullData.name}</extra>",
+            )
+
+        fig.update_layout(
+            barmode="stack",
+            width=700,
+            height=450,
+            title=dict(text="De novo sequencing accuracy by tool", font=dict(size=16)),
+            yaxis=dict(title="Proportion of spectra", tickformat=".0%", range=[0, 1]),
+            xaxis=dict(title="Tool"),
+            legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1, title=None),
+            margin=dict(t=70, b=50, l=60, r=30),
         )
         return fig
 

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -806,6 +806,26 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
         software_colors: Dict[str, str] = SOFTWARE_COLORS,
     ):
         fig = go.Figure()
+
+        # Same continuous corner gradient as the main plot (light -> dark towards (1, 1)):
+        # this plot's diagonal has the same "good" orientation -- top-right is strong
+        # performance, bottom-left is poor -- per Description.ptm_specific below.
+        grid_coords = np.linspace(0.0, 1.0, 60)
+        grid_z = [[(x + y) / 2 for x in grid_coords] for y in grid_coords]
+        fig.add_trace(
+            go.Heatmap(
+                x=grid_coords,
+                y=grid_coords,
+                z=grid_z,
+                zmin=0,
+                zmax=1,
+                colorscale=QUADRANT_COLORSCALE,
+                showscale=False,
+                opacity=0.45,
+                hoverinfo="skip",
+            )
+        )
+
         for i, row in benchmark_metrics_df.iterrows():
             ptm_data = row["results"]["in_depth"]["PTM"]
 
@@ -816,11 +836,30 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             tool = row["software_name"]
             fig.add_trace(go.Scatter(x=[x], y=[y], name=tool, marker=dict(color=software_colors[tool])))
 
+        # Short corner descriptions, condensed from Description.ptm_specific's
+        # "How to interpret the plot" section.
+        for x, y, xanchor, yanchor, text in (
+            (0.97, 0.97, "right", "top", "<b>Strong performance</b><br>frequent & correct"),
+            (0.03, 0.97, "left", "top", "<b>Conservative</b><br>rare but correct"),
+            (0.03, 0.03, "left", "bottom", "<b>Poor performance</b><br>rare & incorrect"),
+            (0.97, 0.03, "right", "bottom", "<b>Overprediction</b><br>frequent but incorrect"),
+        ):
+            fig.add_annotation(
+                x=x,
+                y=y,
+                xanchor=xanchor,
+                yanchor=yanchor,
+                text=text,
+                showarrow=False,
+                align=xanchor,
+                font=dict(size=10, color="rgba(60,60,60,0.85)"),
+            )
+
         fig.update_layout(
             width=500,
             height=500,
-            xaxis=dict(title="Precision (Ground-truth)", color="black", gridwidth=2),
-            yaxis=dict(title="Precision (denovo)", color="black", gridwidth=2),
+            xaxis=dict(title="Precision (Ground-truth)", color="black", gridwidth=2, range=[0, 1]),
+            yaxis=dict(title="Precision (denovo)", color="black", gridwidth=2, range=[0, 1]),
         )
 
         return fig

--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -355,7 +355,7 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
                 zmax=1,
                 colorscale=QUADRANT_COLORSCALE,
                 showscale=False,
-                opacity=0.45,
+                opacity=0.28,
                 hoverinfo="skip",
             )
         )
@@ -852,7 +852,7 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
                 zmax=1,
                 colorscale=QUADRANT_COLORSCALE,
                 showscale=False,
-                opacity=0.45,
+                opacity=0.28,
                 hoverinfo="skip",
             )
         )

--- a/proteobench/score/denovoscores.py
+++ b/proteobench/score/denovoscores.py
@@ -18,12 +18,7 @@ from proteobench.score.score_base import ScoreBase
 PEPTIDE_SETS_URL = "https://proteobench.cubimed.rub.de/datasets/module_data/de_novo_peptide_sets"
 PEPTIDE_SETS_DIR_SERVER = "/mnt/data/proteobench/module_data/"
 PEPTIDE_SETS_DIR_LOCAL_DENOVO = os.path.join(
-    Path(__file__).resolve().parent,
-    "io_parse_settings",
-    "denovo",
-    "DDA",
-    "HCD",
-    "peptide_sets"
+    Path(__file__).resolve().parent, "io_parse_settings", "denovo", "DDA", "HCD", "peptide_sets"
 )
 
 # Ambiguity toggle combinations for exact-mode matching. Keys double as the column-name
@@ -132,30 +127,27 @@ class DenovoScores(ScoreBase):
                 filtered_df["aa_matches_gt"] = match_df["aa_matches_gt"]
                 filtered_df["aa_matches_dn"] = match_df["aa_matches_dn"]
                 filtered_df["pep_match"] = match_df["pep_match"]
-                
+
         species_sets = self.load_species_sets()
-        filtered_df = self.add_fasta_category(
-            df=filtered_df,
-            species_sets=species_sets
-        )
-                
+        filtered_df = self.add_fasta_category(df=filtered_df, species_sets=species_sets)
+
         return filtered_df
 
     def load_species_sets(self, path: Optional[str] = None) -> dict[str, set]:
         from proteobench.utils.server_io import download_file
+
         def _has_peptide_sets(directory: str) -> bool:
             """A directory counts as usable if it exists and already has at least one species file."""
             directory_path = Path(directory)
             return directory_path.is_dir() and any(directory_path.glob("*.txt.gz"))
+
         def _list_remote_peptide_set_files(url: str) -> list[str]:
             """Parse the server's directory listing for available peptide set filenames."""
             response = requests.get(url, timeout=30)
             response.raise_for_status()
             soup = BeautifulSoup(response.text, "html.parser")
-            return [
-                link["href"] for link in soup.find_all("a", href=True)
-                if link["href"].endswith(".txt.gz")
-            ]
+            return [link["href"] for link in soup.find_all("a", href=True) if link["href"].endswith(".txt.gz")]
+
         def _download_peptide_sets(url: str, local_dir: str) -> None:
             """Download every peptide set file listed at the server URL into local_dir."""
             os.makedirs(local_dir, exist_ok=True)
@@ -534,24 +526,21 @@ class DenovoScores(ScoreBase):
         return mz1 - mz2 if mode_is_da else (mz1 - mz2) / mz2 * 10**6
 
     def add_fasta_category(
-        self,
-        df: pd.DataFrame, 
-        species_sets: dict[str, set[str]], 
-        min_length: int = 8
+        self, df: pd.DataFrame, species_sets: dict[str, set[str]], min_length: int = 8
     ) -> pd.DataFrame:
         def normalize_for_fasta_match(peptidoform: Peptidoform) -> Optional[str]:
             if isinstance(peptidoform, Peptidoform):
-                return peptidoform.sequence.replace('I', 'L')
+                return peptidoform.sequence.replace("I", "L")
             return None
-        
+
         df = df.copy()
         df["bare"] = df["peptidoform"].map(normalize_for_fasta_match)
         df["category"] = "not_in_fasta"
-        
-        # Exact matching taken from IL allowed str matching
-        df.loc[df["match_type_il"]=='exact', "category"] = "correct"
 
-        incorrect = df.loc[~(df["category"]=='correct')]
+        # Exact matching taken from IL allowed str matching
+        df.loc[df["match_type_il"] == "exact", "category"] = "correct"
+
+        incorrect = df.loc[~(df["category"] == "correct")]
         for species, idx in incorrect.groupby("collection").groups.items():
             peptide_set = species_sets.get(species, set())
             bare = df.loc[idx, "bare"]

--- a/proteobench/score/denovoscores.py
+++ b/proteobench/score/denovoscores.py
@@ -85,25 +85,37 @@ class DenovoScores(ScoreBase):
     def generate_intermediate(self, filtered_df: pd.DataFrame, replicate_to_raw=None) -> pd.DataFrame:
         # TODO: Evaluate which PSMs match, and which don't and return new table
 
+        # Tokenize each row's peptidoforms once, not once per ambiguity combination --
+        # `convert_peptidoform` doesn't depend on the toggles, so re-running it 4x per row
+        # (once per entry in AMBIGUITY_COMBOS below) was pure waste. Extracting the two
+        # peptidoform columns to plain lists once also means the per-combo loop below runs
+        # as plain Python, not `.apply(axis=1)` (which boxes every row into its own `Series`
+        # just to pull two values back out of it).
+        ground_truths = filtered_df["peptidoform_ground_truth"].tolist()
+        de_novos = filtered_df["peptidoform"].tolist()
+        gt_tokens_list = [self.convert_peptidoform(gt) for gt in ground_truths]
+        dn_tokens_list = [self.convert_peptidoform(dn) for dn in de_novos]
+
         # Add match type label (exact, mass, mismatch) and the amino acid-level evaluations,
         # once per ambiguity toggle combination. `aa_matches_*`/`pep_match` are mass-based and
         # therefore identical across all combinations, so they're only stored for the baseline
         # ("") combination; `match_type`/`aa_exact_*` do depend on the toggles and are stored
         # per combination, suffixed accordingly (baseline keeps the original, unsuffixed names).
         for suffix, flags in AMBIGUITY_COMBOS.items():
-            match_dict = filtered_df.apply(
-                lambda x: self.evaluate_match(
-                    ground_truth=x["peptidoform_ground_truth"], de_novo=x["peptidoform"], **flags
-                ),
-                axis=1,
-            )
-            filtered_df[f"match_type{suffix}"] = match_dict.apply(lambda x: x["match_type"])
-            filtered_df[f"aa_exact_gt{suffix}"] = match_dict.apply(lambda x: x["aa_exact_gt"])
-            filtered_df[f"aa_exact_dn{suffix}"] = match_dict.apply(lambda x: x["aa_exact_dn"])
+            match_dicts = [
+                self.evaluate_match_tokenized(gt, dn, gt_tokens, dn_tokens, **flags)
+                for gt, dn, gt_tokens, dn_tokens in zip(ground_truths, de_novos, gt_tokens_list, dn_tokens_list)
+            ]
+            # One DataFrame construction instead of 3-6 separate `.apply(lambda x: x["key"])`
+            # passes over the whole column to pull each field out of the dicts above.
+            match_df = pd.DataFrame(match_dicts, index=filtered_df.index)
+            filtered_df[f"match_type{suffix}"] = match_df["match_type"]
+            filtered_df[f"aa_exact_gt{suffix}"] = match_df["aa_exact_gt"]
+            filtered_df[f"aa_exact_dn{suffix}"] = match_df["aa_exact_dn"]
             if suffix == "":
-                filtered_df["aa_matches_gt"] = match_dict.apply(lambda x: x["aa_matches_gt"])
-                filtered_df["aa_matches_dn"] = match_dict.apply(lambda x: x["aa_matches_dn"])
-                filtered_df["pep_match"] = match_dict.apply(lambda x: x["pep_match"])
+                filtered_df["aa_matches_gt"] = match_df["aa_matches_gt"]
+                filtered_df["aa_matches_dn"] = match_df["aa_matches_dn"]
+                filtered_df["pep_match"] = match_df["pep_match"]
         return filtered_df
 
     def evaluate_match(
@@ -125,32 +137,64 @@ class DenovoScores(ScoreBase):
             Treat deamidated Q/N as equivalent to E/D when deciding exactness
             (mass-based matching is unaffected: they're already isobaric).
         """
-        gt = self.convert_peptidoform(ground_truth)
-        dn = self.convert_peptidoform(de_novo)
+        gt_tokens = self.convert_peptidoform(ground_truth)
+        dn_tokens = self.convert_peptidoform(de_novo)
+        return self.evaluate_match_tokenized(
+            ground_truth, de_novo, gt_tokens, dn_tokens, allow_il=allow_il, allow_deamidation=allow_deamidation
+        )
 
-        if dn is None:
+    def evaluate_match_tokenized(
+        self,
+        ground_truth: Peptidoform,
+        de_novo: Peptidoform,
+        gt_tokens,
+        dn_tokens,
+        allow_il: bool = False,
+        allow_deamidation: bool = False,
+    ):
+        """
+        Same as `evaluate_match`, but takes already-tokenized peptidoforms (the output of
+        `convert_peptidoform`) instead of tokenizing internally. Tokenization doesn't depend
+        on the ambiguity toggles, so a caller comparing the same pair under multiple
+        combinations (as `generate_intermediate` does, once per entry in `AMBIGUITY_COMBOS`)
+        can tokenize once and reuse the result across all of them, rather than re-tokenizing
+        on every combination. `evaluate_match` is a thin wrapper around this for callers
+        comparing a single pair once.
+
+        Parameters
+        ----------
+        gt_tokens, dn_tokens
+            `convert_peptidoform(ground_truth)` / `convert_peptidoform(de_novo)`.
+        allow_il : bool
+            Treat I and L as equivalent when deciding per-residue and whole-peptide
+            exactness (mass-based matching is unaffected: I/L are already isomeric).
+        allow_deamidation : bool
+            Treat deamidated Q/N as equivalent to E/D when deciding exactness
+            (mass-based matching is unaffected: they're already isobaric).
+        """
+        if dn_tokens is None:
             return {
                 "match_type": "mismatch",
-                "aa_matches_gt": np.full(len(gt), False),
-                "aa_matches_dn": np.full(len(gt), False),
-                "aa_exact_gt": np.full(len(gt), False),
-                "aa_exact_dn": np.full(len(gt), False),
+                "aa_matches_gt": np.full(len(gt_tokens), False),
+                "aa_matches_dn": np.full(len(gt_tokens), False),
+                "aa_exact_gt": np.full(len(gt_tokens), False),
+                "aa_exact_dn": np.full(len(gt_tokens), False),
                 "pep_match": False,
             }
 
         if ground_truth == de_novo:
             return {
                 "match_type": "exact",
-                "aa_matches_gt": np.full(len(gt), True),
-                "aa_matches_dn": np.full(len(dn), True),
-                "aa_exact_gt": np.full(len(gt), True),
-                "aa_exact_dn": np.full(len(dn), True),
+                "aa_matches_gt": np.full(len(gt_tokens), True),
+                "aa_matches_dn": np.full(len(dn_tokens), True),
+                "aa_exact_gt": np.full(len(gt_tokens), True),
+                "aa_exact_dn": np.full(len(dn_tokens), True),
                 "pep_match": True,
             }
 
         aa_matches, pep_match, (aa_matches_1, aa_matches_2), (exact_match_1, exact_match_2) = self.aa_match(
-            gt,
-            dn,
+            gt_tokens,
+            dn_tokens,
             allow_il=allow_il,
             allow_deamidation=allow_deamidation,
         )

--- a/proteobench/score/denovoscores.py
+++ b/proteobench/score/denovoscores.py
@@ -2,13 +2,29 @@
 Module containing the DenovoScores class.
 """
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
+import os
 import numpy as np
 import pandas as pd
 from psm_utils import Peptidoform
 
+import requests
+from bs4 import BeautifulSoup
+import gzip
+from pathlib import Path
 from proteobench.score.score_base import ScoreBase
+
+PEPTIDE_SETS_URL = "https://proteobench.cubimed.rub.de/datasets/module_data/de_novo_peptide_sets"
+PEPTIDE_SETS_DIR_SERVER = "/mnt/data/proteobench/module_data/"
+PEPTIDE_SETS_DIR_LOCAL_DENOVO = os.path.join(
+    Path(__file__).resolve().parent,
+    "io_parse_settings",
+    "denovo",
+    "DDA",
+    "HCD",
+    "peptide_sets"
+)
 
 # Ambiguity toggle combinations for exact-mode matching. Keys double as the column-name
 # suffix used in the intermediate dataframe ("" = baseline, unsuffixed columns).
@@ -116,7 +132,57 @@ class DenovoScores(ScoreBase):
                 filtered_df["aa_matches_gt"] = match_df["aa_matches_gt"]
                 filtered_df["aa_matches_dn"] = match_df["aa_matches_dn"]
                 filtered_df["pep_match"] = match_df["pep_match"]
+                
+        species_sets = self.load_species_sets()
+        filtered_df = self.add_fasta_category(
+            df=filtered_df,
+            species_sets=species_sets
+        )
+                
         return filtered_df
+
+    def load_species_sets(self, path: Optional[str] = None) -> dict[str, set]:
+        from proteobench.utils.server_io import download_file
+        def _has_peptide_sets(directory: str) -> bool:
+            """A directory counts as usable if it exists and already has at least one species file."""
+            directory_path = Path(directory)
+            return directory_path.is_dir() and any(directory_path.glob("*.txt.gz"))
+        def _list_remote_peptide_set_files(url: str) -> list[str]:
+            """Parse the server's directory listing for available peptide set filenames."""
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            return [
+                link["href"] for link in soup.find_all("a", href=True)
+                if link["href"].endswith(".txt.gz")
+            ]
+        def _download_peptide_sets(url: str, local_dir: str) -> None:
+            """Download every peptide set file listed at the server URL into local_dir."""
+            os.makedirs(local_dir, exist_ok=True)
+            filenames = _list_remote_peptide_set_files(url)
+            if not filenames:
+                raise RuntimeError(f"No peptide set files found at {url}")
+            for filename in filenames:
+                local_path = os.path.join(local_dir, filename)
+                if not os.path.isfile(local_path):
+                    download_file(f"{url.rstrip('/')}/{filename}", local_path)
+
+        if path is not None:
+            source_dir = path
+        elif _has_peptide_sets(PEPTIDE_SETS_DIR_SERVER):
+            source_dir = PEPTIDE_SETS_DIR_SERVER
+        elif _has_peptide_sets(PEPTIDE_SETS_DIR_LOCAL_DENOVO):
+            source_dir = PEPTIDE_SETS_DIR_LOCAL_DENOVO
+        else:
+            _download_peptide_sets(PEPTIDE_SETS_URL, PEPTIDE_SETS_DIR_LOCAL_DENOVO)
+            source_dir = PEPTIDE_SETS_DIR_LOCAL_DENOVO
+
+        species_sets = {}
+        for peptide_set_path in Path(source_dir).glob("*.txt.gz"):
+            species_name = peptide_set_path.name.removesuffix(".txt.gz")
+            with gzip.open(peptide_set_path, "rt") as f:
+                species_sets[species_name] = set(f.read().splitlines())
+        return species_sets
 
     def evaluate_match(
         self,
@@ -466,3 +532,30 @@ class DenovoScores(ScoreBase):
             The mass difference(s) between the given m/z values.
         """
         return mz1 - mz2 if mode_is_da else (mz1 - mz2) / mz2 * 10**6
+
+    def add_fasta_category(
+        self,
+        df: pd.DataFrame, 
+        species_sets: dict[str, set[str]], 
+        min_length: int = 8
+    ) -> pd.DataFrame:
+        def normalize_for_fasta_match(peptidoform: Peptidoform) -> Optional[str]:
+            if isinstance(peptidoform, Peptidoform):
+                return peptidoform.sequence.replace('I', 'L')
+            return None
+        
+        df = df.copy()
+        df["bare"] = df["peptidoform"].map(normalize_for_fasta_match)
+        df["category"] = "not_in_fasta"
+        
+        # Exact matching taken from IL allowed str matching
+        df.loc[df["match_type_il"]=='exact', "category"] = "correct"
+
+        incorrect = df.loc[~(df["category"]=='correct')]
+        for species, idx in incorrect.groupby("collection").groups.items():
+            peptide_set = species_sets.get(species, set())
+            bare = df.loc[idx, "bare"]
+            long_enough = bare.str.len() >= min_length
+            match = bare.isin(peptide_set) & long_enough
+            df.loc[idx[match], "category"] = "in_fasta"
+        return df

--- a/proteobench/score/denovoscores.py
+++ b/proteobench/score/denovoscores.py
@@ -10,6 +10,37 @@ from psm_utils import Peptidoform
 
 from proteobench.score.score_base import ScoreBase
 
+# Ambiguity toggle combinations for exact-mode matching. Keys double as the column-name
+# suffix used in the intermediate dataframe ("" = baseline, unsuffixed columns).
+AMBIGUITY_COMBOS = {
+    "": {"allow_il": False, "allow_deamidation": False},
+    "_il": {"allow_il": True, "allow_deamidation": False},
+    "_deam": {"allow_il": False, "allow_deamidation": True},
+    "_both": {"allow_il": True, "allow_deamidation": True},
+}
+
+
+def get_ambiguity_suffix(allow_il: bool, allow_deamidation: bool) -> str:
+    """
+    Return the intermediate-dataframe column suffix for a given ambiguity toggle state.
+
+    Parameters
+    ----------
+    allow_il : bool
+        Whether I/L are treated as equivalent in exact-mode matching.
+    allow_deamidation : bool
+        Whether deamidated Q/N are treated as equivalent to E/D in exact-mode matching.
+
+    Returns
+    -------
+    str
+        The matching key in `AMBIGUITY_COMBOS` ("", "_il", "_deam", or "_both").
+    """
+    for suffix, flags in AMBIGUITY_COMBOS.items():
+        if flags["allow_il"] == allow_il and flags["allow_deamidation"] == allow_deamidation:
+            return suffix
+    raise ValueError(f"No known ambiguity combination for allow_il={allow_il}, allow_deamidation={allow_deamidation}")
+
 
 class DenovoScores(ScoreBase):
     """
@@ -43,26 +74,56 @@ class DenovoScores(ScoreBase):
             "Y": 163.06332852985201,
             "W": 186.07931294673998,
         }
+        # UNIMOD accessions (as `.id`, an int) for the two deamidation modifications
+        # tracked elsewhere in the module, mapped to the residue they're isobaric with.
+        # Deamidated Q (+0.98402 Da) is isobaric with E; deamidated N is isobaric with D.
+        self.DEAMIDATION_ISOBARS = {
+            ("Q", 7): "E",
+            ("N", 7): "D",
+        }
 
     def generate_intermediate(self, filtered_df: pd.DataFrame, replicate_to_raw=None) -> pd.DataFrame:
         # TODO: Evaluate which PSMs match, and which don't and return new table
 
-        # Add match type label (exact, mass, mismatch) and the amino acid-level evaluations
-        filtered_df["match_dict"] = filtered_df.apply(
-            lambda x: self.evaluate_match(ground_truth=x["peptidoform_ground_truth"], de_novo=x["peptidoform"]), axis=1
-        )
-        filtered_df["match_type"] = filtered_df["match_dict"].apply(lambda x: x["match_type"])
-        filtered_df["aa_matches_dn"] = filtered_df["match_dict"].apply(lambda x: x["aa_matches_dn"])
-        filtered_df["aa_matches_gt"] = filtered_df["match_dict"].apply(lambda x: x["aa_matches_gt"])
-        filtered_df["aa_exact_gt"] = filtered_df["match_dict"].apply(lambda x: x["aa_exact_gt"])
-        filtered_df["aa_exact_dn"] = filtered_df["match_dict"].apply(lambda x: x["aa_exact_dn"])
-        filtered_df["pep_match"] = filtered_df["match_dict"].apply(lambda x: x["pep_match"])
-        _ = filtered_df.pop("match_dict")
+        # Add match type label (exact, mass, mismatch) and the amino acid-level evaluations,
+        # once per ambiguity toggle combination. `aa_matches_*`/`pep_match` are mass-based and
+        # therefore identical across all combinations, so they're only stored for the baseline
+        # ("") combination; `match_type`/`aa_exact_*` do depend on the toggles and are stored
+        # per combination, suffixed accordingly (baseline keeps the original, unsuffixed names).
+        for suffix, flags in AMBIGUITY_COMBOS.items():
+            match_dict = filtered_df.apply(
+                lambda x: self.evaluate_match(
+                    ground_truth=x["peptidoform_ground_truth"], de_novo=x["peptidoform"], **flags
+                ),
+                axis=1,
+            )
+            filtered_df[f"match_type{suffix}"] = match_dict.apply(lambda x: x["match_type"])
+            filtered_df[f"aa_exact_gt{suffix}"] = match_dict.apply(lambda x: x["aa_exact_gt"])
+            filtered_df[f"aa_exact_dn{suffix}"] = match_dict.apply(lambda x: x["aa_exact_dn"])
+            if suffix == "":
+                filtered_df["aa_matches_gt"] = match_dict.apply(lambda x: x["aa_matches_gt"])
+                filtered_df["aa_matches_dn"] = match_dict.apply(lambda x: x["aa_matches_dn"])
+                filtered_df["pep_match"] = match_dict.apply(lambda x: x["pep_match"])
         return filtered_df
 
-    def evaluate_match(self, ground_truth: Peptidoform, de_novo: Peptidoform):
+    def evaluate_match(
+        self,
+        ground_truth: Peptidoform,
+        de_novo: Peptidoform,
+        allow_il: bool = False,
+        allow_deamidation: bool = False,
+    ):
         """
         Return the match type between two peptide sequences.
+
+        Parameters
+        ----------
+        allow_il : bool
+            Treat I and L as equivalent when deciding per-residue and whole-peptide
+            exactness (mass-based matching is unaffected: I/L are already isomeric).
+        allow_deamidation : bool
+            Treat deamidated Q/N as equivalent to E/D when deciding exactness
+            (mass-based matching is unaffected: they're already isobaric).
         """
         gt = self.convert_peptidoform(ground_truth)
         dn = self.convert_peptidoform(de_novo)
@@ -90,17 +151,10 @@ class DenovoScores(ScoreBase):
         aa_matches, pep_match, (aa_matches_1, aa_matches_2), (exact_match_1, exact_match_2) = self.aa_match(
             gt,
             dn,
+            allow_il=allow_il,
+            allow_deamidation=allow_deamidation,
         )
-        if pep_match:
-            return {
-                "match_type": "mass",
-                "aa_matches_gt": aa_matches_1,
-                "aa_matches_dn": aa_matches_2,
-                "aa_exact_gt": exact_match_1,
-                "aa_exact_dn": exact_match_2,
-                "pep_match": pep_match,
-            }
-        else:
+        if not pep_match:
             return {
                 "match_type": "mismatch",
                 "aa_matches_gt": aa_matches_1,
@@ -110,12 +164,26 @@ class DenovoScores(ScoreBase):
                 "pep_match": pep_match,
             }
 
+        # Full mass-based alignment reached. If every aligned residue is also identity-equal
+        # under the active ambiguity toggles, this is an exact match rather than a mass-only one.
+        is_fully_exact = bool(exact_match_1.all()) and bool(exact_match_2.all())
+        return {
+            "match_type": "exact" if is_fully_exact else "mass",
+            "aa_matches_gt": aa_matches_1,
+            "aa_matches_dn": aa_matches_2,
+            "aa_exact_gt": exact_match_1,
+            "aa_exact_dn": exact_match_2,
+            "pep_match": pep_match,
+        }
+
     def aa_match(
         self,
         peptide1: List[str],
         peptide2: List[str],
         cum_mass_threshold: float = 50,
         ind_mass_threshold: float = 20,
+        allow_il: bool = False,
+        allow_deamidation: bool = False,
     ) -> Tuple[np.ndarray, bool, Tuple[np.ndarray], Tuple[np.ndarray]]:
         """
         Find the matching prefix and suffix amino acids between two peptide
@@ -128,10 +196,15 @@ class DenovoScores(ScoreBase):
         peptide2 : List[str]
             The second tokenized peptide sequence to be compared.
         cum_mass_threshold : float
-            Mass threshold in Dalton to accept cumulative mass-matching amino acid
+            Mass threshold in ppm to accept cumulative mass-matching amino acid
             sequences.
         ind_mass_threshold : float
-            Mass threshold in Dalton to accept individual mass-matching amino acids.
+            Mass threshold in ppm to accept individual mass-matching amino acids.
+        allow_il : bool
+            Treat I and L as identical when computing the per-residue exact-match flags.
+        allow_deamidation : bool
+            Treat deamidated Q/N as identical to E/D when computing the per-residue
+            exact-match flags.
 
         Returns
         -------
@@ -145,7 +218,12 @@ class DenovoScores(ScoreBase):
         """
         # Find longest mass-matching prefix.
         aa_matches, pep_match, (aa_matches_1, aa_matches_2), (aa_exact_1, aa_exact_2) = self.aa_match_prefix(
-            peptide1, peptide2, cum_mass_threshold, ind_mass_threshold
+            peptide1,
+            peptide2,
+            cum_mass_threshold,
+            ind_mass_threshold,
+            allow_il=allow_il,
+            allow_deamidation=allow_deamidation,
         )
 
         # No need to evaluate the suffixes if the sequences already fully match.
@@ -158,6 +236,16 @@ class DenovoScores(ScoreBase):
         cum_mass1, cum_mass2 = 0.0, 0.0
 
         while i1 >= i_stop and i2 >= i_stop:
+            # Exact (identity, subject to the ambiguity toggles) -- the prefix walk records
+            # this for every position it visits; the suffix walk must do the same, or any
+            # position resolved only here silently keeps its initialized `False` regardless
+            # of whether it's actually an identity match.
+            aa_str1 = self.get_token_str(peptide1[i1], allow_il=allow_il, allow_deamidation=allow_deamidation)
+            aa_str2 = self.get_token_str(peptide2[i2], allow_il=allow_il, allow_deamidation=allow_deamidation)
+            exact_match = aa_str1 == aa_str2
+            aa_exact_1[i1] = exact_match
+            aa_exact_2[i2] = exact_match
+
             aa_mass1 = self.get_token_mass(peptide1[i1])
             aa_mass2 = self.get_token_mass(peptide2[i2])
             tol_suffix = abs(self.mass_diff(cum_mass1 + aa_mass1, cum_mass2 + aa_mass2, False))
@@ -185,6 +273,8 @@ class DenovoScores(ScoreBase):
         peptide2: List[str],
         cum_mass_threshold: float = 50,
         ind_mass_threshold: float = 20,
+        allow_il: bool = False,
+        allow_deamidation: bool = False,
     ) -> Tuple[np.ndarray, bool, Tuple[np.ndarray], Tuple[np.ndarray]]:
         """
         Find the matching prefix amino acids between two peptide sequences.
@@ -196,10 +286,15 @@ class DenovoScores(ScoreBase):
         peptide2 : List[str]
             The second tokenized peptide sequence to be compared.
         cum_mass_threshold : float
-            Mass threshold in Dalton to accept cumulative mass-matching amino acid
+            Mass threshold in ppm to accept cumulative mass-matching amino acid
             sequences.
         ind_mass_threshold : float
-            Mass threshold in Dalton to accept individual mass-matching amino acids.
+            Mass threshold in ppm to accept individual mass-matching amino acids.
+        allow_il : bool
+            Treat I and L as identical when computing the per-residue exact-match flags.
+        allow_deamidation : bool
+            Treat deamidated Q/N as identical to E/D when computing the per-residue
+            exact-match flags.
 
         Returns
         -------
@@ -221,9 +316,9 @@ class DenovoScores(ScoreBase):
         # Find longest mass-matching prefix.
         i1, i2, cum_mass1, cum_mass2 = 0, 0, 0.0, 0.0
         while i1 < len(peptide1) and i2 < len(peptide2):
-            # Exact
-            aa_str1 = self.get_token_str(peptide1[i1])
-            aa_str2 = self.get_token_str(peptide2[i2])
+            # Exact (identity, subject to the ambiguity toggles)
+            aa_str1 = self.get_token_str(peptide1[i1], allow_il=allow_il, allow_deamidation=allow_deamidation)
+            aa_str2 = self.get_token_str(peptide2[i2], allow_il=allow_il, allow_deamidation=allow_deamidation)
             exact_match = aa_str1 == aa_str2
             aa_exact_1[i1] = exact_match
             aa_exact_2[i2] = exact_match
@@ -281,15 +376,31 @@ class DenovoScores(ScoreBase):
             mass += mod.mass
         return mass
 
-    def get_token_str(self, token: tuple) -> str:
+    def get_token_str(self, token: tuple, allow_il: bool = False, allow_deamidation: bool = False) -> str:
         """
         Convert the amino acid to string format including the modification if present.
+
+        Parameters
+        ----------
+        allow_il : bool
+            If True, I and L are rendered as the same canonical letter, so tokens that
+            differ only by I/L compare equal.
+        allow_deamidation : bool
+            If True, a deamidated Q or N (UNIMOD:7) is rendered as its isobaric partner
+            (E or D respectively) with the modification stripped, so it compares equal
+            to a plain, unmodified E or D token.
         """
         aa, mods = token
+        mods = [mod for mod in mods if mod is not None]
+
+        if allow_deamidation and len(mods) == 1 and (aa, mods[0].id) in self.DEAMIDATION_ISOBARS:
+            return self.DEAMIDATION_ISOBARS[(aa, mods[0].id)]
+
+        if allow_il and aa in ("I", "L"):
+            aa = "L"
+
         token_str = aa
         for mod in mods:
-            if mod is None:
-                continue
             token_str += "[{}]".format(mod.value)
         return token_str
 

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -462,6 +462,12 @@ class DeNovoUIObjects(BaseUIModule):
 
         st.plotly_chart(figs[evaluation_type], key=self.variables.fig_species_overview)
 
+    def _display_infasta_overview(self, figs) -> None:
+        with st.expander("Description"):
+            st.markdown(self.variables.texts.Description.in_fasta_overview)
+
+        st.plotly_chart(figs)
+
     def _display_indepth_plot(self, plot_name: str, figs) -> None:
         if plot_name == "ptm_overview":
             self._display_ptm_overview(figs)
@@ -471,6 +477,8 @@ class DeNovoUIObjects(BaseUIModule):
             self._display_spectrum_features(figs)
         elif plot_name == "species_overview":
             self._display_species_overview(figs)
+        elif plot_name == "in_fasta_overview":
+            self._display_infasta_overview(figs)
         else:
             raise Exception("Cannot display non-implemented in-depth plot.")
 

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -177,24 +177,36 @@ class DeNovoUIObjects(BaseUIModule):
             st.session_state.get(st.session_state.get(self.variables.radio_evaluation_id_uuid, ""), "Exact")
         ]
 
+        filtered_data = tab1.load_and_filter_main_data(
+            variables=self.variables, ionmodule=self.ionmodule, use_slider=False
+        )
+
+        if filtered_data.empty:
+            st.info("No results available yet.", icon="ℹ️")
+            return
+
+        plot_params = {
+            "label": st.session_state.get(st.session_state.get(self.variables.selectbox_id_uuid, ""), "None"),
+            "level": self.level_mapping[
+                st.session_state.get(st.session_state.get(self.variables.radio_level_id_uuid, ""), "Precision")
+            ],
+            "evaluation_type": evaluation_type,
+            "allow_il": allow_il,
+            "allow_deamidation": allow_deamidation,
+            "colorblind_mode": colorblind_mode,
+            "alpha_warning": getattr(self.variables, "alpha_warning", False),
+            "beta_warning": getattr(self.variables, "beta_warning", False),
+        }
+
+        # Only the figure switches between these two tabs -- the results table below is
+        # shared and stays visible regardless of which one is selected.
         view_tabs = st.tabs(["Scatter", "Precision-Coverage Curves"])
         with view_tabs[0]:
-            filtered_data = tab1.display_existing_results(
+            tab1.render_main_plot(
                 variables=self.variables,
                 ionmodule=self.ionmodule,
-                plot_params={
-                    "label": st.session_state.get(st.session_state.get(self.variables.selectbox_id_uuid, ""), "None"),
-                    "level": self.level_mapping[
-                        st.session_state.get(st.session_state.get(self.variables.radio_level_id_uuid, ""), "Precision")
-                    ],
-                    "evaluation_type": evaluation_type,
-                    "allow_il": allow_il,
-                    "allow_deamidation": allow_deamidation,
-                    "colorblind_mode": colorblind_mode,
-                    "alpha_warning": getattr(self.variables, "alpha_warning", False),
-                    "beta_warning": getattr(self.variables, "beta_warning", False),
-                },
-                use_slider=False,
+                plot_params=plot_params,
+                filtered_data=filtered_data,
             )
         with view_tabs[1]:
             self._display_precision_coverage_curves(
@@ -204,6 +216,8 @@ class DeNovoUIObjects(BaseUIModule):
                 allow_deamidation=allow_deamidation,
                 fig_key_uuid=self.variables.fig_pc_curve,
             )
+
+        tab1.render_results_table(variables=self.variables, filtered_data=filtered_data)
 
     def _display_precision_coverage_curves(
         self,
@@ -563,20 +577,26 @@ class DeNovoUIObjects(BaseUIModule):
             st.session_state.get(st.session_state.get(self.variables.radio_evaluation_id_submitted_uuid, ""), "Exact")
         ]
 
-        # Plot the datapoints
+        # Load once, then only the figure switches between the two tabs below -- the
+        # results table stays outside the switcher, visible regardless of which is selected.
+        filtered_data = tab4.load_and_filter_submitted_data(variables=self.variables, ionmodule=self.ionmodule)
+
+        plot_params = {
+            "label": label,
+            "level": level,
+            "evaluation_type": evaluation_type,
+            "allow_il": allow_il,
+            "allow_deamidation": allow_deamidation,
+            "colorblind_mode": colorblind_mode,
+        }
+
         view_tabs = st.tabs(["Scatter", "Precision-Coverage Curves"])
         with view_tabs[0]:
-            filtered_data = tab4.display_submitted_results(
-                self.variables,
-                self.ionmodule,
-                plot_params={
-                    "label": label,
-                    "level": level,
-                    "evaluation_type": evaluation_type,
-                    "allow_il": allow_il,
-                    "allow_deamidation": allow_deamidation,
-                    "colorblind_mode": colorblind_mode,
-                },
+            tab4.render_submitted_main_plot(
+                variables=self.variables,
+                ionmodule=self.ionmodule,
+                plot_params=plot_params,
+                filtered_data=filtered_data,
             )
         with view_tabs[1]:
             self._display_precision_coverage_curves(
@@ -586,6 +606,8 @@ class DeNovoUIObjects(BaseUIModule):
                 allow_deamidation=allow_deamidation,
                 fig_key_uuid=self.variables.fig_pc_curve_submitted,
             )
+
+        tab4.render_submitted_results_table(filtered_data, self.variables)
 
         st.session_state[self.variables.table_id_uuid] = uuid.uuid4()
         st.data_editor(

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -335,7 +335,7 @@ class DeNovoUIObjects(BaseUIModule):
             options=dataset_options,
             key=st.session_state[self.variables.dataset_selector_id_uuid],
             format_func=lambda x: x[0],
-            default=[dataset_options[0]],
+            default=dataset_options,
             help=self.variables.texts.Help.dataset_selection_indepth,
         )
 

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -609,12 +609,12 @@ class DeNovoUIObjects(BaseUIModule):
 
         tab4.render_submitted_results_table(filtered_data, self.variables)
 
-        st.session_state[self.variables.table_id_uuid] = uuid.uuid4()
-        st.data_editor(
-            st.session_state[self.variables.all_datapoints_submitted],
-            key=st.session_state[self.variables.table_id_uuid],
-            on_change=self._handle_submitted_table_edits,
-        )
+        # st.session_state[self.variables.table_id_uuid] = uuid.uuid4()
+        # st.data_editor(
+        #     st.session_state[self.variables.all_datapoints_submitted],
+        #     key=st.session_state[self.variables.table_id_uuid],
+        #     on_change=self._handle_submitted_table_edits,
+        # )
 
         st.title("Public submission")
         st.markdown(

--- a/webinterface/pages/base_pages/denovo.py
+++ b/webinterface/pages/base_pages/denovo.py
@@ -80,8 +80,8 @@ class DeNovoUIObjects(BaseUIModule):
         )
 
         # Specific to the 'de novo' module.
-        self.level_mapping = {"Precision": "precision", "Recall": "recall"}
-        self.level_mapping_submitted = {"Precision": "precision", "Recall": "recall"}
+        self.level_mapping = {"Precision": "precision", "AUC": "auc"}
+        self.level_mapping_submitted = {"Precision": "precision", "AUC": "auc"}
         self.evaluation_type_mapping = {"Exact": "exact", "Mass-based": "mass"}
 
     @st.fragment
@@ -95,7 +95,7 @@ class DeNovoUIObjects(BaseUIModule):
             default_value="None",
         )
 
-        # Radio for level (Precision or Recall)
+        # Radio for level (Precision or AUC)
         tab1.initialize_radio(
             radio_id_uuid=self.variables.radio_level_id_uuid, default_value=self.variables.default_level
         )
@@ -105,6 +105,12 @@ class DeNovoUIObjects(BaseUIModule):
             radio_id_uuid=self.variables.radio_evaluation_id_uuid, default_value=self.variables.default_evaluation
         )
 
+        def current_evaluation_type() -> str:
+            evaluation_choice = st.session_state.get(
+                st.session_state.get(self.variables.radio_evaluation_id_uuid, ""), self.variables.default_evaluation
+            )
+            return self.evaluation_type_mapping[evaluation_choice]
+
         # Define callbacks for plot options
         def render_selectbox():
             tab1.generate_main_selectbox(self.variables, selectbox_id_uuid=self.variables.selectbox_id_uuid)
@@ -113,7 +119,7 @@ class DeNovoUIObjects(BaseUIModule):
             tab1.generate_main_radio(
                 radio_id_uuid=self.variables.radio_level_id_uuid,
                 description="Select the classification metric",
-                options=["Precision", "Recall"],
+                options=["Precision", "AUC"],
                 help=self.variables.texts.Help.radio_level,
             )
 
@@ -128,34 +134,107 @@ class DeNovoUIObjects(BaseUIModule):
         def render_colorblind_selector():
             return tab1.display_colorblindmode_selector(self.variables)
 
+        def render_il_toggle():
+            is_mass_mode = current_evaluation_type() == "mass"
+            return tab1.generate_forced_toggle(
+                toggle_id_uuid=self.variables.il_toggle_id_uuid,
+                label="Allow I/L mismatches",
+                default=True,
+                force_value=True if is_mass_mode else None,
+                help=self.variables.texts.Help.toggle_il,
+            )
+
+        def render_deamidation_toggle():
+            is_mass_mode = current_evaluation_type() == "mass"
+            return tab1.generate_forced_toggle(
+                toggle_id_uuid=self.variables.deamidation_toggle_id_uuid,
+                label="Allow deamidation mismatches (Q↔E, N↔D)",
+                default=False,
+                force_value=True if is_mass_mode else None,
+                help=self.variables.texts.Help.toggle_deamidation,
+            )
+
         # Render plot options expander
         results = self.render_plot_options_expander(
             filter_callbacks=[render_selectbox],
-            selector_callbacks=[render_level_radio, render_evaluation_radio, render_colorblind_selector],
+            selector_callbacks=[
+                render_level_radio,
+                render_evaluation_radio,
+                render_colorblind_selector,
+                render_il_toggle,
+                render_deamidation_toggle,
+            ],
             filter_cols_spec=1,
-            selector_cols_spec=[1, 1, 1, 1],
+            selector_cols_spec=[1, 1, 1, 1, 1],
         )
 
-        # Extract colorblind mode from results
+        # Extract toggle values from results (index 0 is the filter/selectbox callback,
+        # which returns None; indices 1-5 are the selector callbacks in the order above).
         colorblind_mode = results[3] if len(results) > 3 else False
+        allow_il = results[4] if len(results) > 4 else True
+        allow_deamidation = results[5] if len(results) > 5 else False
+        evaluation_type = self.evaluation_type_mapping[
+            st.session_state.get(st.session_state.get(self.variables.radio_evaluation_id_uuid, ""), "Exact")
+        ]
 
-        tab1.display_existing_results(
-            variables=self.variables,
-            ionmodule=self.ionmodule,
-            plot_params={
-                "label": st.session_state.get(st.session_state.get(self.variables.selectbox_id_uuid, ""), "None"),
-                "level": self.level_mapping[
-                    st.session_state.get(st.session_state.get(self.variables.radio_level_id_uuid, ""), "Precision")
-                ],
-                "evaluation_type": self.evaluation_type_mapping[
-                    st.session_state.get(st.session_state.get(self.variables.radio_evaluation_id_uuid, ""), "Exact")
-                ],
-                "colorblind_mode": colorblind_mode,
-                "alpha_warning": getattr(self.variables, "alpha_warning", False),
-                "beta_warning": getattr(self.variables, "beta_warning", False),
-            },
-            use_slider=False,
-        )
+        view_tabs = st.tabs(["Scatter", "Precision-Coverage Curves"])
+        with view_tabs[0]:
+            filtered_data = tab1.display_existing_results(
+                variables=self.variables,
+                ionmodule=self.ionmodule,
+                plot_params={
+                    "label": st.session_state.get(st.session_state.get(self.variables.selectbox_id_uuid, ""), "None"),
+                    "level": self.level_mapping[
+                        st.session_state.get(st.session_state.get(self.variables.radio_level_id_uuid, ""), "Precision")
+                    ],
+                    "evaluation_type": evaluation_type,
+                    "allow_il": allow_il,
+                    "allow_deamidation": allow_deamidation,
+                    "colorblind_mode": colorblind_mode,
+                    "alpha_warning": getattr(self.variables, "alpha_warning", False),
+                    "beta_warning": getattr(self.variables, "beta_warning", False),
+                },
+                use_slider=False,
+            )
+        with view_tabs[1]:
+            self._display_precision_coverage_curves(
+                filtered_data=filtered_data,
+                evaluation_type=evaluation_type,
+                allow_il=allow_il,
+                allow_deamidation=allow_deamidation,
+                fig_key_uuid=self.variables.fig_pc_curve,
+            )
+
+    def _display_precision_coverage_curves(
+        self,
+        filtered_data: Optional[pd.DataFrame],
+        evaluation_type: str,
+        allow_il: bool,
+        allow_deamidation: bool,
+        fig_key_uuid: str,
+    ) -> None:
+        """
+        Render the peptide-level/amino-acid-level precision-coverage curve view, sharing the
+        same filtered dataset and evaluation/ambiguity selections as the scatter view in the
+        adjacent tab.
+        """
+        if filtered_data is None or filtered_data.empty:
+            st.info("No results available yet.", icon="ℹ️")
+            return
+
+        try:
+            plot_generator = self.ionmodule.get_plot_generator()
+            fig = plot_generator.plot_precision_coverage_curves(
+                result_df=filtered_data,
+                evaluation_type=evaluation_type,
+                allow_il=allow_il,
+                allow_deamidation=allow_deamidation,
+            )
+            if fig_key_uuid not in st.session_state:
+                st.session_state[fig_key_uuid] = uuid.uuid4()
+            st.plotly_chart(fig, key=st.session_state[fig_key_uuid])
+        except Exception as e:
+            st.error(f"Unable to plot the precision-coverage curves: {e}", icon="🚨")
 
     def display_submission_form(self) -> None:
         """Create the main submission form for the Streamlit UI in Tab 2."""
@@ -247,7 +326,6 @@ class DeNovoUIObjects(BaseUIModule):
         )
 
         # Use default values for plot rendering (no user controls on this tab)
-        levels = ["precision", "recall"]
         evaluation_types = ["exact", "mass"]
         colorblind_mode = False
 
@@ -283,7 +361,6 @@ class DeNovoUIObjects(BaseUIModule):
             plot_kwargs = {
                 "mod_labels": modifications,
                 "feature": feature_names,
-                "level": levels,
                 "evaluation_type": evaluation_types,
                 "colorblind_mode": colorblind_mode,
             }
@@ -394,7 +471,7 @@ class DeNovoUIObjects(BaseUIModule):
             default_value="None",
         )
 
-        # Radio one for precision or recall
+        # Radio one for precision or AUC
         tab1.initialize_radio(
             radio_id_uuid=self.variables.radio_level_id_submitted_uuid, default_value=self.variables.default_level
         )
@@ -404,6 +481,13 @@ class DeNovoUIObjects(BaseUIModule):
             radio_id_uuid=self.variables.radio_evaluation_id_submitted_uuid,
             default_value=self.variables.default_evaluation,
         )
+
+        def current_evaluation_type() -> str:
+            evaluation_choice = st.session_state.get(
+                st.session_state.get(self.variables.radio_evaluation_id_submitted_uuid, ""),
+                self.variables.default_evaluation,
+            )
+            return self.evaluation_type_mapping[evaluation_choice]
 
         # Define callbacks for plot options
         def render_selectbox():
@@ -415,7 +499,7 @@ class DeNovoUIObjects(BaseUIModule):
             tab1.generate_main_radio(
                 radio_id_uuid=self.variables.radio_level_id_submitted_uuid,
                 description="Select the classification metric",
-                options=["Precision", "Recall"],
+                options=["Precision", "AUC"],
                 help=self.variables.texts.Help.radio_level,
             )
 
@@ -430,16 +514,45 @@ class DeNovoUIObjects(BaseUIModule):
         def render_colorblind_selector():
             return tab1.display_colorblindmode_selector(self.variables, use_submitted=True)
 
+        def render_il_toggle():
+            is_mass_mode = current_evaluation_type() == "mass"
+            return tab1.generate_forced_toggle(
+                toggle_id_uuid=self.variables.il_toggle_id_submitted_uuid,
+                label="Allow I/L mismatches",
+                default=True,
+                force_value=True if is_mass_mode else None,
+                help=self.variables.texts.Help.toggle_il,
+            )
+
+        def render_deamidation_toggle():
+            is_mass_mode = current_evaluation_type() == "mass"
+            return tab1.generate_forced_toggle(
+                toggle_id_uuid=self.variables.deamidation_toggle_id_submitted_uuid,
+                label="Allow deamidation mismatches (Q↔E, N↔D)",
+                default=False,
+                force_value=True if is_mass_mode else None,
+                help=self.variables.texts.Help.toggle_deamidation,
+            )
+
         # Render plot options expander
         results = self.render_plot_options_expander(
             filter_callbacks=[render_selectbox],
-            selector_callbacks=[render_level_radio, render_evaluation_radio, render_colorblind_selector],
+            selector_callbacks=[
+                render_level_radio,
+                render_evaluation_radio,
+                render_colorblind_selector,
+                render_il_toggle,
+                render_deamidation_toggle,
+            ],
             filter_cols_spec=1,
-            selector_cols_spec=[1, 1, 1, 1],
+            selector_cols_spec=[1, 1, 1, 1, 1],
         )
 
-        # Extract colorblind mode from results
+        # Extract toggle values from results (index 0 is the filter/selectbox callback,
+        # which returns None; indices 1-5 are the selector callbacks in the order above).
         colorblind_mode = results[3] if len(results) > 3 else False
+        allow_il = results[4] if len(results) > 4 else True
+        allow_deamidation = results[5] if len(results) > 5 else False
 
         # Get current selections from session state
         label = st.session_state.get(st.session_state.get(self.variables.selectbox_id_submitted_uuid, ""), "None")
@@ -451,16 +564,29 @@ class DeNovoUIObjects(BaseUIModule):
         ]
 
         # Plot the datapoints
-        tab4.display_submitted_results(
-            self.variables,
-            self.ionmodule,
-            plot_params={
-                "label": label,
-                "level": level,
-                "evaluation_type": evaluation_type,
-                "colorblind_mode": colorblind_mode,
-            },
-        )
+        view_tabs = st.tabs(["Scatter", "Precision-Coverage Curves"])
+        with view_tabs[0]:
+            filtered_data = tab4.display_submitted_results(
+                self.variables,
+                self.ionmodule,
+                plot_params={
+                    "label": label,
+                    "level": level,
+                    "evaluation_type": evaluation_type,
+                    "allow_il": allow_il,
+                    "allow_deamidation": allow_deamidation,
+                    "colorblind_mode": colorblind_mode,
+                },
+            )
+        with view_tabs[1]:
+            self._display_precision_coverage_curves(
+                filtered_data=filtered_data,
+                evaluation_type=evaluation_type,
+                allow_il=allow_il,
+                allow_deamidation=allow_deamidation,
+                fig_key_uuid=self.variables.fig_pc_curve_submitted,
+            )
+
         st.session_state[self.variables.table_id_uuid] = uuid.uuid4()
         st.data_editor(
             st.session_state[self.variables.all_datapoints_submitted],
@@ -671,13 +797,25 @@ class DeNovoUIObjects(BaseUIModule):
             # Get plot generator from module (following Quant pattern)
             plot_generator = self.ionmodule.get_plot_generator()
 
-            # Get colorblind mode from session state
+            # Get colorblind mode and ambiguity toggle states from session state
             colorblind_key = self.variables.colorblind_mode_selector_uuid
             if colorblind_key in st.session_state:
                 colorblind_mode_id = st.session_state[colorblind_key]
                 colorblind_mode = st.session_state.get(colorblind_mode_id, False)
             else:
                 colorblind_mode = False
+
+            il_key = self.variables.il_toggle_id_uuid
+            allow_il = (
+                st.session_state.get(st.session_state.get(il_key, ""), True) if il_key in st.session_state else True
+            )
+
+            deamidation_key = self.variables.deamidation_toggle_id_uuid
+            allow_deamidation = (
+                st.session_state.get(st.session_state.get(deamidation_key, ""), False)
+                if deamidation_key in st.session_state
+                else False
+            )
 
             fig_metric = plot_generator.plot_main_metric(
                 result_df=st.session_state[self.variables.all_datapoints],
@@ -687,6 +825,8 @@ class DeNovoUIObjects(BaseUIModule):
                 evaluation_type=self.evaluation_type_mapping[
                     st.session_state[st.session_state[self.variables.radio_evaluation_id_uuid]]
                 ],
+                allow_il=allow_il,
+                allow_deamidation=allow_deamidation,
                 colorblind_mode=colorblind_mode,
             )
         except Exception as e:

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -198,6 +198,51 @@ def display_colorblindmode_selector(variables, use_submitted: bool = False) -> s
     )
 
 
+def generate_forced_toggle(
+    toggle_id_uuid: str,
+    label: str,
+    default: bool,
+    force_value: Optional[bool] = None,
+    help: Optional[str] = None,
+) -> bool:
+    """Render a toggle widget that can be forced to a fixed value and disabled.
+
+    Parameters
+    ----------
+    toggle_id_uuid : str
+        Session-state key holding this widget's UUID (created on first use).
+    label : str
+        Widget label.
+    default : bool
+        Default (first-render) checked state.
+    force_value : Optional[bool], optional
+        If not None, the widget is shown at this value and disabled, overriding whatever
+        the user previously set -- used when the toggle is meaningless under the current
+        mode (e.g. an ambiguity toggle while Mass-based evaluation is selected).
+    help : str, optional
+        Widget help/tooltip text.
+
+    Returns
+    -------
+    bool
+        The toggle's current (possibly forced) value.
+    """
+    if toggle_id_uuid not in st.session_state.keys():
+        st.session_state[toggle_id_uuid] = uuid.uuid4()
+    widget_key = st.session_state[toggle_id_uuid]
+
+    if force_value is not None:
+        st.session_state[widget_key] = force_value
+
+    return st.toggle(
+        label,
+        value=default,
+        help=help,
+        key=widget_key,
+        disabled=force_value is not None,
+    )
+
+
 def filter_data_if_applicable(variables, ionmodule, use_slider: bool = True) -> pd.DataFrame:
     """
     Filter data using module-specific filtering logic.
@@ -353,7 +398,7 @@ def display_existing_results(
     table_style: str = "aggrid",
     column_config: Optional[Dict] = None,
     render_forest_plot=None,
-) -> None:
+) -> Optional[pd.DataFrame]:
     """
     Main orchestration function for Tab 1: plot + interactive table with bidirectional
     highlight synchronisation.
@@ -379,6 +424,13 @@ def display_existing_results(
     render_forest_plot : callable, optional
         Optional callable that renders an additional plot (e.g. a forest plot)
         between the scatter plot and the results table.
+
+    Returns
+    -------
+    Optional[pd.DataFrame]
+        The filtered dataframe used to render the plot and table (after slider/parameter
+        filtering), so a caller can reuse it for an alternative view of the same selection
+        (e.g. de novo's precision-coverage-curve tab). `None` if nothing has been rendered yet.
     """
     initialize_main_data_points(variables, ionmodule)
     filtered_data = filter_data_if_applicable(variables, ionmodule, use_slider)
@@ -390,7 +442,7 @@ def display_existing_results(
 
     if filtered_data.empty:
         st.info("No results available yet.", icon="ℹ️")
-        return
+        return filtered_data
 
     # Get plot generator from module
     plot_generator = ionmodule.get_plot_generator(y_axis_title=getattr(variables, "y_axis_title", None))
@@ -482,3 +534,5 @@ def display_existing_results(
     # Display download section
     with st.container(key="tour_download_section"):
         display_download_section(variables)
+
+    return filtered_data

--- a/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
+++ b/webinterface/pages/base_pages/tabs/tab1_view_public_results.py
@@ -390,21 +390,47 @@ def display_download_section(variables, sort_by: str = "id") -> None:
         )
 
 
-def display_existing_results(
+def load_and_filter_main_data(variables, ionmodule, use_slider: bool = True) -> pd.DataFrame:
+    """
+    Load, slider/parameter-filter, and open-source-annotate the main (public) datapoints
+    table for Tab 1 -- the data-loading half of `display_existing_results`, exposed
+    separately so a caller can render more than one view (e.g. a plot *and* an alternative
+    plot behind a tab switcher) off the same filtered selection without loading it twice.
+
+    Parameters
+    ----------
+    variables : object
+        Variables object containing session state keys and configuration.
+    ionmodule : object
+        The module instance (Quant, De Novo, etc.).
+    use_slider : bool, optional
+        Whether to use slider-based filtering (default True for Quant).
+
+    Returns
+    -------
+    pd.DataFrame
+        The filtered dataframe (empty if there's nothing to show yet).
+    """
+    initialize_main_data_points(variables, ionmodule)
+    filtered_data = filter_data_if_applicable(variables, ionmodule, use_slider)
+    filtered_data = add_open_source_column(filtered_data)
+    # Apply parameter-based filters (key_prefix must be unique per module page)
+    filtered_data = generate_parameter_filters(filtered_data, key_prefix=f"param_filter_{variables.all_datapoints}")
+    return filtered_data
+
+
+def render_main_plot(
     variables,
     ionmodule,
     plot_params: Dict[str, Any],
-    use_slider: bool = True,
-    table_style: str = "aggrid",
-    column_config: Optional[Dict] = None,
+    filtered_data: pd.DataFrame,
     render_forest_plot=None,
-) -> Optional[pd.DataFrame]:
+) -> None:
     """
-    Main orchestration function for Tab 1: plot + interactive table with bidirectional
-    highlight synchronisation.
-
-    Clicking a point in the scatter plot highlights the matching row in the table.
-    Clicking a row in the table highlights the matching point in the scatter plot.
+    Render Tab 1's main scatter/metric plot, with click-to-highlight against the table
+    rendered separately by `render_results_table` (both read/write the same highlight
+    session-state key, so they stay in sync even when rendered in different containers,
+    e.g. one inside a tab switcher and the other outside it).
 
     Parameters
     ----------
@@ -415,36 +441,12 @@ def display_existing_results(
     plot_params : Dict[str, Any]
         Module-specific plotting parameters passed straight through to render_metric_plot
         (and on to plot_main_metric). alpha_warning and beta_warning are consumed here.
-    use_slider : bool, optional
-        Whether to use slider-based filtering (default True for Quant).
-    table_style : str, optional
-        Reserved; AgGrid is always used.
-    column_config : Optional[Dict], optional
-        Reserved for future st.dataframe column configuration.
+    filtered_data : pd.DataFrame
+        The dataframe to plot, as returned by `load_and_filter_main_data`.
     render_forest_plot : callable, optional
         Optional callable that renders an additional plot (e.g. a forest plot)
-        between the scatter plot and the results table.
-
-    Returns
-    -------
-    Optional[pd.DataFrame]
-        The filtered dataframe used to render the plot and table (after slider/parameter
-        filtering), so a caller can reuse it for an alternative view of the same selection
-        (e.g. de novo's precision-coverage-curve tab). `None` if nothing has been rendered yet.
+        directly below the main plot.
     """
-    initialize_main_data_points(variables, ionmodule)
-    filtered_data = filter_data_if_applicable(variables, ionmodule, use_slider)
-
-    filtered_data = add_open_source_column(filtered_data)
-
-    # Apply parameter-based filters (key_prefix must be unique per module page)
-    filtered_data = generate_parameter_filters(filtered_data, key_prefix=f"param_filter_{variables.all_datapoints}")
-
-    if filtered_data.empty:
-        st.info("No results available yet.", icon="ℹ️")
-        return filtered_data
-
-    # Get plot generator from module
     plot_generator = ionmodule.get_plot_generator(y_axis_title=getattr(variables, "y_axis_title", None))
 
     # --- Session state keys for bidirectional selection ---
@@ -501,7 +503,28 @@ def display_existing_results(
     if render_forest_plot is not None:
         render_forest_plot()
 
-    # --- Render table via shared utilities ---
+
+def render_results_table(variables, filtered_data: pd.DataFrame) -> None:
+    """
+    Render Tab 1's "Benchmark Results" table and download section, using whichever ID is
+    currently highlighted (set by `render_main_plot` or by a row click here) -- kept as its
+    own function so it can be rendered once regardless of how many alternative plots a page
+    switches between (see `render_main_plot`'s docstring).
+
+    Parameters
+    ----------
+    variables : object
+        Variables object containing session state keys and configuration.
+    filtered_data : pd.DataFrame
+        The dataframe to display, as returned by `load_and_filter_main_data`.
+    """
+    highlight_key = f"{variables.fig_metric}_tab1_highlight_id"
+    agrid_key_id = f"{variables.fig_metric}_tab1_aggrid_key"
+
+    if agrid_key_id not in st.session_state:
+        st.session_state[agrid_key_id] = uuid.uuid4()
+    highlight_id = st.session_state.get(highlight_key, None)
+
     with st.container(key="tour_results_table"):
         st.subheader("Benchmark Results")
         df_display = prepare_display_dataframe(filtered_data, highlight_id)
@@ -534,5 +557,62 @@ def display_existing_results(
     # Display download section
     with st.container(key="tour_download_section"):
         display_download_section(variables)
+
+
+def display_existing_results(
+    variables,
+    ionmodule,
+    plot_params: Dict[str, Any],
+    use_slider: bool = True,
+    table_style: str = "aggrid",
+    column_config: Optional[Dict] = None,
+    render_forest_plot=None,
+) -> Optional[pd.DataFrame]:
+    """
+    Main orchestration function for Tab 1: plot + interactive table with bidirectional
+    highlight synchronisation.
+
+    Clicking a point in the scatter plot highlights the matching row in the table.
+    Clicking a row in the table highlights the matching point in the scatter plot.
+
+    A thin wrapper around `load_and_filter_main_data` + `render_main_plot` +
+    `render_results_table` -- callers that need the plot and table in separate containers
+    (e.g. de novo's Scatter/Precision-Coverage-Curves tab switcher, where only the plot
+    should swap and the table should stay put) can call those three directly instead.
+
+    Parameters
+    ----------
+    variables : object
+        Variables object containing session state keys and configuration.
+    ionmodule : object
+        The module instance (Quant, De Novo, etc.).
+    plot_params : Dict[str, Any]
+        Module-specific plotting parameters passed straight through to render_metric_plot
+        (and on to plot_main_metric). alpha_warning and beta_warning are consumed here.
+    use_slider : bool, optional
+        Whether to use slider-based filtering (default True for Quant).
+    table_style : str, optional
+        Reserved; AgGrid is always used.
+    column_config : Optional[Dict], optional
+        Reserved for future st.dataframe column configuration.
+    render_forest_plot : callable, optional
+        Optional callable that renders an additional plot (e.g. a forest plot)
+        between the scatter plot and the results table.
+
+    Returns
+    -------
+    Optional[pd.DataFrame]
+        The filtered dataframe used to render the plot and table (after slider/parameter
+        filtering), so a caller can reuse it for an alternative view of the same selection
+        (e.g. de novo's precision-coverage-curve tab). `None` if nothing has been rendered yet.
+    """
+    filtered_data = load_and_filter_main_data(variables, ionmodule, use_slider)
+
+    if filtered_data.empty:
+        st.info("No results available yet.", icon="ℹ️")
+        return filtered_data
+
+    render_main_plot(variables, ionmodule, plot_params, filtered_data, render_forest_plot=render_forest_plot)
+    render_results_table(variables, filtered_data)
 
     return filtered_data

--- a/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
+++ b/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
@@ -170,7 +170,7 @@ def display_submitted_results(
     table_style: str = "dataframe",
     column_config: Optional[Dict] = None,
     render_forest_plot=None,
-) -> None:
+) -> Optional[pd.DataFrame]:
     """
     Display submitted benchmark results with plot and table.
 
@@ -191,6 +191,13 @@ def display_submitted_results(
     render_forest_plot : callable, optional
         Optional callable that renders an additional plot (e.g. a forest plot)
         between the scatter plot and the results table.
+
+    Returns
+    -------
+    Optional[pd.DataFrame]
+        The filtered dataframe used to render the plot and table, so a caller can reuse it
+        for an alternative view of the same selection (e.g. de novo's precision-coverage-curve
+        tab).
     """
     # Initialize submitted data
     initialize_submitted_data_points(variables, ionmodule)
@@ -241,3 +248,5 @@ def display_submitted_results(
 
     # Render results table (same styled grid as Tab 1)
     render_submitted_results_table(filtered_data, variables)
+
+    return filtered_data

--- a/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
+++ b/webinterface/pages/base_pages/tabs/tab4_view_public_and_new_results.py
@@ -163,6 +163,98 @@ def render_submitted_results_table(data: pd.DataFrame, variables) -> None:
     )
 
 
+def load_and_filter_submitted_data(variables, ionmodule) -> pd.DataFrame:
+    """
+    Load, slider/parameter-filter, and open-source-annotate the submitted (public + new)
+    datapoints table for Tab 4 -- the data-loading half of `display_submitted_results`,
+    exposed separately so a caller can render more than one view (e.g. a plot *and* an
+    alternative plot behind a tab switcher) off the same filtered selection without loading
+    it twice.
+
+    Parameters
+    ----------
+    variables : object
+        Variables object containing session state keys and configuration.
+    ionmodule : object
+        The module instance (Quant, De Novo, etc.).
+
+    Returns
+    -------
+    pd.DataFrame
+        The filtered dataframe, with the newly-submitted row (if any) pinned so it survives
+        all filters.
+    """
+    initialize_submitted_data_points(variables, ionmodule)
+
+    filtered_data = filter_submitted_data_if_applicable(variables, ionmodule, use_slider=True)
+    filtered_data = add_open_source_column(filtered_data)
+
+    # Pin the newly submitted row so it survives all filters
+    pinned = (
+        filtered_data.index[filtered_data.get("old_new", pd.Series(dtype=str)) == "new"]
+        if "old_new" in filtered_data.columns
+        else None
+    )
+    filtered_data = generate_parameter_filters(
+        filtered_data,
+        key_prefix=f"param_filter_{variables.all_datapoints_submitted}",
+        pinned_indices=pinned,
+    )
+    return filtered_data
+
+
+def render_submitted_main_plot(
+    variables,
+    ionmodule,
+    plot_params: Dict[str, Any],
+    filtered_data: pd.DataFrame,
+    render_forest_plot=None,
+) -> None:
+    """
+    Render Tab 4's main scatter/metric plot, kept separate from `render_submitted_results_table`
+    so a caller can put them in different containers (e.g. one inside a tab switcher and the
+    other outside it).
+
+    Parameters
+    ----------
+    variables : object
+        Variables object containing session state keys and configuration.
+    ionmodule : object
+        The module instance (Quant, De Novo, etc.).
+    plot_params : Dict[str, Any]
+        Module-specific plotting parameters.
+    filtered_data : pd.DataFrame
+        The dataframe to plot, as returned by `load_and_filter_submitted_data`.
+    render_forest_plot : callable, optional
+        Optional callable that renders an additional plot (e.g. a forest plot)
+        directly below the main plot.
+    """
+    plot_generator = ionmodule.get_plot_generator(y_axis_title=getattr(variables, "y_axis_title", None))
+
+    fig_key = variables.fig_metric_submitted if hasattr(variables, "fig_metric_submitted") else "submitted_plot"
+    if fig_key not in st.session_state:
+        st.session_state[fig_key] = uuid.uuid4()
+    plot_uuid = st.session_state[fig_key]
+
+    with st.container(key="tour_submitted_plot"):
+        try:
+            fig = plot_generator.plot_main_metric(
+                result_df=filtered_data,
+                hide_annot=plot_params.get("hide_annot", False),
+                **plot_params,
+            )
+            st.plotly_chart(fig, key=plot_uuid)
+        except Exception as e:
+            st.error(f"Unable to plot the datapoints: {e}", icon="🚨")
+            import traceback
+
+            with st.expander("Error details"):
+                st.code(traceback.format_exc())
+
+    if render_forest_plot is not None:
+        render_forest_plot()
+
+
 def display_submitted_results(
     variables,
     ionmodule,
@@ -175,6 +267,11 @@ def display_submitted_results(
     Display submitted benchmark results with plot and table.
 
     This is the main entry point for Tab 4, working across all module types.
+
+    A thin wrapper around `load_and_filter_submitted_data` + `render_submitted_main_plot` +
+    `render_submitted_results_table` -- callers that need the plot and table in separate
+    containers (e.g. de novo's Scatter/Precision-Coverage-Curves tab switcher, where only the
+    plot should swap and the table should stay put) can call those three directly instead.
 
     Parameters
     ----------
@@ -199,52 +296,9 @@ def display_submitted_results(
         for an alternative view of the same selection (e.g. de novo's precision-coverage-curve
         tab).
     """
-    # Initialize submitted data
-    initialize_submitted_data_points(variables, ionmodule)
+    filtered_data = load_and_filter_submitted_data(variables, ionmodule)
 
-    # Filter data using slider if applicable
-    filtered_data = filter_submitted_data_if_applicable(variables, ionmodule, use_slider=True)
-    filtered_data = add_open_source_column(filtered_data)
-
-    # Pin the newly submitted row so it survives all filters
-    pinned = (
-        filtered_data.index[filtered_data.get("old_new", pd.Series(dtype=str)) == "new"]
-        if "old_new" in filtered_data.columns
-        else None
-    )
-    filtered_data = generate_parameter_filters(
-        filtered_data,
-        key_prefix=f"param_filter_{variables.all_datapoints_submitted}",
-        pinned_indices=pinned,
-    )
-
-    # Get plot generator from module
-    plot_generator = ionmodule.get_plot_generator(y_axis_title=getattr(variables, "y_axis_title", None))
-
-    # Prepare plot key
-    fig_key = variables.fig_metric_submitted if hasattr(variables, "fig_metric_submitted") else "submitted_plot"
-    if fig_key not in st.session_state:
-        st.session_state[fig_key] = uuid.uuid4()
-    plot_uuid = st.session_state[fig_key]
-
-    with st.container(key="tour_submitted_plot"):
-        try:
-            # Generate plot using plot_generator interface
-            fig = plot_generator.plot_main_metric(
-                result_df=filtered_data,
-                hide_annot=plot_params.get("hide_annot", False),
-                **plot_params,
-            )
-            st.plotly_chart(fig, key=plot_uuid)
-        except Exception as e:
-            st.error(f"Unable to plot the datapoints: {e}", icon="🚨")
-            import traceback
-
-            with st.expander("Error details"):
-                st.code(traceback.format_exc())
-
-    if render_forest_plot is not None:
-        render_forest_plot()
+    render_submitted_main_plot(variables, ionmodule, plot_params, filtered_data, render_forest_plot=render_forest_plot)
 
     # Render results table (same styled grid as Tab 1)
     render_submitted_results_table(filtered_data, variables)

--- a/webinterface/pages/pages_variables/DeNovo/DDA_HCD_variables.py
+++ b/webinterface/pages/pages_variables/DeNovo/DDA_HCD_variables.py
@@ -22,6 +22,7 @@ class VariablesDDADeNovo:
 
     # TAB 1
     fig_metric: str = "fig_metric_dda_hcd_denovo"
+    fig_pc_curve: str = "fig_pc_curve_dda_hcd_denovo"
     metric_plot_labels: List[str] = field(
         default_factory=lambda: ["None", "checkpoint", "n_beams", "precursor_mass_tolerance", "decoding_strategy"]
     )
@@ -37,6 +38,7 @@ class VariablesDDADeNovo:
 
     # Tab 4
     fig_metric_submitted: str = "fig_metric_dda_hcd_denovo_submitted"
+    fig_pc_curve_submitted: str = "fig_pc_curve_dda_hcd_denovo_submitted"
 
     # Tab 5
     uploaded_id: str = "Uploaded dataset"
@@ -70,6 +72,13 @@ class VariablesDDADeNovo:
     colorblind_mode_selector_uuid: str = "colorblind_mode_selector_dda_hcd_denovo"
     colorblind_mode_selector_indepth_uuid: str = "colorblind_mode_selector_indepth_dda_hcd_denovo"
     colorblind_mode_selector_submitted_uuid: str = "colorblind_mode_selector_submitted_dda_hcd_denovo"
+
+    # Ambiguity toggles (I/L mismatches, deamidation mismatches) for the main metric plot.
+    # Only meaningful under Exact evaluation; forced to "allow" and disabled under Mass-based.
+    il_toggle_id_uuid: str = "il_toggle_id_dda_hcd_denovo"
+    il_toggle_id_submitted_uuid: str = "il_toggle_id_submitted_dda_hcd_denovo"
+    deamidation_toggle_id_uuid: str = "deamidation_toggle_id_dda_hcd_denovo"
+    deamidation_toggle_id_submitted_uuid: str = "deamidation_toggle_id_submitted_dda_hcd_denovo"
 
     download_selector_id_uuid: str = "download_selector_id_dda_hcd_denovo"
     table_id_uuid: str = "table_id_dda_hcd_denovo"

--- a/webinterface/pages/texts/generic_texts_denovo.py
+++ b/webinterface/pages/texts/generic_texts_denovo.py
@@ -94,53 +94,101 @@ class WebpageTexts:
         """
 
         radio_level = """
-        **Precision vs Recall**
+        **Precision vs AUC**
 
         This setting determines which metric is shown on the **x-axis** of the accuracy plot. The **y-axis always shows the amino-acid level metric**, while the x-axis represents the peptide-level metric.
 
-        **Precision**  
-        Precision measures how many of the reported identifications are correct. A high precision means that most predictions above the selected score threshold are accurate.
+        **Precision**
+        Precision measures how many of the reported identifications are correct, considering every prediction
+        (no score threshold applied). A high precision means that most reported sequences are accurate.
 
-        *Precision = correct predictions ÷ predictions above threshold*
+        *Precision = correct predictions ÷ all predictions*
 
-        This option is useful when you want to evaluate the **reliability of reported sequences**.
+        This option is useful when you want to evaluate the **reliability of reported sequences** at a single,
+        fixed operating point.
 
-        **Recall**  
-        Recall measures how many of the total spectra were correctly identified. A high recall means that a large fraction of spectra receive a correct prediction.
+        **AUC**
+        AUC (average precision) is the area under the tool's precision-vs-coverage curve, swept across every
+        possible score threshold. A high AUC means the tool stays precise even as more of its lower-confidence
+        predictions are included, not just at its single default operating point.
 
-        *Recall = correct predictions ÷ total spectra*
+        This option is useful when you want to evaluate a tool's **overall ranking quality** rather than one
+        specific threshold. It can be `N/A` for tools that don't report a real per-residue confidence score.
 
-        This option is useful when you want to evaluate the **identification coverage of the dataset**.
-
-        **Note:**  
+        **Note:**
         Both metrics can be calculated at the **peptide level** or **amino-acid level**. In the plot, the selected peptide-level metric is displayed on the **x-axis**, while the corresponding amino-acid metric is shown on the **y-axis**.
+
+        **Reading the four background regions**
+
+        The plot background is shaded from light (bottom-left) to dark (top-right): the further
+        into the top-right corner a point sits, the better it's performing on both axes at once.
+        The dashed lines at the midpoint of each axis also split the plot into four named regions:
+
+        - **Good performance** (top-right): both peptide- and amino-acid-level metrics are high.
+        - **Near-miss** (top-left): peptide-level is low but amino-acid-level is high. Often
+          suggests a very similar peptide -- usually only one or a few residues off from the
+          true sequence.
+        - **Low performance** (bottom-left): both metrics are low.
+        - **Alternative candidate** (bottom-right): peptide-level is high but amino-acid-level
+          is low. Suggests a fully different peptide when wrong, rather than a near match --
+          this can indicate an alternative candidate that a database search might miss, or that
+          the spectrum quality was too low to call any part of the sequence correctly. This
+          region is expected to be sparse: amino-acid-level correctness dominates the tally in
+          most realistic cases, so most tools land at or above the diagonal rather than below it.
         """
 
         radio_evaluation = """
-        **Exact vs Match-based evaluation**
+        **Exact vs Mass-based evaluation**
 
         This setting determines how predicted peptide sequences are considered **correct** when computing accuracy metrics.
 
-        **Exact**  
-        Only predictions that match the ground-truth peptide sequence exactly are considered correct.  
+        **Exact**
+        Only predictions that match the ground-truth peptide sequence exactly are considered correct.
         This requires the **same amino acids and modifications in the same order**.
 
-        This option provides the most **strict evaluation of de novo sequencing accuracy**.
+        This option provides the most **strict evaluation of de novo sequencing accuracy**. Two toggles let you
+        relax this strictness for ambiguities that are inherent to the data (see below).
 
-        **Match-based**  
-        Predictions are considered correct if they match the ground-truth sequence based on **cumulative fragment masses**.  
+        **Mass-based**
+        Predictions are considered correct if they match the ground-truth sequence based on **cumulative fragment masses**.
         The algorithm identifies the longest **mass-matching prefix and suffix** between the predicted and reference sequence.
 
-        Two mass tolerances are used during matching:  
-        *Cumulative mass threshold* – maximum allowed mass difference (50ppm) between cumulative fragment masses.  
+        Two mass tolerances are used during matching:
+        *Cumulative mass threshold* – maximum allowed mass difference (50ppm) between cumulative fragment masses.
         *Individual mass threshold* – maximum allowed mass difference (20ppm) between individual amino acids.
 
         This allows equivalent interpretations such as **isobaric amino acids (e.g. I/L)** or small sequence shifts that preserve peptide mass.
 
         This option provides a more **tolerant evaluation reflecting ambiguity in mass spectrometry data**.
 
-        **Note:**  
-        Match-based evaluation counts both **exact matches and mass-equivalent matches**, while exact evaluation only counts **perfect sequence matches**.
+        **Note:**
+        Mass-based evaluation counts both **exact matches and mass-equivalent matches**, while exact evaluation only counts **perfect sequence matches**
+        (subject to the ambiguity toggles below).
+        """
+
+        toggle_il = """
+        **Allow I/L mismatches**
+
+        Isoleucine (I) and Leucine (L) have identical mass, so a de novo model cannot distinguish
+        them from the spectrum alone -- many tools only ever predict one of the two. When this
+        toggle is on, a predicted I is counted as correct for a ground-truth L (and vice versa)
+        under **Exact** evaluation.
+
+        This toggle is forced on and disabled under **Mass-based** evaluation, since mass-based
+        matching already can't tell I and L apart regardless of this setting.
+        """
+
+        toggle_deamidation = """
+        **Allow deamidation mismatches (Q↔E, N↔D)**
+
+        Deamidation converts glutamine (Q) to a residue that is essentially identical in mass to
+        glutamate (E), and asparagine (N) to one essentially identical in mass to aspartate (D).
+        A de novo model may therefore predict the plain acidic residue (E or D) where the ground
+        truth has the deamidated amide (Q or N). When this toggle is on, such a prediction is
+        counted as correct under **Exact** evaluation.
+
+        This toggle is forced on and disabled under **Mass-based** evaluation, since mass-based
+        matching already can't tell these apart regardless of this setting.
         """
 
         dataset_selection_indepth = """

--- a/webinterface/pages/texts/generic_texts_denovo.py
+++ b/webinterface/pages/texts/generic_texts_denovo.py
@@ -296,5 +296,19 @@ class WebpageTexts:
 
         Each species label corresponds to the organism from which the benchmark spectra were derived.
 
-        For a full description related to the source of the data for each species, see the full module description. 
+        For a full description related to the source of the data for each species, see the full module description.
+        """
+
+        in_fasta_overview = """
+        This plot shows, for each de novo sequencing tool, how its predictions break down into three categories:
+
+        - **Correct** -- the predicted peptide matches the ground-truth peptide exactly (allowing I/L ambiguity, since they cannot be distinguished by mass).
+        - **In FASTA** -- the prediction does not match the ground truth, but the predicted sequence (again allowing I/L ambiguity) is nonetheless found elsewhere in the proteome of the species the spectrum came from.
+        - **Not in FASTA** -- the prediction matches neither the ground truth nor any other protein in that species' proteome. This also includes spectra for which the tool made no prediction at all.
+
+        Each bar shows the **proportion of all spectra** in the dataset that fall into each category for that tool.
+
+        **How to interpret the plot**
+
+        A large **"In FASTA"** segment indicates that, even where a tool's prediction is wrong, it is often still calling a *real, existing* peptide from the correct organism -- suggesting the tool is finding a genuinely different but plausible peptide (e.g. a co-eluting or chimeric spectrum), rather than sequencing errors, only for peptides of at least 8 amino acids (below this, matches to the proteome by chance become likely, and are therefore not calculated). A large **"Not in FASTA"** segment instead points to predictions that are not just wrong, but not proteome-supported.
         """


### PR DESCRIPTION
## Summary

This PR addresses feedback from two external reviewers on the *de novo*
sequencing (DDA-HCD) module, received during community review. Each
reviewer's comment is quoted or paraphrased below, followed by how it was
addressed — including cases where a deliberate decision was made *not*
to change something, for transparency.

---

## Reviewer 1

### 1. Average precision (AUC)
**Comment:** Reporting average precision (area under the precision-coverage
curve) is more informative than precision at 100% coverage alone.

- [x] Added AUC as a metric option. Removed the "recall" toggle (see 3.
  below for why) and added a second tab on the in-depth plot showing full
  precision-coverage curves.

### 2. Amino acid substitutions (I/L, Q/E)
**Comment:** Most evaluations allow I/L substitution; uncertain whether
Q/E should also be allowed — worth showing both ways.

- [x] Added a toggle to allow/disallow I/L ambiguity and a separate toggle
  for Q/E (deamidation) ambiguity, so results can be viewed either way.

### 3. Recall is not well-defined for de novo sequencing
**Comment:** The notion of a false negative (required for a standard
recall definition) doesn't apply to de novo sequencing, since there's no
true negative class.

- [x] Removed "recall" from the module. Replaced with **coverage**
  (proportion of spectra for which a prediction was made) and **AUC**
  (area under the precision-coverage curve), which don't rely on an
  undefined false-negative concept.

### 4. Database search vs. matching precision
**Comment:** Worth evaluating precision by matching predicted peptides
(≥8 amino acids) against a reference proteome, as a complement to the
standard database-search gold standard.

- [x] Added this as a new in-depth plot: a stacked bar chart per tool
  showing the proportion of predictions that are **correct**,
  **incorrect but present in the reference proteome ("in FASTA")**, or
  **incorrect and not found in the proteome**.

---

## Reviewer 2

### 1. Main benchmarking plot is hard to interpret
**Comment:** Plotting amino-acid-level and peptide-level metrics against
each other may obscure interpretation, since different tools show
different AA-vs-peptide performance profiles with different
implications. Suggested separate swarmplots, or at minimum fixing the
axis ranges to [0, 1].

- [x] Kept the combined scatterplot (rather than switching to
  swarmplots), but fixed both axis ranges to [0, 1] and added
  quadrant-based color coding with explicit labels describing what a
  tool's position in each corner implies. Applied the same treatment to
  the PTM-related scatterplots.

### 2. Recall vs. coverage
**Comment:** Coverage is a clearer concept than recall for de novo
sequencing tools (see linked reference).

- [x] Same fix as Reviewer 1, item 3 above — recall replaced with
  coverage and AUC.

### 3. I/L should not be treated as equivalent in exact matching
**Comment:** Isoleucine and leucine should not automatically be
considered equivalent in exact-match evaluation, given evidence some
tools can distinguish them.

- [x] Addressed via the same I/L toggle described in Reviewer 1, item 2 —
  equivalence is now optional rather than assumed.

### 4. Terminology inconsistency (tooltip vs. docs)
**Comment:** The plot menu says "Mass-based" while the tooltip says
"Match-based"; mass tolerance units are described inconsistently
(Da vs. ppm) across different doc sections.

- [x] Fixed. Terminology and units are now consistent between the UI,
  tooltips, and documentation.

### 5. Benchmark Results table columns
**Comment:** Current columns seem tool-specific and may not be relevant
for all submissions; worth clarifying which are expected to be
standardized vs. tool-dependent.

- [ ] **Not changed in this PR.** Columns are kept as-is for now. Open to
  revisiting in a follow-up once we've gathered feedback from more tool
  submissions on which columns are actually useful across the board.

---

# Closing remark

Finally, I'd like to thank both reviewers for their contributions! Feel free to comment further and we'll gladly accomodate/discuss any points related to the module