### PR TITLE
Tell repeat submissions of one de novo tool apart in plots and tables

### DIFF
--- a/proteobench/plotting/plot_generator_denovo.py
+++ b/proteobench/plotting/plot_generator_denovo.py
@@ -2,6 +2,7 @@
 Module for plotting results of de novo models
 """
 
+import re
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -34,6 +35,20 @@ QUADRANT_COLORSCALE = [
     [0.85, "#4d87ac"],
     [1.0, "#1f5678"],
 ]
+# Every curve from one tool is drawn in that tool's colour, so a tool submitted several times
+# -- one datapoint per decoding strategy, say -- would otherwise draw identically coloured,
+# identically named lines that no legend entry or hover text could tell apart. Label each line
+# by whatever actually differs between that tool's submissions, and vary the dash so the lines
+# stay separable even where the colour cannot change.
+DASH_CYCLE = ("solid", "dash", "dot", "dashdot", "longdash", "longdashdot")
+# Tried in order, most workflow-defining first, so the shortest label that disambiguates wins.
+WORKFLOW_LABEL_FIELDS = ("decoding_strategy", "n_beams", "checkpoint", "software_version")
+# A run refined by a second model records both checkpoints in one field, base model first.
+CHECKPOINT_SEPARATOR = ";"
+# Product names for refinement models, keyed by the leading token of their checkpoint name.
+# A refinement checkpoint that is not listed still gets its own clause, just unnamed.
+REFINEMENT_MODEL_NAMES = {"instanovoplus": "InstaNovo+"}
+
 QUADRANT_LABELS = {
     "good": {"text": "<b>Good performance</b>"},
     "near_miss": {
@@ -174,6 +189,196 @@ def flatten_results_column(df: pd.DataFrame, ambiguity_combo: Optional[str] = No
                     results[f"{level}_{evaluation_type}_{metric}"].append(leaf.get(metric, float("nan")))
 
     return pd.DataFrame(results)
+
+
+def _is_blank(value: object) -> bool:
+    """Whether a datapoint field carries no usable value."""
+    if value is None:
+        return True
+    if isinstance(value, float) and np.isnan(value):
+        return True
+    return str(value).strip() in ("", "nan", "None", "<NA>")
+
+
+def _format_label_field(field: str, value: object) -> str:
+    """Render one distinguishing field for use inside a workflow label."""
+    text = str(value).strip()
+    if field == "n_beams":
+        # A blank in any row makes the whole column float, which would read "10.0 beams".
+        try:
+            count = float(text)
+        except ValueError:
+            return f"{text} beams"
+        return f"{count:g} beam" if count == 1 else f"{count:g} beams"
+    if field == "software_version":
+        return f"v{text.lstrip('v')}"
+    return text
+
+
+def _split_checkpoint(value: object) -> tuple:
+    """
+    Split a checkpoint field into the base model and any refinement stages.
+
+    A run that post-processes its predictions with a second model records both, separated by
+    ``;`` -- the base model first. Reported separately so a refined run reads as a refinement
+    of its base rather than as an unrelated pair of checkpoints.
+    """
+    stages = [stage.strip() for stage in str(value).split(CHECKPOINT_SEPARATOR) if stage.strip()]
+    return (stages[0] if stages else ""), stages[1:]
+
+
+def _refinement_model_name(checkpoint: str) -> Optional[str]:
+    """The product name of a refinement model, from its checkpoint name."""
+    token = re.split(r"[-_ ]", checkpoint.strip(), maxsplit=1)[0].lower()
+    return REFINEMENT_MODEL_NAMES.get(token)
+
+
+def _refinement_clause(refinements: List[str]) -> str:
+    """Render the trailing "with ... refinement" clause for any post-processing stages."""
+    if not refinements:
+        return ""
+    rendered = []
+    for checkpoint in refinements:
+        name = _refinement_model_name(checkpoint)
+        rendered.append(f"{name} refinement ({checkpoint})" if name else f"refinement ({checkpoint})")
+    return " with " + " and ".join(rendered)
+
+
+def _display_software_name(software: str, checkpoint: object) -> str:
+    """
+    The name to show for a datapoint, which is not always its ``software_name``.
+
+    A run whose only checkpoint is a refinement model is that model working on its own rather
+    than the tool that usually calls it: InstaNovo+ diffusion sampling is recorded under
+    ``software_name`` "InstaNovo", but it is not InstaNovo. Only the displayed name changes --
+    colour, marker and grouping still follow ``software_name``, which keeps such a run with the
+    rest of its project's results and avoids inventing a tool name the palettes do not know.
+    """
+    if _is_blank(checkpoint):
+        return software
+    base, refinements = _split_checkpoint(checkpoint)
+    if refinements:
+        return software  # a base model that was refined; the base model still names the run
+    return _refinement_model_name(base) or software
+
+
+def _render_workflow_label(software: str, parts: List[str], suffix: str) -> str:
+    """Assemble a workflow label from the tool name, its distinguishing fields and any suffix."""
+    if not parts:
+        return f"{software}{suffix}"
+    return f"{software} ({', '.join(parts)}){suffix}"
+
+
+def build_workflow_labels(result_df: pd.DataFrame) -> pd.Series:
+    """
+    Build a display label per datapoint, unique within each software tool.
+
+    A tool that appears once keeps its plain name. A tool submitted several times gets the
+    fields that actually differ between its own submissions appended, so the label says what
+    makes each run distinct rather than repeating the tool name. Fields that are constant
+    across a tool's submissions are left out -- they would lengthen every label without
+    separating anything.
+
+    Parameters
+    ----------
+    result_df : pd.DataFrame
+        Datapoints to label. Must carry ``software_name``; any of
+        :data:`WORKFLOW_LABEL_FIELDS` and ``id`` are used when present.
+
+    Returns
+    -------
+    pd.Series
+        Labels aligned to ``result_df.index``.
+    """
+    if "software_name" not in result_df.columns or len(result_df) == 0:
+        return pd.Series([], dtype=str) if len(result_df) == 0 else pd.Series("", index=result_df.index)
+
+    software_names = result_df["software_name"].astype(str)
+    # Grouping stays on software_name -- runs of one project are compared against each other --
+    # but the name shown can differ per row, so a standalone refinement model is not mislabelled
+    # as the tool that usually drives it.
+    if "checkpoint" in result_df.columns:
+        display_names = pd.Series(
+            [
+                _display_software_name(name, checkpoint)
+                for name, checkpoint in zip(software_names, result_df["checkpoint"])
+            ],
+            index=result_df.index,
+            dtype=object,
+        )
+    else:
+        display_names = software_names.copy()
+    labels = display_names.copy()
+
+    for _, group in result_df.groupby(software_names, sort=False):
+        if len(group) < 2:
+            continue
+
+        parts: Dict[object, List[str]] = {idx: [] for idx in group.index}
+        suffixes: Dict[object, str] = {idx: "" for idx in group.index}
+        for field in WORKFLOW_LABEL_FIELDS:
+            if field not in group.columns:
+                continue
+            values = group[field]
+            # A field only earns a place in the label if this tool's own submissions differ
+            # on it; two distinct non-blank values is the minimum that can separate two rows.
+            if len({str(v).strip() for v in values if not _is_blank(v)}) < 2:
+                continue
+            for idx, value in values.items():
+                if _is_blank(value):
+                    continue
+                if field == "checkpoint":
+                    # The base model belongs with the other settings; refinement stages read
+                    # as a clause after them, so a refined run names what refined it.
+                    base, refinements = _split_checkpoint(value)
+                    if base:
+                        parts[idx].append(base)
+                    suffixes[idx] = _refinement_clause(refinements)
+                else:
+                    parts[idx].append(_format_label_field(field, value))
+            rendered = {_render_workflow_label(display_names.at[idx], parts[idx], suffixes[idx]) for idx in group.index}
+            if len(rendered) == len(group):
+                break  # already unique; more fields would only add noise
+
+        for idx in group.index:
+            if parts[idx] or suffixes[idx]:
+                labels.at[idx] = _render_workflow_label(display_names.at[idx], parts[idx], suffixes[idx])
+
+    # Whatever the recorded parameters could not separate, the ProteoBench ID always can.
+    duplicated = labels.duplicated(keep=False)
+    if duplicated.any() and "id" in result_df.columns:
+        labels[duplicated] = [
+            f"{label} [{point_id}]"
+            for label, point_id in zip(labels[duplicated], result_df.loc[duplicated, "id"].astype(str))
+        ]
+
+    return labels
+
+
+def build_curve_dashes(result_df: pd.DataFrame) -> pd.Series:
+    """
+    Assign a line dash per datapoint, cycling within each software tool.
+
+    Colour already encodes the tool, so the dash is what separates several submissions of the
+    same tool from one another.
+
+    Parameters
+    ----------
+    result_df : pd.DataFrame
+        Datapoints to assign dashes to. Must carry ``software_name``.
+
+    Returns
+    -------
+    pd.Series
+        Plotly dash names aligned to ``result_df.index``.
+    """
+    dashes = pd.Series(DASH_CYCLE[0], index=result_df.index, dtype=object)
+    if "software_name" not in result_df.columns or len(result_df) == 0:
+        return dashes
+    for _, group in result_df.groupby(result_df["software_name"].astype(str), sort=False):
+        for position, idx in enumerate(group.index):
+            dashes.at[idx] = DASH_CYCLE[position % len(DASH_CYCLE)]
+    return dashes
 
 
 class DeNovoPlotGenerator(PlotGeneratorBase):
@@ -531,22 +736,29 @@ class DeNovoPlotGenerator(PlotGeneratorBase):
             horizontal_spacing=0.12,
         )
 
+        # Labelled per datapoint rather than per tool, so several submissions of one tool are
+        # separable in the legend and hover; legendgroup follows the label so toggling a
+        # workflow hides both of its levels rather than every workflow from the same tool.
+        workflow_labels = build_workflow_labels(benchmark_metrics_df)
+        curve_dashes = build_curve_dashes(benchmark_metrics_df)
+
         for col_idx, level in enumerate(_LEVELS, start=1):
-            for _, row in benchmark_metrics_df.iterrows():
+            for idx, row in benchmark_metrics_df.iterrows():
                 curve = _get_metrics_leaf(row, level, evaluation_type, ambiguity_combo).get("curve")
                 if not curve or not curve.get("coverage"):
                     continue  # degenerate curve (e.g. all-identical scores) or legacy datapoint
                 software = row["software_name"]
+                label = workflow_labels.at[idx]
                 fig.add_trace(
                     go.Scatter(
                         x=curve["coverage"],
                         y=curve["precision"],
                         mode="lines",
-                        name=software,
-                        legendgroup=software,
+                        name=label,
+                        legendgroup=label,
                         showlegend=(col_idx == 1),
-                        line=dict(color=software_colors.get(software, "gray")),
-                        hovertemplate=f"{software}<br>Coverage: %{{x:.3f}}<br>Precision: %{{y:.3f}}<extra></extra>",
+                        line=dict(color=software_colors.get(software, "gray"), dash=curve_dashes.at[idx]),
+                        hovertemplate=f"{label}<br>Coverage: %{{x:.3f}}<br>Precision: %{{y:.3f}}<extra></extra>",
                     ),
                     row=1,
                     col=col_idx,

--- a/test/test_plot_denovo.py
+++ b/test/test_plot_denovo.py
@@ -1,0 +1,208 @@
+"""Tests for the de novo plotting helpers that keep repeat submissions distinguishable."""
+
+import pandas as pd
+import pytest
+
+from proteobench.plotting.plot_generator_denovo import (
+    DASH_CYCLE,
+    build_curve_dashes,
+    build_workflow_labels,
+)
+
+
+def _datapoint(point_id, software, decoding=None, n_beams=None, checkpoint=None, version="1.2.2"):
+    return {
+        "id": point_id,
+        "software_name": software,
+        "software_version": version,
+        "decoding_strategy": decoding,
+        "n_beams": n_beams,
+        "checkpoint": checkpoint,
+    }
+
+
+# The seven InstaNovo v1.2.2 inference modes, as they are recorded in a datapoint.
+INSTANOVO_MODES = pd.DataFrame(
+    [
+        _datapoint("InstaNovo_1", "InstaNovo", "greedy search", 1, "instanovo-v1.2.0"),
+        _datapoint("InstaNovo_2", "InstaNovo", "greedy search", 1, "instanovo-v1.2.0; instanovoplus-v1.1.0"),
+        _datapoint("InstaNovo_3", "InstaNovo", "beam search", 10, "instanovo-v1.2.0"),
+        _datapoint("InstaNovo_4", "InstaNovo", "beam search", 10, "instanovo-v1.2.0; instanovoplus-v1.1.0"),
+        _datapoint("InstaNovo_5", "InstaNovo", "knapsack beam search", 10, "instanovo-v1.2.0"),
+        _datapoint("InstaNovo_6", "InstaNovo", "knapsack beam search", 10, "instanovo-v1.2.0; instanovoplus-v1.1.0"),
+        _datapoint("InstaNovo_7", "InstaNovo", "diffusion sampling", None, "instanovoplus-v1.1.0"),
+    ]
+)
+
+
+class TestBuildWorkflowLabels:
+    def test_single_submission_keeps_the_plain_tool_name(self):
+        df = pd.DataFrame([_datapoint("Casanovo_1", "Casanovo", "beam search", 5, "casanovo_massivekb.ckpt")])
+        assert list(build_workflow_labels(df)) == ["Casanovo"]
+
+    def test_each_of_the_seven_modes_gets_a_distinct_label(self):
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert len(set(labels)) == len(INSTANOVO_MODES)
+        assert all(label.startswith("InstaNovo") for label in labels)
+
+    def test_label_names_the_decoding_strategy_and_beam_count(self):
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert "greedy search" in labels.iloc[0]
+        assert "10 beams" in labels.iloc[2]
+
+    def test_refined_and_unrefined_runs_are_separable(self):
+        # These two differ only by the extra refinement checkpoint.
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert labels.iloc[2] != labels.iloc[3]
+        assert "instanovoplus-v1.1.0" in labels.iloc[3]
+        assert "instanovoplus" not in labels.iloc[2]
+
+    def test_refined_run_names_the_model_that_refined_it(self):
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert labels.iloc[3] == (
+            "InstaNovo (beam search, 10 beams, instanovo-v1.2.0) " "with InstaNovo+ refinement (instanovoplus-v1.1.0)"
+        )
+
+    def test_unrefined_run_has_no_refinement_clause(self):
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert labels.iloc[2] == "InstaNovo (beam search, 10 beams, instanovo-v1.2.0)"
+        assert "refinement" not in labels.iloc[2]
+
+    def test_single_beam_reads_as_singular(self):
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert "1 beam," in labels.iloc[0]
+        assert "1 beams" not in labels.iloc[0]
+
+    def test_a_standalone_refinement_model_is_named_after_itself(self):
+        # diffusion-only runs InstaNovo+ on its own -- it is not a refinement of anything, and
+        # it is not InstaNovo either, even though that is its recorded software_name.
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert labels.iloc[6] == "InstaNovo+ (diffusion sampling, instanovoplus-v1.1.0)"
+        assert "refinement" not in labels.iloc[6]
+
+    def test_standalone_refinement_model_is_renamed_even_as_a_lone_submission(self):
+        df = INSTANOVO_MODES.iloc[[6]]
+        assert list(build_workflow_labels(df)) == ["InstaNovo+"]
+
+    def test_a_refined_run_keeps_the_base_tool_name(self):
+        # The base model drove the run, so the tool name stays; only the clause names InstaNovo+.
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert labels.iloc[3].startswith("InstaNovo (")
+
+    def test_an_unrecognised_lone_checkpoint_keeps_the_software_name(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Tool", "greedy search", 1, "mystery-v2.ckpt"),
+                _datapoint("B", "Tool", "beam search", 5, "mystery-v2.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert all(label.startswith("Tool (") for label in labels)
+
+    def test_unknown_refinement_model_still_gets_its_own_clause(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Tool", "beam search", 5, "base.ckpt"),
+                _datapoint("B", "Tool", "beam search", 5, "base.ckpt; mystery-v2.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert labels.iloc[1] == "Tool (base.ckpt) with refinement (mystery-v2.ckpt)"
+
+    def test_multiple_refinement_stages_are_all_named(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Tool", "beam search", 5, "base.ckpt"),
+                _datapoint("B", "Tool", "beam search", 5, "base.ckpt; first.ckpt; second.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert labels.iloc[1] == "Tool (base.ckpt) with refinement (first.ckpt) and refinement (second.ckpt)"
+
+    def test_constant_fields_are_left_out_of_the_label(self):
+        # Both rows share a checkpoint and version, so only the strategy should appear.
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Tool", "greedy search", 1, "same.ckpt"),
+                _datapoint("B", "Tool", "beam search", 1, "same.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert list(labels) == ["Tool (greedy search)", "Tool (beam search)"]
+
+    def test_blank_fields_are_skipped(self):
+        # diffusion sampling records no beam count; the label must not read "nan beams".
+        labels = build_workflow_labels(INSTANOVO_MODES)
+        assert "nan" not in labels.iloc[6]
+        assert "None" not in labels.iloc[6]
+
+    def test_tools_are_labelled_independently(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Casanovo", "beam search", 5, "casanovo.ckpt"),
+                _datapoint("B", "InstaNovo", "greedy search", 1, "instanovo.ckpt"),
+                _datapoint("C", "InstaNovo", "beam search", 10, "instanovo.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert labels.iloc[0] == "Casanovo"  # only submitted once
+        assert labels.iloc[1] != labels.iloc[2]
+
+    def test_identical_parameters_fall_back_to_the_proteobench_id(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("Tool_20260815_1", "Tool", "greedy search", 1, "same.ckpt"),
+                _datapoint("Tool_20260815_2", "Tool", "greedy search", 1, "same.ckpt"),
+            ]
+        )
+        labels = build_workflow_labels(df)
+        assert len(set(labels)) == 2
+        assert "Tool_20260815_1" in labels.iloc[0]
+
+    def test_missing_optional_columns_do_not_raise(self):
+        df = pd.DataFrame([{"software_name": "Tool"}, {"software_name": "Tool"}])
+        assert len(build_workflow_labels(df)) == 2
+
+    def test_empty_frame_returns_empty(self):
+        assert len(build_workflow_labels(pd.DataFrame())) == 0
+
+    def test_labels_align_to_a_non_default_index(self):
+        df = INSTANOVO_MODES.copy()
+        df.index = range(100, 100 + len(df))
+        labels = build_workflow_labels(df)
+        assert list(labels.index) == list(df.index)
+
+
+class TestBuildCurveDashes:
+    def test_dashes_cycle_within_one_tool(self):
+        dashes = build_curve_dashes(INSTANOVO_MODES)
+        assert list(dashes[:3]) == list(DASH_CYCLE[:3])
+
+    def test_dash_cycle_restarts_for_each_tool(self):
+        df = pd.DataFrame(
+            [
+                _datapoint("A", "Casanovo", "beam search", 5),
+                _datapoint("B", "InstaNovo", "greedy search", 1),
+                _datapoint("C", "InstaNovo", "beam search", 10),
+            ]
+        )
+        dashes = build_curve_dashes(df)
+        assert dashes.iloc[0] == DASH_CYCLE[0]
+        assert dashes.iloc[1] == DASH_CYCLE[0]
+        assert dashes.iloc[2] == DASH_CYCLE[1]
+
+    def test_more_submissions_than_dash_styles_wraps(self):
+        df = pd.DataFrame([_datapoint(str(i), "Tool", f"strategy {i}") for i in range(len(DASH_CYCLE) + 2)])
+        dashes = build_curve_dashes(df)
+        assert dashes.iloc[len(DASH_CYCLE)] == DASH_CYCLE[0]
+
+    def test_empty_frame_returns_empty(self):
+        assert len(build_curve_dashes(pd.DataFrame())) == 0
+
+
+@pytest.mark.parametrize("column", ["decoding_strategy", "n_beams", "checkpoint"])
+def test_labels_stay_unique_when_one_field_is_unavailable(column):
+    """Older datapoints may not carry every field; the rest must still separate them."""
+    df = INSTANOVO_MODES.drop(columns=[column])
+    labels = build_workflow_labels(df)
+    assert len(set(labels)) == len(df)

--- a/webinterface/pages/base_pages/utils/resulttable.py
+++ b/webinterface/pages/base_pages/utils/resulttable.py
@@ -2,6 +2,7 @@ import pandas as pd
 from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode, JsCode
 
 from proteobench.io.parsing.parse_settings import get_open_source_tools
+from proteobench.plotting.plot_generator_denovo import build_workflow_labels
 
 # this file contains utility functions for rendering the result table in tab1_results and tab4_display_results_submitted
 
@@ -33,6 +34,39 @@ def add_open_source_column(df: pd.DataFrame) -> pd.DataFrame:
     cols.remove("open_source")
     idx = cols.index("software_name") + 1
     cols.insert(idx, "open_source")
+    return df[cols]
+
+
+def add_workflow_column(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add a 'workflow' column naming what distinguishes repeat submissions of one tool.
+
+    A de novo tool may be submitted several times -- one datapoint per decoding strategy or
+    checkpoint -- in which case every row reads the same in the 'software_name' column and the
+    differences sit in scattered parameter columns. This spells the difference out in one
+    column next to the tool name. The column is only added for de novo results (identified by
+    the presence of 'decoding_strategy') that actually contain a repeated tool, so tables where
+    it would merely duplicate 'software_name' are left unchanged.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame of datapoints, expected to carry a 'software_name' column.
+
+    Returns
+    -------
+    pd.DataFrame
+        The DataFrame, with a 'workflow' column inserted after 'software_name' where it applies.
+    """
+    if "software_name" not in df.columns or "decoding_strategy" not in df.columns or len(df) == 0:
+        return df
+    if not df["software_name"].astype(str).duplicated().any():
+        return df
+    df = df.copy()
+    df["workflow"] = build_workflow_labels(df)
+    cols = df.columns.tolist()
+    cols.remove("workflow")
+    cols.insert(cols.index("software_name") + 1, "workflow")
     return df[cols]
 
 
