### PR TITLE
Give generated datapoint IDs sub-second resolution

### DIFF
--- a/proteobench/datapoint/denovo_datapoint.py
+++ b/proteobench/datapoint/denovo_datapoint.py
@@ -197,9 +197,12 @@ class DenovoDatapoint(DatapointBase):
         """
         Generate a unique ID for the benchmark run by combining the software name and a timestamp.
 
-        This ID is used to uniquely identify each run of the benchmark.
+        This ID is used to uniquely identify each run of the benchmark. The timestamp carries
+        microseconds because datapoints are also generated in batches -- the resubmission
+        script regenerates many in a loop -- where whole-second resolution hands several runs
+        the same ID.
         """
-        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self.id = "_".join([self.software_name, str(time_stamp)])
         logging.info(f"Assigned the following ID to this run: {self.id}")
 

--- a/proteobench/datapoint/entrapment_datapoint.py
+++ b/proteobench/datapoint/entrapment_datapoint.py
@@ -89,9 +89,12 @@ class EntrapmentDatapoint(DatapointBase):
         """
         Generate a unique ID for the benchmark run by combining the software name and a timestamp.
 
-        This ID is used to uniquely identify each run of the benchmark.
+        This ID is used to uniquely identify each run of the benchmark. The timestamp carries
+        microseconds because datapoints are also generated in batches -- the resubmission
+        script regenerates many in a loop -- where whole-second resolution hands several runs
+        the same ID.
         """
-        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self.id = "_".join([self.software_name, str(time_stamp)])
         logging.info(f"Assigned the following ID to this run: {self.id}")
 

--- a/proteobench/datapoint/quant_datapoint.py
+++ b/proteobench/datapoint/quant_datapoint.py
@@ -327,9 +327,12 @@ class QuantDatapointHYE(DatapointBase):
         """
         Generate a unique ID for the benchmark run by combining the software name and a timestamp.
 
-        This ID is used to uniquely identify each run of the benchmark.
+        This ID is used to uniquely identify each run of the benchmark. The timestamp carries
+        microseconds because datapoints are also generated in batches -- the resubmission
+        script regenerates many in a loop -- where whole-second resolution hands several runs
+        the same ID.
         """
-        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self.id = "_".join([self.software_name, str(time_stamp)])
         logging.info(f"Assigned the following ID to this run: {self.id}")
 

--- a/test/test_datapoint_id.py
+++ b/test/test_datapoint_id.py
@@ -1,0 +1,50 @@
+"""Tests that generated datapoint IDs stay unique when datapoints are created in a batch."""
+
+import re
+
+import pytest
+
+from proteobench.datapoint.denovo_datapoint import DenovoDatapoint
+from proteobench.datapoint.entrapment_datapoint import EntrapmentDatapoint
+from proteobench.datapoint.quant_datapoint import QuantDatapointHYE
+
+DATAPOINT_CLASSES = [QuantDatapointHYE, DenovoDatapoint, EntrapmentDatapoint]
+
+# software name, then date_time_microseconds
+ID_PATTERN = re.compile(r"^(?P<software>.+)_\d{8}_\d{6}_\d{6}$")
+
+
+@pytest.mark.parametrize("datapoint_class", DATAPOINT_CLASSES)
+def test_generated_id_starts_with_the_software_name(datapoint_class):
+    datapoint = datapoint_class(software_name="TestTool")
+    datapoint.generate_id()
+    assert datapoint.id.startswith("TestTool_")
+
+
+@pytest.mark.parametrize("datapoint_class", DATAPOINT_CLASSES)
+def test_generated_id_carries_sub_second_resolution(datapoint_class):
+    datapoint = datapoint_class(software_name="TestTool")
+    datapoint.generate_id()
+    match = ID_PATTERN.match(datapoint.id)
+    assert match is not None, f"unexpected ID format: {datapoint.id}"
+    assert match.group("software") == "TestTool"
+
+
+@pytest.mark.parametrize("datapoint_class", DATAPOINT_CLASSES)
+def test_ids_generated_in_a_tight_loop_are_unique(datapoint_class):
+    """A batch (e.g. the resubmission script) must not hand several runs the same ID."""
+    ids = []
+    for _ in range(50):
+        datapoint = datapoint_class(software_name="TestTool")
+        datapoint.generate_id()
+        ids.append(datapoint.id)
+    assert len(set(ids)) == len(ids)
+
+
+def test_ids_stay_distinct_across_datapoint_types():
+    ids = []
+    for datapoint_class in DATAPOINT_CLASSES:
+        datapoint = datapoint_class(software_name="TestTool")
+        datapoint.generate_id()
+        ids.append(datapoint.id)
+    assert len(set(ids)) == len(ids)


### PR DESCRIPTION
`generate_id()` stamps the ID with whole-second resolution:

```python
time_stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
self.id = "_".join([self.software_name, str(time_stamp)])
```

so two datapoints created within the same second get the same ID.

`generate_datapoint()` already builds a microsecond-precision ID in the constructor:

```python
id=input_format + "_" + user_input["software_version"] + "_" + formatted_datetime,   # %Y%m%d_%H%M%S_%f
...
result_datapoint.generate_id()                                                        # overwrites it
```

and then `generate_id()` runs immediately afterwards and overwrites it, so the coarser value is the one that survives.

You will never hit this when submitting by hand. But datapoints are also generated in batches: `resubmit_datapoints.py` regenerates many in a loop, where several per second is normal.

A duplicate ID is not a data-loss risk, results are stored as `{intermediate_hash}.json`, and that hash is derived from the data itself. But the ID is what the results table displays, what row highlighting matches on (`df["id"].apply(lambda x: "➡️" if x == highlight_id else "")` would mark both rows), and what the submission branch name is built from.

## The change

One line per class: `%Y%m%d_%H%M%S` → `%Y%m%d_%H%M%S_%f`, plus a docstring line saying why.

Applied to all three datapoint classes — `QuantDatapointHYE`, `DenovoDatapoint`, `EntrapmentDatapoint`, which carry identical copies of `generate_id()`.

The ID shape is otherwise unchanged (`<software>_<timestamp>`), and only newly generated IDs are affected; stored datapoints keep theirs.