@@ -165,6 +199,7 @@ def configure_aggrid(df: pd.DataFrame, enable_selection: bool = False):
 
     parameter_cols = {
         "software_name",
+        "workflow",
         "software_version",
         "search_engine",
         "search_engine_version",
@@ -279,11 +314,13 @@ def prepare_display_dataframe(df: pd.DataFrame, highlight_id: str | None) -> pd.
         return df
     df["selected"] = df["id"].apply(lambda x: "➡️" if x == highlight_id else "")
     df = add_open_source_column(df)
+    df = add_workflow_column(df)
 
     try:
         identifier_cols = ["selected", "id"]
         parameter_cols = [
             "software_name",
+            "workflow",
             "open_source",
             "software_version",
             "search_engine",


### PR DESCRIPTION
`plot_precision_coverage_curves` draws one line per datapoint, but named every trace after the software tool:

```python
name=software,
legendgroup=software,
showlegend=(col_idx == 1),
line=dict(color=software_colors.get(software, "gray")),
hovertemplate=f"{software}<br>Coverage: …<br>Precision: …",
```

A tool submitted once is fine. A tool submitted several times (for example: one datapoint per decoding strategy) produces N identically coloured, identically named lines that share one legendgroup. The legend repeats the same entry N times, clicking any of them toggles all N at once, and the hover text never says which run a curve belongs to.

I hit this when benchmarking InstaNovo across different inference modes. InstaNovo has three decoding strategies (greedy search (1 beam), beam search and knapsack beam search). And we can run our diffusion model InstaNovo+ standalone or use it to refine the InstaNovo predictions. 

## The change

**Curves are labelled per datapoint.** A new `build_workflow_labels()` appends whatever actually differs between one tool's own submissions, trying `decoding_strategy`, `n_beams`, `checkpoint`, `software_version` in that order and stopping as soon as the labels are unique:

```
InstaNovo  (greedy search, 1 beam, instanovo-v1.2.0)
InstaNovo  (greedy search, 1 beam, instanovo-v1.2.0) with InstaNovo+ refinement (instanovoplus-v1.1.0)
InstaNovo  (beam search, 10 beams, instanovo-v1.2.0)
InstaNovo  (beam search, 10 beams, instanovo-v1.2.0) with InstaNovo+ refinement (instanovoplus-v1.1.0)
InstaNovo  (knapsack beam search, 10 beams, instanovo-v1.2.0)
InstaNovo  (knapsack beam search, 10 beams, instanovo-v1.2.0) with InstaNovo+ refinement (instanovoplus-v1.1.0)
InstaNovo+ (diffusion sampling, instanovoplus-v1.1.0)
```